### PR TITLE
Fix exif writing

### DIFF
--- a/tests/unit/imutils/test_exif.py
+++ b/tests/unit/imutils/test_exif.py
@@ -1,0 +1,27 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2019 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+"""Tests for vimiv.imutils.exif."""
+
+import pytest
+
+from vimiv.imutils import exif
+
+
+@pytest.fixture
+def no_piexif():
+    initial_piexif = exif.piexif
+    exif.piexif = None
+    yield
+    exif.piexif = initial_piexif
+
+
+def test_check_piexif(no_piexif):
+    @exif.check_piexif(return_value="")
+    def dummy_func():
+        return "this should never be returned"
+
+    assert dummy_func() == ""

--- a/vimiv/imutils/__init__.py
+++ b/vimiv/imutils/__init__.py
@@ -44,6 +44,7 @@ Image manipulation:
 from PyQt5.QtCore import QObject, pyqtSignal
 from PyQt5.QtGui import QPixmap, QMovie
 
+from . import exif
 from .filelist import load, current, pathlist
 from .filelist import SignalHandler as _FilelistSignalHandler
 from ._file_handler import ImageFileHandler as _ImageFileHandler

--- a/vimiv/imutils/exif.py
+++ b/vimiv/imutils/exif.py
@@ -45,6 +45,15 @@ def copy_exif(src: str, dest: str, reset_orientation: bool = True) -> None:
         logging.debug("No exif data in '%s'", dest)
 
 
+def exif_date_time(filename) -> str:
+    """Exif creation date and time of filename."""
+    if piexif is not None:
+        with suppress(piexif.InvalidImageDataError, FileNotFoundError, KeyError):
+            exif_dict = piexif.load(filename)
+            return exif_dict["0th"][piexif.ImageIFD.DateTime].decode()
+    return ""
+
+
 class ExifOrientation:
     """Namespace for exif orientation tags.
 

--- a/vimiv/imutils/exif.py
+++ b/vimiv/imutils/exif.py
@@ -1,0 +1,62 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2019 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+"""Utility functions and classes for exif handling.
+
+All exif related tasks are implemented in this module. The heavy lifting is done using
+piexif (https://github.com/hMatoba/Piexif).
+"""
+
+import logging
+from contextlib import suppress
+
+# We need the check as exif support is optional
+try:
+    import piexif
+except ImportError:
+    piexif = None
+
+
+def copy_exif(src: str, dest: str, reset_orientation: bool = True) -> None:
+    """Copy exif information from src to dest.
+
+    Args:
+        src: Path to retrieve the exif information from.
+        dest: Path to write the exif information to.
+        reset_orientation: If true, reset the exif orientation tag to normal.
+    """
+    if piexif is None:  # No exif support
+        logging.debug("copy_exif: Nothing to do as piexif not found")
+        return
+    try:
+        exif_dict = piexif.load(src)
+        if reset_orientation:
+            with suppress(KeyError):
+                exif_dict["0th"][piexif.ImageIFD.Orientation] = ExifOrientation.Normal
+        exif_bytes = piexif.dump(exif_dict)
+        piexif.insert(exif_bytes, dest)
+        logging.debug("Succesfully wrote exif data for '%s'", dest)
+    except piexif.InvalidImageDataError:  # File is not a jpg
+        logging.debug("File format for '%s' does not support exif", dest)
+    except ValueError:
+        logging.debug("No exif data in '%s'", dest)
+
+
+class ExifOrientation:
+    """Namespace for exif orientation tags.
+
+    For more information see: http://jpegclub.org/exif_orientation.html.
+    """
+
+    Unspecified = 0
+    Normal = 1
+    HorizontalFlip = 2
+    Rotation180 = 3
+    VerticalFlip = 4
+    Rotation90HorizontalFlip = 5
+    Rotation90 = 6
+    Rotation90VerticalFlip = 7
+    Rotation270 = 8

--- a/vimiv/imutils/filelist.py
+++ b/vimiv/imutils/filelist.py
@@ -12,7 +12,6 @@ new image in the filelist is selected, it is passed on to the file handler to op
 
 import logging
 import os
-from contextlib import suppress
 from random import shuffle
 from typing import List, Iterable
 
@@ -21,13 +20,6 @@ from PyQt5.QtCore import QObject, pyqtSlot
 from vimiv import api, utils, imutils
 from vimiv.commands import search
 from vimiv.utils import files, slideshow, working_directory
-
-
-# We need the check as exif support is optional
-try:
-    import piexif
-except ImportError:
-    piexif = None
 
 
 _paths: List[str] = []
@@ -133,11 +125,7 @@ def exif_date_time() -> str:
     data in the statusbar. If there are any requests/ideas for more, this can
     be used as basis to work with.
     """
-    if piexif is not None:
-        with suppress(piexif.InvalidImageDataError, FileNotFoundError, KeyError):
-            exif_dict = piexif.load(current())
-            return exif_dict["0th"][piexif.ImageIFD.DateTime].decode()
-    return ""
+    return imutils.exif.exif_date_time(current())
 
 
 def pathlist() -> List[str]:


### PR DESCRIPTION
By implementing an exif module the exif orientation is now reset when saving an image file using autowrite or the `:write` command. The module helps keep the exif related code in one place and is thus also the only module requiring the optional dependency piexif.

fixes #51 