### PR TITLE
Introduce keyhint widget

### DIFF
--- a/tests/end2end/features/misc/keyhint.feature
+++ b/tests/end2end/features/misc/keyhint.feature
@@ -1,0 +1,21 @@
+Feature: The keyhint overlay widget
+
+    Background:
+        Given I start vimiv
+        And I re-initialize the keyhint widget
+
+    Scenario: Display widget on partial keybindings
+        When I press g
+        And I wait for the keyhint widget
+        Then the keyhint widget should be visible
+
+    Scenario: Keyhint widget contains partial matches
+        When I press g
+        Then the keyhint widget should contain goto 1
+        And the keyhint widget should contain enter image
+
+    Scenario: Keyhint widget cleared and hidden after timeout
+        When I press g
+        And I wait for the keyhint widget
+        And I wait for the keyhint widget timeout
+        Then the keyhint widget should not be visible

--- a/tests/end2end/features/misc/test_keyhint_bdd.py
+++ b/tests/end2end/features/misc/test_keyhint_bdd.py
@@ -1,0 +1,50 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2019 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+import pytest_bdd as bdd
+
+from vimiv import api
+from vimiv.gui import keyhint_widget
+from vimiv.utils import eventhandler
+
+
+bdd.scenarios("keyhint.feature")
+
+
+@bdd.given("I re-initialize the keyhint widget")
+def reinitialize_keyhint():
+    api.settings.override("keyhint.delay", "5")
+    api.settings.signals.changed.emit(api.settings.KEYHINT_DELAY)
+    api.settings.override("keyhint.timeout", "100")
+    api.settings.signals.changed.emit(api.settings.KEYHINT_TIMEOUT)
+    eventhandler.KeyHandler.partial_handler.clear_keys()
+
+
+@bdd.when("I wait for the keyhint widget")
+def wait_for_keyhint_widget(qtbot):
+    with qtbot.waitSignal(keyhint_widget.instance()._show_timer.timeout, 100):
+        pass
+
+
+@bdd.when("I wait for the keyhint widget timeout")
+def wait_for_keyhint_widget_timeout(qtbot):
+    with qtbot.waitSignal(eventhandler.KeyHandler.partial_handler.partial_cleared, 500):
+        pass
+
+
+@bdd.then("the keyhint widget should be visible")
+def keyhint_widget_visible():
+    assert keyhint_widget.instance().isVisible()
+
+
+@bdd.then("the keyhint widget should not be visible")
+def keyhint_widget_not_visible():
+    assert not keyhint_widget.instance().isVisible()
+
+
+@bdd.then(bdd.parsers.parse("the keyhint widget should contain {command}"))
+def keyhint_widget_contains(command):
+    assert command in keyhint_widget.instance().text()

--- a/tox.ini
+++ b/tox.ini
@@ -65,3 +65,5 @@ commands = {envpython} -c ""
 # Settings for pycodestyle
 [pycodestyle]
 max-line-length = 88
+# E203: whitespace before ':' wrongly raised for slicing
+ignore = E203

--- a/vimiv/api/keybindings.py
+++ b/vimiv/api/keybindings.py
@@ -122,20 +122,17 @@ class _Bindings(collections.UserDict):
             )
         return _Bindings({**self, **other})
 
-    def partial_match(self, keys: str) -> bool:
+    def partial_matches(self, keys: str) -> List[str]:
         """Check if keys match some of the bindings partially.
 
         Args:
             keys: String containing the keynames to check, e.g. "g".
         Return:
-            True for match.
+            List of partial matches.
         """
         if not keys:
-            return False
-        for binding in self:
-            if binding.startswith(keys):
-                return True
-        return False
+            return []
+        return [binding for binding in self if binding.startswith(keys)]
 
 
 _registry = {mode: _Bindings() for mode in modes.ALL}

--- a/vimiv/api/keybindings.py
+++ b/vimiv/api/keybindings.py
@@ -35,7 +35,7 @@ earth with ``ge`` we could use::
 
 import collections
 from contextlib import suppress
-from typing import Any, Callable, ItemsView, List, Union
+from typing import Any, Callable, ItemsView, List, Union, Tuple
 
 from . import commands, modes
 
@@ -122,7 +122,7 @@ class _Bindings(collections.UserDict):
             )
         return _Bindings({**self, **other})
 
-    def partial_matches(self, keys: str) -> List[str]:
+    def partial_matches(self, keys: str) -> List[Tuple[str, str]]:
         """Check if keys match some of the bindings partially.
 
         Args:
@@ -132,7 +132,7 @@ class _Bindings(collections.UserDict):
         """
         if not keys:
             return []
-        return [binding for binding in self if binding.startswith(keys)]
+        return [binding for binding in self.items() if binding[0].startswith(keys)]
 
 
 _registry = {mode: _Bindings() for mode in modes.ALL}

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -453,6 +453,14 @@ StrSetting("statusbar.center_thumbnail", "{thumbnail-size}")
 StrSetting("statusbar.center", "{slideshow-indicator} {slideshow-delay}")
 StrSetting("statusbar.right", "{keys}  {mode}")
 
+# Keyhint widget
+KEYHINT_DELAY = IntSetting(
+    "keyhint.delay",
+    500,
+    desc="Delay until the keyhint widget is displayed",
+    min_value=0,
+)
+
 # Title module strings, these are not retrieved by their type
 StrSetting(
     "title.fallback",

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -453,12 +453,18 @@ StrSetting("statusbar.center_thumbnail", "{thumbnail-size}")
 StrSetting("statusbar.center", "{slideshow-indicator} {slideshow-delay}")
 StrSetting("statusbar.right", "{keys}  {mode}")
 
-# Keyhint widget
+# Keyhint widget and related settings
 KEYHINT_DELAY = IntSetting(
     "keyhint.delay",
     500,
-    desc="Delay until the keyhint widget is displayed",
+    desc="Delay (in ms) until the keyhint widget is displayed",
     min_value=0,
+)
+KEYHINT_TIMEOUT = IntSetting(
+    "keyhint.timeout",
+    5000,
+    desc="Time (in ms) after which partially typed keybindings are cleared",
+    min_value=500,
 )
 
 # Title module strings, these are not retrieved by their type

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -464,7 +464,7 @@ KEYHINT_TIMEOUT = IntSetting(
     "keyhint.timeout",
     5000,
     desc="Time (in ms) after which partially typed keybindings are cleared",
-    min_value=500,
+    min_value=100,
 )
 
 # Title module strings, these are not retrieved by their type

--- a/vimiv/config/configfile.py
+++ b/vimiv/config/configfile.py
@@ -90,6 +90,7 @@ def _update_setting(name, parser):
         setting_name = "%s.%s" % (section.lower(), option)
         setting_name = setting_name.replace("general.", "")
         api.settings.override(setting_name, parser_option)
+        api.settings.signals.changed.emit(api.settings.get(setting_name))
         logging.debug("Overriding '%s' with '%s'", setting_name, parser_option)
     except (configparser.NoSectionError, configparser.NoOptionError) as e:
         logging.info("%s in configfile", str(e))

--- a/vimiv/config/styles.py
+++ b/vimiv/config/styles.py
@@ -206,6 +206,10 @@ def _insert_values(style):
     style["completion.scrollbar.bg"] = "{image.scrollbar.bg}"
     style["completion.scrollbar.fg"] = "{image.scrollbar.fg}"
     style["completion.scrollbar.padding"] = "{image.scrollbar.padding}"
+    # Keyhint
+    style["keyhint.padding"] = "2px"
+    style["keyhint.border_radius"] = "10px"
+    style["keyhint.suffix_color"] = "{base0c}"
     # Manipulate
     style["manipulate.fg"] = "{statusbar.fg}"
     style["manipulate.focused.fg"] = "{base0c}"

--- a/vimiv/gui/keyhint_widget.py
+++ b/vimiv/gui/keyhint_widget.py
@@ -16,7 +16,7 @@ from vimiv.config import styles
 from vimiv.utils import eventhandler, slot
 
 
-class PartialOverlay(QLabel):
+class KeyhintWidget(QLabel):
     """Widget to display partial matches above the statusbar.
 
     The widget is shown when there are partial keybinding matches, e.g. on 'g'. It is
@@ -109,5 +109,5 @@ class PartialOverlay(QLabel):
             self._show_timer.setInterval(setting.value)
 
 
-def instance() -> PartialOverlay:
-    return api.objreg.get(PartialOverlay)
+def instance() -> KeyhintWidget:
+    return api.objreg.get(KeyhintWidget)

--- a/vimiv/gui/mainwindow.py
+++ b/vimiv/gui/mainwindow.py
@@ -19,7 +19,7 @@ from vimiv.gui import (
     thumbnail,
     widgets,
     manipulate,
-    partial_overlay,
+    keyhint_widget,
 )
 
 
@@ -49,7 +49,7 @@ class MainWindow(QWidget):
         self._overlays.append(manwidget)
         compwidget = completionwidget.CompletionView(self)
         self._overlays.append(compwidget)
-        self._overlays.append(partial_overlay.PartialOverlay(self))
+        self._overlays.append(keyhint_widget.KeyhintWidget(self))
         grid.addWidget(self.bar, 1, 0, 1, 2)
         # Initialize completer and config commands
         completer.Completer(self.bar.commandline, compwidget)

--- a/vimiv/gui/mainwindow.py
+++ b/vimiv/gui/mainwindow.py
@@ -19,6 +19,7 @@ from vimiv.gui import (
     thumbnail,
     widgets,
     manipulate,
+    partial_overlay,
 )
 
 
@@ -48,6 +49,7 @@ class MainWindow(QWidget):
         self._overlays.append(manwidget)
         compwidget = completionwidget.CompletionView(self)
         self._overlays.append(compwidget)
+        self._overlays.append(partial_overlay.PartialOverlay(self))
         grid.addWidget(self.bar, 1, 0, 1, 2)
         # Initialize completer and config commands
         completer.Completer(self.bar.commandline, compwidget)

--- a/vimiv/gui/partial_overlay.py
+++ b/vimiv/gui/partial_overlay.py
@@ -1,0 +1,113 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2019 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+"""Widget to display partial matches above the statusbar."""
+
+from typing import List, Tuple
+
+from PyQt5.QtCore import pyqtSlot, QTimer, Qt
+from PyQt5.QtWidgets import QLabel, QSizePolicy
+
+from vimiv import api
+from vimiv.config import styles
+from vimiv.utils import eventhandler, slot
+
+
+class PartialOverlay(QLabel):
+    """Widget to display partial matches above the statusbar.
+
+    The widget is shown when there are partial keybinding matches, e.g. on 'g'. It is
+    filled with a list of possible keybindings to fulfill a command.
+
+    Attributes:
+        _show_timer: Timer used to show the widget on partial matches after a delay.
+        _suffix_color: Color used to display the remaining keys for a match.
+        _mainwindow_bottom: y-coordinate of the bottom of the mainwindow.
+    """
+
+    STYLESHEET = """
+    QLabel {
+        font: {statusbar.font};
+        color: {statusbar.fg};
+        background: {statusbar.bg};
+        padding: {keyhint.padding};
+        border-top-right-radius: {keyhint.border_radius};
+    }
+    """
+
+    @api.objreg.register
+    def __init__(self, parent):
+        super().__init__(parent=parent)
+        self._show_timer = QTimer(self)
+        self._show_timer.setSingleShot(True)
+        self._show_timer.setInterval(api.settings.KEYHINT_DELAY.value)
+        self._show_timer.timeout.connect(self.show)
+
+        self._suffix_color = styles.get("keyhint.suffix_color")
+        self._mainwindow_bottom = 0
+
+        styles.apply(self)
+        self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Minimum)
+        self.setTextFormat(Qt.RichText)
+
+        eventhandler.KeyHandler.partial_handler.partial_matches.connect(
+            self._on_partial_matches
+        )
+        eventhandler.KeyHandler.partial_handler.partial_cleared.connect(
+            self._on_partial_cleared
+        )
+        api.settings.signals.changed.connect(self._on_settings_changed)
+
+        self.hide()
+
+    def update_geometry(self, window_width, window_bottom):
+        """Adapt location when main window geometry changes."""
+        self._mainwindow_bottom = window_bottom
+        self._update_geometry()
+
+    def _update_geometry(self):
+        """Update geometry according to current text content and window location."""
+        self.adjustSize()
+        y = self._mainwindow_bottom - self.height()
+        self.setGeometry(0, y, self.width(), self.height())
+
+    @pyqtSlot(str, list)
+    def _on_partial_matches(self, prefix: str, matches: List[Tuple[str, str]]):
+        """Initialize widget when partial matches exist.
+
+        Args:
+            prefix: Key(s) pressed for which there are partial matches.
+            matches: List of keybindings and commands that can complete the partial.
+        """
+        self._show_timer.start()
+        text = ""
+        for keybinding, command in matches:
+            suffix = keybinding[len(prefix) :]
+            text += (
+                "<tr>"
+                f"<td>{prefix}</td>"
+                f"<td style='color: {self._suffix_color}'>{suffix}</td>"
+                f"<td style='padding-left: 2ex'>{command}</td>"
+                "</tr>"
+            )
+        self.setText(f"<table>{text}</table>")
+        self._update_geometry()
+
+    @slot
+    def _on_partial_cleared(self):
+        """Stop timer and hide widget when there are no partial matches to show."""
+        self._show_timer.stop()
+        self.hide()
+
+    @slot
+    def _on_settings_changed(self, setting: api.settings.Setting):
+        """Update timer interval if the keyhint delay setting changed."""
+        if setting == api.settings.KEYHINT_DELAY:
+            self._show_timer.setInterval(setting.value)
+
+
+def instance() -> PartialOverlay:
+    return api.objreg.get(PartialOverlay)

--- a/vimiv/utils/eventhandler.py
+++ b/vimiv/utils/eventhandler.py
@@ -116,7 +116,7 @@ class KeyHandler:
             cmd = runners.update_command(cmd, mode)
             runners.command(count + cmd, mode)
         # Partial match => store keys
-        elif bindings.partial_match(keyname):
+        elif bindings.partial_matches(keyname):
             self._partial_handler.keys.add_text(keyname)
         # Nothing => run default Qt bindings of parent object
         else:

--- a/vimiv/utils/eventhandler.py
+++ b/vimiv/utils/eventhandler.py
@@ -29,8 +29,9 @@ class TempKeyStorage(QTimer):
         self.text = ""
 
         self.setSingleShot(True)
-        self.setInterval(2000)
+        self.setInterval(api.settings.KEYHINT_TIMEOUT.value)
         self.timeout.connect(self.on_timeout)
+        api.settings.signals.changed.connect(self._on_settings_changed)
 
     def add_text(self, text):
         """Add text to storage."""
@@ -56,6 +57,12 @@ class TempKeyStorage(QTimer):
         """Clear text and update status to remove partial keys from statusbar."""
         self.clear_text()
         api.status.update()
+
+    @utils.slot
+    def _on_settings_changed(self, setting: api.settings.Setting):
+        """Update timer interval if the keyhint timeout setting changed."""
+        if setting == api.settings.KEYHINT_TIMEOUT:
+            self.setInterval(setting.value)
 
 
 class PartialHandler(QObject):


### PR DESCRIPTION
The keyhint widget displays possible keybindings to complete partial matches, e.g. `gg  goto 1` after pressing `g`. This allows for better discoverability for more complicated chained keybindings.

Here is a screenshot of it in action:
![vimiv_keyhint](https://user-images.githubusercontent.com/12006766/55002671-512d5880-4fd7-11e9-93a9-5078b950193f.png)
