### PR TITLE
Easier custom styles

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,3 +7,19 @@ v0.1.0
 ------
 
 Initial release of the Qt version.
+
+
+v0.2.0 (unreleased)
+-------------------
+
+Added:
+^^^^^^
+
+* A global ``font`` style option to set all fonts at once. If a local option such as
+  ``statusbar.font`` is defined, it overrides the global option.
+
+Changed:
+^^^^^^^^
+
+* All styles are now based upon base16. Therefore custom styles must define the colors
+  ``base00`` to ``base0f``. All other style options are optional.

--- a/docs/documentation/configuration/style.rst
+++ b/docs/documentation/configuration/style.rst
@@ -11,18 +11,22 @@ on startup if they do not exist.  The styles directory is located in
 ``$XDG_CONFIG_HOME/vimiv/`` where ``$XDG_CONFIG_HOME`` is usually
 ``~/.config/`` if you have not updated it.
 
-You can implement your own style by copying a default file in the ``styles``
-directory, configuring it to your liking, and changing the ``style`` setting in
-the ``vimiv.conf`` file to the name of the new file.
+Creating your own style is easy:
 
-As the default files show, it is possible to define variables and referencing
-them afterwards. Say you define ``red = #ff0000`` and you would like the
-statusbar text to be red. You can then reference it via
-``statusbar.fg = {red}``.
+#. Create a new file in the ``styles`` directory. The file must start with the
+   ``[STYLE]`` header.
+#. Define the colors ``base00`` to ``base0f``. This is required as these colors are
+   referenced by the individual options.
+#. Change the ``style`` setting in the ``vimiv.conf`` file to the name of your newly
+   created file.
+#. Optional: override any other option such as the global ``font`` or individual
+   settings like ``thumbnail.padding``.
 
-.. warning:: Your style **MUST** implement **ALL** of the variables defined
-   in the default style. Not doing so leads to undefined behaviour as the
-   corresponding style of the Qt Widget will be left empty.
+.. hint:: Refer to the created default style for all available options
+
+.. hint:: Defined style options can be referenced via ``new_option = {other_option}``,
+   for example to use a different base color for mark-related things you can use
+   ``mark.color = {base0a}``.
 
 .. hint:: The python configparser module is not case sensitive. Therefore it is
    a good idea to keep all your styles in lower case.

--- a/tests/unit/config/test_styles.py
+++ b/tests/unit/config/test_styles.py
@@ -12,7 +12,7 @@ from vimiv.config import styles
 
 @pytest.fixture
 def new_style():
-    new_style = styles.Style()
+    new_style = styles.create_default(save_to_file=False)
     yield new_style
     del new_style
 

--- a/tests/unit/config/test_styles.py
+++ b/tests/unit/config/test_styles.py
@@ -42,3 +42,39 @@ def test_fail_get_nonexisting_style_option(mocker, new_style):
     styles._style = new_style
     assert styles.get("anything") == ""
     styles._style = None
+
+
+def test_is_color_option():
+    assert styles.Style.is_color_option("test.bg")
+    assert styles.Style.is_color_option("test.fg")
+    assert not styles.Style.is_color_option("test.fga")
+    assert not styles.Style.is_color_option("test.f")
+
+
+def test_check_valid_color():
+    # If a check fails, ValueError is raised, so we need no assert statement
+    styles.Style.check_valid_color("#fff")  # 3 digit hex
+    styles.Style.check_valid_color("#FFF")  # 3 digit hex capital
+    styles.Style.check_valid_color("#FfF")  # 3 digit hex mixed case
+    styles.Style.check_valid_color("#0fF")  # 3 digit hex mixed case and number
+    styles.Style.check_valid_color("#ffffff")  # 6 digit hex
+    styles.Style.check_valid_color("#FFFFFF")  # 6 digit hex capital
+    styles.Style.check_valid_color("#FFfFfF")  # 6 digit hex mixed case
+    styles.Style.check_valid_color("#00fFfF")  # 6 digit hex mixed case and number
+
+
+def test_fail_check_valid_color():
+    _fail_check_valid_color("ffffff")  # Missing leading #
+    _fail_check_valid_color("#fffffff")  # 7 digits
+    _fail_check_valid_color("#fffff")  # 5 digits
+    _fail_check_valid_color("#ffff")  # 4 digits
+    _fail_check_valid_color("#ff")  # 2 digits
+    _fail_check_valid_color("#f")  # 1 digit
+    _fail_check_valid_color("#")  # 0 digits
+    _fail_check_valid_color("#agfjkl")  # invalid content
+
+
+def _fail_check_valid_color(color: str):
+    """Helper method used by test_fail_check_valid_color."""
+    with pytest.raises(ValueError):
+        styles.Style.check_valid_color(color)

--- a/vimiv/config/styles.py
+++ b/vimiv/config/styles.py
@@ -32,8 +32,8 @@ class Style(collections.OrderedDict):
     Ordered so referencing and dereferencing variables is well defined.
     """
 
-    def __init__(self, *colors):
-        """Initialize style with 16 colors for base 16."""
+    def __init__(self, *colors, font="10pt Monospace"):
+        """Initialize style with 16 colors for base 16 and a font."""
         # We are mainly storing all the values here
         # pylint: disable=too-many-statements
         super().__init__()
@@ -43,6 +43,7 @@ class Style(collections.OrderedDict):
         for i, color in enumerate(colors):
             self[f"base{i:02x}"] = color
         # Fill in all values
+        self["font"] = font
         # Image
         self["image.bg"] = "{base00}"
         self["image.scrollbar.width"] = "8px"
@@ -50,7 +51,7 @@ class Style(collections.OrderedDict):
         self["image.scrollbar.fg"] = "{base03}"
         self["image.scrollbar.padding"] = "2px"
         # Library
-        self["library.font"] = "10pt Monospace"
+        self["library.font"] = "{font}"
         self["library.fg"] = "{base06}"
         self["library.padding"] = "2px"
         self["library.directory.fg"] = "{base07}"
@@ -66,7 +67,7 @@ class Style(collections.OrderedDict):
         self["library.scrollbar.padding"] = "{image.scrollbar.padding}"
         self["library.border"] = "0px solid"
         # Thumbnail
-        self["thumbnail.font"] = "{library.font}"
+        self["thumbnail.font"] = "{font}"
         self["thumbnail.fg"] = "{library.fg}"
         self["thumbnail.bg"] = "{image.bg}"
         self["thumbnail.padding"] = "20"
@@ -76,7 +77,7 @@ class Style(collections.OrderedDict):
         self["thumbnail.error.bg"] = "{statusbar.error}"
         self["thumbnail.frame.fg"] = "{thumbnail.fg}"
         # Statusbar
-        self["statusbar.font"] = "10pt Monospace"
+        self["statusbar.font"] = "{font}"
         self["statusbar.bg"] = "{base02}"
         self["statusbar.fg"] = "{base06}"
         self["statusbar.error"] = "{base08}"
@@ -234,9 +235,13 @@ def read(filename):
     """
     parser = configparser.ConfigParser()
     parser.read(filename)
+    section = parser["STYLE"]
     # Retrieve base colors
-    colors = [parser["STYLE"].pop(f"base{i:02x}") for i in range(16)]
-    style = Style(*colors)
+    colors = [section.pop(f"base{i:02x}") for i in range(16)]
+    if "font" in section:  # User-defined global font
+        style = Style(*colors, font=section["font"])
+    else:  # Default global font
+        style = Style(*colors)
     # Override additional options
     for option, value in parser["STYLE"].items():
         style[option] = value

--- a/vimiv/config/styles.py
+++ b/vimiv/config/styles.py
@@ -257,10 +257,21 @@ def read(filename):
         filename: Name of the styles file to read
     """
     parser = configparser.ConfigParser()
-    parser.read(filename)
-    section = parser["STYLE"]
+    # Retrieve the STYLE section
+    try:
+        parser.read(filename)
+        section = parser["STYLE"]
+    except (configparser.MissingSectionHeaderError, KeyError):
+        logging.error(
+            "Style files must start with the [STYLE] header. Falling back to default."
+        )
+        return create_default(save_to_file=False)
     # Retrieve base colors
-    colors = [section.pop(f"base{i:02x}") for i in range(16)]
+    try:
+        colors = [section.pop(f"base{i:02x}") for i in range(16)]
+    except KeyError as e:
+        logging.error("Style is missing color %s. Falling back to default.", e)
+        return create_default(save_to_file=False)
     if "font" in section:  # User-defined global font
         style = Style(*colors, font=section["font"])
     else:  # Default global font

--- a/vimiv/config/styles.py
+++ b/vimiv/config/styles.py
@@ -14,7 +14,6 @@ Module Attributes:
         _style["image.bg"] = "#000000"
 """
 
-import collections
 import configparser
 import logging
 import os
@@ -30,7 +29,7 @@ NAME_DEFAULT_DARK = "default-dark"
 _style = None
 
 
-class Style(collections.OrderedDict):
+class Style(dict):
     """Class defining a single style.
 
     The style is based on 16 colors according to base16.

--- a/vimiv/config/styles.py
+++ b/vimiv/config/styles.py
@@ -7,6 +7,9 @@
 """Functions dealing with the stylesheet of the Qt widgets.
 
 Module Attributes:
+    NAME_DEFAULT: Name of the default theme.
+    NAME_DEFAULT_DARK: Name of the dark default theme.
+
     _style: Dictionary saving the style settings from the config file, form:
         _style["image.bg"] = "#000000"
 """
@@ -19,6 +22,9 @@ import os
 from vimiv import api
 from vimiv.utils import xdg
 
+
+NAME_DEFAULT = "default"
+NAME_DEFAULT_DARK = "default-dark"
 
 _style = None
 
@@ -135,10 +141,10 @@ def parse():
     global _style
     name = api.settings.style.value
     filename = xdg.join_vimiv_config("styles/%s" % (name))
-    if name == "default":
+    if name == NAME_DEFAULT:
         _style = create_default()
-    elif name == "default-dark":
-        _style = create_default_dark()
+    elif name == NAME_DEFAULT_DARK:
+        _style = create_default(dark=True)
     elif os.path.exists(filename):
         _style = read(filename)
     else:
@@ -169,62 +175,59 @@ def get(name):
         return ""
 
 
-def create_default():
-    """Create the default style."""
+def create_default(dark=False, save_to_file=True):
+    """Create the default style.
+
+    Args:
+        dark: Create the default dark style instead.
+        save_to_file: Dump the default style to file for reading and reference.
+    """
     # Color definitions
     # Uses base16 tomorrow
     # Thanks to https://github.com/chriskempson/base16-tomorrow-scheme/
-    default = Style(
-        "#ffffff",  # base00
-        "#e0e0e0",  # base01
-        "#d6d6d6",  # base02
-        "#8e908c",  # base03
-        "#969896",  # base04
-        "#4d4d4c",  # base05
-        "#282a2e",  # base06
-        "#1d1f21",  # base07
-        "#c82829",  # base08
-        "#f5871f",  # base09
-        "#eab700",  # base0a
-        "#718c00",  # base0b
-        "#3e999f",  # base0c
-        "#81a2be",  # base0d
-        "#8959a8",  # base0e
-        "#a3685a",  # base0f
-    )
-    # Dump
-    if not os.path.isfile(xdg.join_vimiv_config("styles/default")):
-        dump("default", default)
-    return default
-
-
-def create_default_dark():
-    """Create the default dark style."""
-    # Color definitions
-    # Uses base16 tomorrow-night
-    # Thanks to https://github.com/chriskempson/base16-tomorrow-scheme/
-    default_dark = Style(
-        "#1d1f21",  # base00
-        "#282a2e",  # base01
-        "#373b41",  # base02
-        "#969896",  # base03
-        "#b4b7b4",  # base04
-        "#c5c8c6",  # base05
-        "#e0e0e0",  # base06
-        "#ffffff",  # base07
-        "#cc6666",  # base08
-        "#de935f",  # base09
-        "#f0c674",  # base0a
-        "#b5bd68",  # base0b
-        "#8abeb7",  # base0c
-        "#81a2be",  # base0d
-        "#b294bb",  # base0e
-        "#a3685a",  # base0f
-    )
-    # Dump
-    if not os.path.isfile(xdg.join_vimiv_config("styles/default-dark")):
-        dump("default-dark", default_dark)
-    return default_dark
+    if dark:
+        style = Style(
+            "#1d1f21",  # base00
+            "#282a2e",  # base01
+            "#373b41",  # base02
+            "#969896",  # base03
+            "#b4b7b4",  # base04
+            "#c5c8c6",  # base05
+            "#e0e0e0",  # base06
+            "#ffffff",  # base07
+            "#cc6666",  # base08
+            "#de935f",  # base09
+            "#f0c674",  # base0a
+            "#b5bd68",  # base0b
+            "#8abeb7",  # base0c
+            "#81a2be",  # base0d
+            "#b294bb",  # base0e
+            "#a3685a",  # base0f
+        )
+        name = NAME_DEFAULT_DARK
+    else:
+        style = Style(
+            "#ffffff",  # base00
+            "#e0e0e0",  # base01
+            "#d6d6d6",  # base02
+            "#8e908c",  # base03
+            "#969896",  # base04
+            "#4d4d4c",  # base05
+            "#282a2e",  # base06
+            "#1d1f21",  # base07
+            "#c82829",  # base08
+            "#f5871f",  # base09
+            "#eab700",  # base0a
+            "#718c00",  # base0b
+            "#3e999f",  # base0c
+            "#81a2be",  # base0d
+            "#8959a8",  # base0e
+            "#a3685a",  # base0f
+        )
+        name = NAME_DEFAULT
+    if save_to_file and not os.path.isfile(xdg.join_vimiv_config("styles", name)):
+        dump(name, style)
+    return style
 
 
 def read(filename):

--- a/vimiv/config/styles.py
+++ b/vimiv/config/styles.py
@@ -26,9 +26,91 @@ _style = None
 class Style(collections.OrderedDict):
     """Class defining a single style.
 
+    The style is based on 16 colors according to base16.
+
     A python dictionary with a name and overridden __setitem__ for convenience.
     Ordered so referencing and dereferencing variables is well defined.
     """
+
+    def __init__(self, *colors):
+        """Initialize style with 16 colors for base 16."""
+        # We are mainly storing all the values here
+        # pylint: disable=too-many-statements
+        super().__init__()
+        # Initialize the colorscheme from base16
+        if len(colors) != 16:
+            raise ValueError("Styles must be created with 16 colors for base16")
+        for i, color in enumerate(colors):
+            self[f"base{i:02x}"] = color
+        # Fill in all values
+        # Image
+        self["image.bg"] = "{base00}"
+        self["image.scrollbar.width"] = "8px"
+        self["image.scrollbar.bg"] = "{image.bg}"
+        self["image.scrollbar.fg"] = "{base03}"
+        self["image.scrollbar.padding"] = "2px"
+        # Library
+        self["library.font"] = "10pt Monospace"
+        self["library.fg"] = "{base06}"
+        self["library.padding"] = "2px"
+        self["library.directory.fg"] = "{base07}"
+        self["library.even.bg"] = "{base01}"
+        self["library.odd.bg"] = "{base01}"
+        self["library.selected.bg"] = "{base0d}"
+        self["library.selected.fg"] = "{base07}"
+        self["library.search.highlighted.fg"] = "{base01}"
+        self["library.search.highlighted.bg"] = "{base04}"
+        self["library.scrollbar.width"] = "{image.scrollbar.width}"
+        self["library.scrollbar.bg"] = "{image.bg}"
+        self["library.scrollbar.fg"] = "{image.scrollbar.fg}"
+        self["library.scrollbar.padding"] = "{image.scrollbar.padding}"
+        self["library.border"] = "0px solid"
+        # Thumbnail
+        self["thumbnail.font"] = "{library.font}"
+        self["thumbnail.fg"] = "{library.fg}"
+        self["thumbnail.bg"] = "{image.bg}"
+        self["thumbnail.padding"] = "20"
+        self["thumbnail.selected.bg"] = "{library.selected.bg}"
+        self["thumbnail.search.highlighted.bg"] = "{library.search.highlighted.bg}"
+        self["thumbnail.default.bg"] = "{statusbar.info}"
+        self["thumbnail.error.bg"] = "{statusbar.error}"
+        self["thumbnail.frame.fg"] = "{thumbnail.fg}"
+        # Statusbar
+        self["statusbar.font"] = "10pt Monospace"
+        self["statusbar.bg"] = "{base02}"
+        self["statusbar.fg"] = "{base06}"
+        self["statusbar.error"] = "{base08}"
+        self["statusbar.warning"] = "{base09}"
+        self["statusbar.info"] = "{base0c}"
+        self["statusbar.message_border"] = "2px solid"
+        self["statusbar.padding"] = "4"
+        # Completion
+        self["completion.height"] = "16em"
+        self["completion.fg"] = "{statusbar.fg}"
+        self["completion.even.bg"] = "{statusbar.bg}"
+        self["completion.odd.bg"] = "{statusbar.bg}"
+        self["completion.selected.fg"] = "{library.selected.fg}"
+        self["completion.selected.bg"] = "{library.selected.bg}"
+        self["completion.scrollbar.width"] = "{image.scrollbar.width}"
+        self["completion.scrollbar.bg"] = "{image.scrollbar.bg}"
+        self["completion.scrollbar.fg"] = "{image.scrollbar.fg}"
+        self["completion.scrollbar.padding"] = "{image.scrollbar.padding}"
+        # Keyhint
+        self["keyhint.padding"] = "2px"
+        self["keyhint.border_radius"] = "10px"
+        self["keyhint.suffix_color"] = "{base0c}"
+        # Manipulate
+        self["manipulate.fg"] = "{statusbar.fg}"
+        self["manipulate.focused.fg"] = "{base0c}"
+        self["manipulate.bg"] = "{image.bg}"
+        self["manipulate.slider.left"] = "{library.selected.bg}"
+        self["manipulate.slider.handle"] = "{base04}"
+        self["manipulate.slider.right"] = "{statusbar.bg}"
+        # Manipulate image overlay
+        self["manipulate.image.border"] = "2px solid"
+        self["manipulate.image.border.color"] = "{base0c}"
+        # Mark
+        self["mark.color"] = "{base0e}"
 
     def __setitem__(self, name, item):
         """Store item automatically surrounding the name with {} if needed."""
@@ -88,28 +170,27 @@ def get(name):
 
 def create_default():
     """Create the default style."""
-    default = Style()
     # Color definitions
     # Uses base16 tomorrow
     # Thanks to https://github.com/chriskempson/base16-tomorrow-scheme/
-    default["base00"] = "#ffffff"
-    default["base01"] = "#e0e0e0"
-    default["base02"] = "#d6d6d6"
-    default["base03"] = "#8e908c"
-    default["base04"] = "#969896"
-    default["base05"] = "#4d4d4c"
-    default["base06"] = "#282a2e"
-    default["base07"] = "#1d1f21"
-    default["base08"] = "#c82829"
-    default["base09"] = "#f5871f"
-    default["base0a"] = "#eab700"
-    default["base0b"] = "#718c00"
-    default["base0c"] = "#3e999f"
-    default["base0d"] = "#81a2be"
-    default["base0e"] = "#8959a8"
-    default["base0f"] = "#a3685a"
-    # Insert style
-    _insert_values(default)
+    default = Style(
+        "#ffffff",  # base00
+        "#e0e0e0",  # base01
+        "#d6d6d6",  # base02
+        "#8e908c",  # base03
+        "#969896",  # base04
+        "#4d4d4c",  # base05
+        "#282a2e",  # base06
+        "#1d1f21",  # base07
+        "#c82829",  # base08
+        "#f5871f",  # base09
+        "#eab700",  # base0a
+        "#718c00",  # base0b
+        "#3e999f",  # base0c
+        "#81a2be",  # base0d
+        "#8959a8",  # base0e
+        "#a3685a",  # base0f
+    )
     # Dump
     if not os.path.isfile(xdg.join_vimiv_config("styles/default")):
         dump("default", default)
@@ -118,110 +199,31 @@ def create_default():
 
 def create_default_dark():
     """Create the default dark style."""
-    default_dark = Style()
     # Color definitions
     # Uses base16 tomorrow-night
     # Thanks to https://github.com/chriskempson/base16-tomorrow-scheme/
-    default_dark["base00"] = "#1d1f21"
-    default_dark["base01"] = "#282a2e"
-    default_dark["base02"] = "#373b41"
-    default_dark["base03"] = "#969896"
-    default_dark["base04"] = "#b4b7b4"
-    default_dark["base05"] = "#c5c8c6"
-    default_dark["base06"] = "#e0e0e0"
-    default_dark["base07"] = "#ffffff"
-    default_dark["base08"] = "#cc6666"
-    default_dark["base09"] = "#de935f"
-    default_dark["base0a"] = "#f0c674"
-    default_dark["base0b"] = "#b5bd68"
-    default_dark["base0c"] = "#8abeb7"
-    default_dark["base0d"] = "#81a2be"
-    default_dark["base0e"] = "#b294bb"
-    default_dark["base0f"] = "#a3685a"
-    # Insert style
-    _insert_values(default_dark)
+    default_dark = Style(
+        "#1d1f21",  # base00
+        "#282a2e",  # base01
+        "#373b41",  # base02
+        "#969896",  # base03
+        "#b4b7b4",  # base04
+        "#c5c8c6",  # base05
+        "#e0e0e0",  # base06
+        "#ffffff",  # base07
+        "#cc6666",  # base08
+        "#de935f",  # base09
+        "#f0c674",  # base0a
+        "#b5bd68",  # base0b
+        "#8abeb7",  # base0c
+        "#81a2be",  # base0d
+        "#b294bb",  # base0e
+        "#a3685a",  # base0f
+    )
     # Dump
     if not os.path.isfile(xdg.join_vimiv_config("styles/default-dark")):
         dump("default-dark", default_dark)
     return default_dark
-
-
-def _insert_values(style):
-    """Insert all style values into a default style.
-
-    Args:
-        style: The Style object to insert values into.
-    """
-    # We are only storing all the values here
-    # pylint: disable=too-many-statements
-    # Image
-    style["image.bg"] = "{base00}"
-    style["image.scrollbar.width"] = "8px"
-    style["image.scrollbar.bg"] = "{image.bg}"
-    style["image.scrollbar.fg"] = "{base03}"
-    style["image.scrollbar.padding"] = "2px"
-    # Library
-    style["library.font"] = "10pt Monospace"
-    style["library.fg"] = "{base06}"
-    style["library.padding"] = "2px"
-    style["library.directory.fg"] = "{base07}"
-    style["library.even.bg"] = "{base01}"
-    style["library.odd.bg"] = "{base01}"
-    style["library.selected.bg"] = "{base0d}"
-    style["library.selected.fg"] = "{base07}"
-    style["library.search.highlighted.fg"] = "{base01}"
-    style["library.search.highlighted.bg"] = "{base04}"
-    style["library.scrollbar.width"] = "{image.scrollbar.width}"
-    style["library.scrollbar.bg"] = "{image.bg}"
-    style["library.scrollbar.fg"] = "{image.scrollbar.fg}"
-    style["library.scrollbar.padding"] = "{image.scrollbar.padding}"
-    style["library.border"] = "0px solid"
-    # Thumbnail
-    style["thumbnail.font"] = "{library.font}"
-    style["thumbnail.fg"] = "{library.fg}"
-    style["thumbnail.bg"] = "{image.bg}"
-    style["thumbnail.padding"] = "20"
-    style["thumbnail.selected.bg"] = "{library.selected.bg}"
-    style["thumbnail.search.highlighted.bg"] = "{library.search.highlighted.bg}"
-    style["thumbnail.default.bg"] = "{statusbar.info}"
-    style["thumbnail.error.bg"] = "{statusbar.error}"
-    style["thumbnail.frame.fg"] = "{thumbnail.fg}"
-    # Statusbar
-    style["statusbar.font"] = "10pt Monospace"
-    style["statusbar.bg"] = "{base02}"
-    style["statusbar.fg"] = "{base07}"
-    style["statusbar.error"] = "{base08}"
-    style["statusbar.warning"] = "{base09}"
-    style["statusbar.info"] = "{base0c}"
-    style["statusbar.message_border"] = "2px solid"
-    style["statusbar.padding"] = "4"
-    # Completion
-    style["completion.height"] = "16em"
-    style["completion.fg"] = "{statusbar.fg}"
-    style["completion.even.bg"] = "{statusbar.bg}"
-    style["completion.odd.bg"] = "{statusbar.bg}"
-    style["completion.selected.fg"] = "{library.selected.fg}"
-    style["completion.selected.bg"] = "{library.selected.bg}"
-    style["completion.scrollbar.width"] = "{image.scrollbar.width}"
-    style["completion.scrollbar.bg"] = "{image.scrollbar.bg}"
-    style["completion.scrollbar.fg"] = "{image.scrollbar.fg}"
-    style["completion.scrollbar.padding"] = "{image.scrollbar.padding}"
-    # Keyhint
-    style["keyhint.padding"] = "2px"
-    style["keyhint.border_radius"] = "10px"
-    style["keyhint.suffix_color"] = "{base0c}"
-    # Manipulate
-    style["manipulate.fg"] = "{statusbar.fg}"
-    style["manipulate.focused.fg"] = "{base0c}"
-    style["manipulate.bg"] = "{image.bg}"
-    style["manipulate.slider.left"] = "{library.selected.bg}"
-    style["manipulate.slider.handle"] = "{base04}"
-    style["manipulate.slider.right"] = "{statusbar.bg}"
-    # Manipulate image overlay
-    style["manipulate.image.border"] = "2px solid"
-    style["manipulate.image.border.color"] = "{base0c}"
-    # Mark
-    style["mark.color"] = "{base0e}"
 
 
 def read(filename):
@@ -232,7 +234,10 @@ def read(filename):
     """
     parser = configparser.ConfigParser()
     parser.read(filename)
-    style = Style()
+    # Retrieve base colors
+    colors = [parser["STYLE"].pop(f"base{i:02x}") for i in range(16)]
+    style = Style(*colors)
+    # Override additional options
     for option, value in parser["STYLE"].items():
         style[option] = value
     return style


### PR DESCRIPTION
This makes it easier to create custom styles and keeping them up-to-date as:

* All styles are now based on base16, the 16 style colors is the only thing that custom styles **MUST** supply

And therefore:

* The custom styles do **NOT** have to supply **ALL** of the style options but can focus on the base colors
* Can provide additional customization for specific options
* Don't break with newly introduced style options