### PR TITLE
Unix style pattern matching

### DIFF
--- a/docs/documentation/getting_started.rst
+++ b/docs/documentation/getting_started.rst
@@ -96,7 +96,9 @@ completion is also supported.
 
 Prepending a command with ``!`` lets vimiv interpret the command as an external
 command. The following text is passed to the shell. Here ``%`` is replaced with the
-currently selected file and ``*`` with the current file list. 
+currently selected file and unix style pattern matching including ``*`` and ``?`` can be
+used. Recursive matching is also possible using ``**`` but please note that this can
+become slow in large directory trees.
 Example: ``:!gimp %`` opens the currently selected image in gimp.
 
 External commands can be "piped to vimiv" by appending the ``|`` char to the

--- a/tests/end2end/features/command/search.feature
+++ b/tests/end2end/features/command/search.feature
@@ -4,17 +4,20 @@ Feature: Run search in different modes.
         Given I open a directory with 5 paths
         When I search for 3
         Then the library row should be 3
+        And there should be 1 search matches
 
     Scenario: Search in image mode
         Given I open 5 images
         When I search for 3
         Then the image should have the index 3
+        And there should be 1 search matches
 
     Scenario: Search in thumbnail mode
         Given I open 5 images
         When I enter thumbnail mode
         And I search for 3
         Then the thumbnail number 3 should be selected
+        And there should be 1 search matches
 
     Scenario: Navigate search results forward
         Given I open a directory with 15 paths
@@ -24,6 +27,7 @@ Feature: Run search in different modes.
         And I run 2search-next
         # Move two forward to _11
         Then the library row should be 11
+        And there should be 7 search matches
 
     Scenario: Navigate search results backward
         Given I open a directory with 15 paths
@@ -33,15 +37,36 @@ Feature: Run search in different modes.
         And I run search-prev
         # Move backward to _15
         Then the library row should be 15
+        And there should be 7 search matches
 
     Scenario: Navigate search results forward in reverse
         Given I open a directory with 15 paths
         When I search in reverse for 1
         And I run search-next
         Then the library row should be 15
+        And there should be 7 search matches
 
     Scenario: Navigate search results backward in reverse
         Given I open a directory with 15 paths
         When I search in reverse for 1
         And I run search-prev
         Then the library row should be 10
+        And there should be 7 search matches
+
+    Scenario: Search using unix-style asterisk pattern matching
+        Given I open a directory with 15 paths
+        When I search for 1*
+        # Matches: 1, 10, 11, 12, 13, 14, 15
+        Then there should be 7 search matches
+
+    Scenario: Search using unix-style question mark pattern matching
+        Given I open a directory with 15 paths
+        When I search for 1?
+        # Matches: 10, 11, 12, 13, 14, 15
+        Then there should be 6 search matches
+
+    Scenario: Search using unix-style group pattern matching
+        Given I open a directory with 15 paths
+        When I search for 1[234]
+        # Matches: 12, 13, 14
+        Then there should be 3 search matches

--- a/tests/end2end/features/command/test_search_bdd.py
+++ b/tests/end2end/features/command/test_search_bdd.py
@@ -13,6 +13,23 @@ from vimiv.commands import search
 bdd.scenarios("search.feature")
 
 
+class SearchResults:
+    """Helper class to store search results."""
+
+    def __init__(self):
+        search.search.new_search.connect(self._on_search)
+        self.results = None
+
+    def _on_search(self, _index, results, _mode, _incsearch):
+        self.results = results
+
+    def __len__(self):
+        return len(self.results)
+
+
+search_results = SearchResults()
+
+
 @bdd.when(bdd.parsers.parse("I search for {text}"))
 def run_search(text):
     search.search(text, api.modes.current())
@@ -21,3 +38,8 @@ def run_search(text):
 @bdd.when(bdd.parsers.parse("I search in reverse for {text}"))
 def run_search_reverse(text):
     search.search(text, api.modes.current(), reverse=True)
+
+
+@bdd.then(bdd.parsers.parse("There should be {n:d} search matches"))
+def check_search_matches(n):
+    assert len(search_results) == n

--- a/tests/end2end/features/image/conftest.py
+++ b/tests/end2end/features/image/conftest.py
@@ -1,0 +1,14 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2019 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+import pytest_bdd as bdd
+
+from vimiv.imutils import filelist
+
+
+@bdd.then(bdd.parsers.parse("the filelist should contain {number} images"))
+def check_filelist_length(number):
+    assert filelist.total() == number

--- a/tests/end2end/features/image/imageopen.feature
+++ b/tests/end2end/features/image/imageopen.feature
@@ -1,8 +1,19 @@
-Feature: Open different image formats
-
-    Background:
-        Given I start vimiv
+Feature: Open different images and image formats
 
     Scenario: Error on invalid image formats
+        Given I start vimiv
         When I open broken images
         Then no crash should happen
+
+    # This does the magic to open all images in the directory
+    # Therefore only the index, not the total number of images changes
+    Scenario: Open single image using the open command
+        Given I open 5 images
+        When I run open image_03.jpg
+        Then the filelist should contain 5 images
+        And the image should have the index 3
+
+    Scenario: Open multiple images using the open command
+        Given I open 5 images
+        When I run open image_01.jpg image_02.jpg
+        Then the filelist should contain 2 images

--- a/tests/end2end/features/image/imageopen.feature
+++ b/tests/end2end/features/image/imageopen.feature
@@ -17,3 +17,18 @@ Feature: Open different images and image formats
         Given I open 5 images
         When I run open image_01.jpg image_02.jpg
         Then the filelist should contain 2 images
+
+    Scenario: Open image using unix-style asterisk pattern expansion
+        Given I open 11 images
+        When I run open image_1*.jpg
+        Then the filelist should contain 2 images
+
+    Scenario: Open image using unix-style question mark pattern expansion
+        Given I open 11 images
+        When I run open image_1?.jpg
+        Then the filelist should contain 2 images
+
+    Scenario: Open image using unix-style group pattern expansion
+        Given I open 12 images
+        When I run open image_1[01].jpg
+        Then the filelist should contain 2 images

--- a/tests/end2end/features/image/test_imagedelete_bdd.py
+++ b/tests/end2end/features/image/test_imagedelete_bdd.py
@@ -22,11 +22,6 @@ def wait_for_working_directory_handler(qtbot):
         pass
 
 
-@bdd.then(bdd.parsers.parse("the filelist should contain {number} images"))
-def check_filelist_length(number):
-    assert filelist.total() == number
-
-
 @bdd.then(bdd.parsers.parse("{basename} should not be in the filelist"))
 def check_image_not_in_filelist(basename):
     abspath = os.path.abspath(basename)

--- a/tests/end2end/features/image/test_imageopen_bdd.py
+++ b/tests/end2end/features/image/test_imageopen_bdd.py
@@ -29,4 +29,4 @@ def _open_file(tmpdir, data):
     with open(path, "wb") as f:
         f.write(data)
     assert imghdr.what(path) is not None, "Invalid magic bytes in test setup"
-    app.open(path)
+    app.open([path])

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -89,3 +89,8 @@ def test_profiler(capsys):
     with utils.profile(5):
         pass
     assert "function calls" in capsys.readouterr().out
+
+
+def test_flatten():
+    list_of_lists = [[1, 2], [3, 4]]
+    assert utils.flatten(list_of_lists) == [1, 2, 3, 4]

--- a/vimiv/commands/runners.py
+++ b/vimiv/commands/runners.py
@@ -52,13 +52,13 @@ def run(text, count=None, mode=None):
 
 
 def update_command(text, mode):
-    """Update command with aliases and wildcards.
+    """Update command with aliases and percent wildcard.
 
     Args:
         text: String passed as command.
         mode: Mode in which the command is supposed to run.
     """
-    return expand_wildcards(alias(text, mode), mode)
+    return expand_percent(alias(text, mode), mode)
 
 
 def command(text, mode=None):
@@ -140,8 +140,8 @@ def _parse(text):
     return count, cmdname, args
 
 
-def expand_wildcards(text, mode):
-    """Expand % and * to the corresponding path and pathlist.
+def expand_percent(text, mode):
+    """Expand % to the corresponding path.
 
     Args:
         text: The command in which the wildcards are expanded.
@@ -151,9 +151,6 @@ def expand_wildcards(text, mode):
     if "%" in text:
         current = shlex.quote(pathreceiver.current(mode))
         text = re.sub(r"(?<!\\)%", current, text)
-    if "*" in text:
-        pathlist = " ".join([shlex.quote(path) for path in pathreceiver.pathlist(mode)])
-        text = re.sub(r"(?<!\\)\*", pathlist, text)
     return text
 
 

--- a/vimiv/commands/runners.py
+++ b/vimiv/commands/runners.py
@@ -191,10 +191,11 @@ class ExternalRunner(QObject):
             stdout: String form of stdout of the exited shell command.
         """
         paths = [path for path in stdout.split("\n") if os.path.exists(path)]
-        if paths and app.open_paths(paths):
-            api.status.update()
+        try:
+            app.open(paths)
             logging.debug("Opened paths from pipe '%s'", cmd)
-        else:
+            api.status.update()
+        except api.commands.CommandError:
             logging.warning("%s: No paths from pipe", cmd)
 
 

--- a/vimiv/commands/search.py
+++ b/vimiv/commands/search.py
@@ -10,6 +10,7 @@ Module Attributes:
     search: Instance of the Search class used.
 """
 
+import fnmatch
 import os
 
 from PyQt5.QtCore import QObject, pyqtSignal
@@ -153,15 +154,18 @@ def _get_next_match(text, count, paths):
         count: Defines how many matches to jump forward.
         paths: List of paths to search in.
     """
-    matches = [path for path in paths if _matches(text, path)]
+    matches = [path for path in paths if _matches(path, text)]
     if matches:
         count = count % len(matches)
         return matches[count], matches
     return paths[0], []
 
 
-def _matches(first, second):
-    """Check if first string is in second string."""
+def _matches(path, pattern):
+    """Return True if path matches pattern.
+
+    This uses fnmatch to perform unix-style filename pattern matching.
+    """
     if api.settings.search.ignore_case.value:
-        return first.lower() in second.lower()
-    return first in second
+        return fnmatch.fnmatchcase(path.lower(), f"*{pattern.lower()}*")
+    return fnmatch.fnmatchcase(path, f"*{pattern}*")

--- a/vimiv/startup.py
+++ b/vimiv/startup.py
@@ -209,8 +209,12 @@ def init_directories(args):
 def init_paths(args):
     """Open paths given from commandline or fallback to library if set."""
     logging.debug("Opening paths")
-    if not app.open_paths(args.paths) and api.settings.startup_library.value:
-        app.open_paths([os.getcwd()])
+    try:
+        app.open(args.paths)
+    except api.commands.CommandError:
+        logging.debug("init_paths: No valid paths retrieved")
+        if api.settings.startup_library.value:
+            app.open([os.getcwd()])
     api.status.update()
 
 

--- a/vimiv/utils/__init__.py
+++ b/vimiv/utils/__init__.py
@@ -14,7 +14,7 @@ import re
 from contextlib import contextmanager, suppress
 from datetime import datetime
 from pstats import Stats
-from typing import Callable, Optional, TypeVar
+from typing import Callable, Optional, TypeVar, List, Any
 
 from PyQt5.QtCore import pyqtSlot
 
@@ -148,6 +148,11 @@ def slot(function):
     slot_args, slot_kwargs = _slot_args(argspec, function), _slot_kwargs(argspec)
     pyqtSlot(*slot_args, **slot_kwargs)(function)
     return function
+
+
+def flatten(list_of_lists: List[List[Any]]) -> List[Any]:
+    """Flatten a list of lists into a single list with all elements."""
+    return [elem for sublist in list_of_lists for elem in sublist]
 
 
 def timed(function):

--- a/vimiv/utils/clipboard.py
+++ b/vimiv/utils/clipboard.py
@@ -52,4 +52,4 @@ def paste_name(primary: bool = True) -> None:
     """
     clipboard = QGuiApplication.clipboard()
     mode = QClipboard.Selection if primary else QClipboard.Clipboard
-    app.open(clipboard.text(mode=mode))
+    app.open([clipboard.text(mode=mode)])


### PR DESCRIPTION
This adds support for unix-style pattern matching for commands that support paths as argument (currently only `:open`) and searching.