### PR TITLE
Fix false positives in is_image

### DIFF
--- a/tests/end2end/features/image/imageopen.feature
+++ b/tests/end2end/features/image/imageopen.feature
@@ -1,0 +1,8 @@
+Feature: Open different image formats
+
+    Background:
+        Given I start vimiv
+
+    Scenario: Error on invalid image formats
+        When I open broken images
+        Then no crash should happen

--- a/tests/end2end/features/image/test_imageopen_bdd.py
+++ b/tests/end2end/features/image/test_imageopen_bdd.py
@@ -1,0 +1,32 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2019 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+import imghdr
+
+import pytest_bdd as bdd
+
+from vimiv import app
+
+
+bdd.scenarios("imageopen.feature")
+
+
+@bdd.when("I open broken images")
+def open_broken_images(tmpdir):
+    _open_file(tmpdir, b"\211PNG\r\n\032\n")  # PNG
+    _open_file(tmpdir, b"000000JFIF")  # JPG
+    _open_file(tmpdir, b"GIF89a")  # GIF
+    _open_file(tmpdir, b"II")  # TIFF
+    _open_file(tmpdir, b"BM")  # BMP
+
+
+def _open_file(tmpdir, data):
+    """Open a file containing the bytes from data."""
+    path = str(tmpdir.join("broken"))
+    with open(path, "wb") as f:
+        f.write(data)
+    assert imghdr.what(path) is not None, "Invalid magic bytes in test setup"
+    app.open(path)

--- a/tests/unit/utils/test_files.py
+++ b/tests/unit/utils/test_files.py
@@ -6,6 +6,9 @@
 
 """Tests for vimiv.utils.files."""
 
+import os
+import tarfile
+
 from vimiv.utils import files
 
 
@@ -50,10 +53,23 @@ def test_directories_supported(mocker):
 def test_images_supported(mocker):
     mocker.patch("os.path.isdir", return_value=False)
     mocker.patch("os.path.isfile", return_value=True)
-    mocker.patch("PyQt5.QtGui.QImageReader.canRead", return_value=True)
+    mocker.patch("imghdr.what", return_value=True)
     images, directories = files.supported(["a", "b"])
     assert images == ["a", "b"]
     assert not directories
+
+
+def test_tar_gz_not_an_image(tmpdir):
+    """Test if is_image for a tar.gz returns False.
+
+    The default implementation of QImageReader.canRead returns True which is not
+    correct.
+    """
+    outfile = str(tmpdir.join("dummy.tar.gz"))
+    indirectory = str(tmpdir.mkdir("indir"))
+    with tarfile.open(outfile, mode="w:gz") as tar:
+        tar.add(indirectory, arcname=os.path.basename(indirectory))
+    assert files.is_image(outfile) is False
 
 
 #


### PR DESCRIPTION
Use the `imghdr` module to detect valid images and their file format instead of `QImageReader.canRead` to get rid of errors when opening invalid files such as `.tar.gz` files.