### PR TITLE
Add command to show image exif metadata

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,9 @@ Added:
 
 * A global ``font`` style option to set all fonts at once. If a local option such as
   ``statusbar.font`` is defined, it overrides the global option.
+* New widget to display image metadata with the ``:metadata`` command bound to ``i`` in
+  image mode by default. It comes with the style options ``metadata.bg``,
+  ``metadata.padding`` and ``metadata.border_radius``.
 
 Changed:
 ^^^^^^^^

--- a/tests/end2end/features/image/metadata.feature
+++ b/tests/end2end/features/image/metadata.feature
@@ -1,0 +1,12 @@
+Feature: Metadata widget displaying image exif information
+
+    Scenario: Show metadata widget
+        Given I open any image
+        When I run metadata
+        Then the metadata widget should be visible
+
+    Scenario: Toggle metadata widget
+        Given I open any image
+        When I run metadata
+        And I run metadata
+        Then the metadata widget should not be visible

--- a/tests/end2end/features/image/test_metadata_bdd.py
+++ b/tests/end2end/features/image/test_metadata_bdd.py
@@ -1,0 +1,29 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2019 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+import pytest
+import pytest_bdd as bdd
+
+from vimiv import api
+from vimiv.gui import metadata_widget
+
+
+bdd.scenarios("metadata.feature")
+
+
+@pytest.fixture
+def metadata():
+    yield api.objreg.get(metadata_widget.MetadataWidget)
+
+
+@bdd.then("the metadata widget should be visible")
+def check_metadata_widget_visible(metadata):
+    assert metadata.isVisible()
+
+
+@bdd.then("the metadata widget should not be visible")
+def check_metadata_widget_not_visible(metadata):
+    assert not metadata.isVisible()

--- a/vimiv/config/styles.py
+++ b/vimiv/config/styles.py
@@ -119,6 +119,10 @@ class Style(dict):
         self["manipulate.image.border.color"] = "{base0c}"
         # Mark
         self["mark.color"] = "{base0e}"
+        # Metadata overlay
+        self["metadata.bg"] = self["{statusbar.bg}"].replace("#", "#AA")  # Add alpha
+        self["metadata.padding"] = "{keyhint.padding}"
+        self["metadata.border_radius"] = "{keyhint.border_radius}"
 
     def __setitem__(self, name, item):
         """Store item automatically surrounding the name with {} if needed."""

--- a/vimiv/gui/mainwindow.py
+++ b/vimiv/gui/mainwindow.py
@@ -24,6 +24,7 @@ from .library import Library
 from .manipulate import Manipulate, ManipulateImage
 from .thumbnail import ThumbnailView
 from .version_popup import VersionPopUp
+from .metadata_widget import MetadataWidget
 
 
 class MainWindow(QWidget):
@@ -60,6 +61,7 @@ class MainWindow(QWidget):
         compwidget = CompletionView(self)
         self._overlays.append(compwidget)
         self._overlays.append(KeyhintWidget(self))
+        self._overlays.append(MetadataWidget(self))
         grid.addWidget(self._bar, 1, 0, 1, 2)
         # Initialize completer and config commands
         completer.Completer(commandline, compwidget)

--- a/vimiv/gui/mainwindow.py
+++ b/vimiv/gui/mainwindow.py
@@ -61,7 +61,8 @@ class MainWindow(QWidget):
         compwidget = CompletionView(self)
         self._overlays.append(compwidget)
         self._overlays.append(KeyhintWidget(self))
-        self._overlays.append(MetadataWidget(self))
+        if MetadataWidget is not None:  # Not defined if there is no exif support
+            self._overlays.append(MetadataWidget(self))
         grid.addWidget(self._bar, 1, 0, 1, 2)
         # Initialize completer and config commands
         completer.Completer(commandline, compwidget)

--- a/vimiv/gui/metadata_widget.py
+++ b/vimiv/gui/metadata_widget.py
@@ -1,0 +1,109 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2019 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+"""Overlay widget to display image metadata."""
+
+import logging
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QLabel, QSizePolicy
+
+from vimiv import api, utils
+from vimiv.imutils import exif
+from vimiv.config import styles
+
+
+class MetadataWidget(QLabel):
+    """Overlay widget to display image metadata.
+
+    The display of the widget can be toggled by command. It is filled with exif metadata
+    information of the current image.
+
+
+    Attributes:
+        _mainwindow_bottom: y-coordinate of the bottom of the mainwindow.
+        _mainwindow_width: width of the mainwindow.
+        _path: Absolute path of the current image to load exif metadata of.
+        _loaded: True if metadata has been loaded for the current image.
+    """
+
+    STYLESHEET = """
+    QLabel {
+        font: {statusbar.font};
+        color: {statusbar.fg};
+        background: {metadata.bg};
+        padding: {metadata.padding};
+        border-top-left-radius: {metadata.border_radius};
+    }
+    """
+
+    @api.objreg.register
+    def __init__(self, parent):
+        super().__init__(parent=parent)
+        styles.apply(self)
+
+        self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Minimum)
+        self.setTextFormat(Qt.RichText)
+
+        self._mainwindow_bottom = 0
+        self._mainwindow_width = 0
+        self._path = ""
+        self._loaded = False
+
+        api.signals.new_image_opened.connect(self._on_image_opened)
+
+        self.hide()
+
+    @api.keybindings.register("i", "metadata", mode=api.modes.IMAGE)
+    @api.commands.register(mode=api.modes.IMAGE)
+    @exif.check_piexif()
+    def metadata(self):
+        """Toggle display of metadata of current image."""
+        if self.isVisible():
+            self.hide()
+        else:
+            self._update_text()
+            self.raise_()
+            self.show()
+
+    def update_geometry(self, window_width, window_bottom):
+        """Adapt location when main window geometry changes."""
+        self._mainwindow_width = window_width
+        self._mainwindow_bottom = window_bottom
+        self._update_geometry()
+
+    def _update_geometry(self):
+        """Update geometry according to current text content and window location."""
+        self.adjustSize()
+        y = self._mainwindow_bottom - self.height()
+        self.setGeometry(
+            self._mainwindow_width - self.width(), y, self.width(), self.height()
+        )
+
+    def _update_text(self):
+        """Update the metadata text if the current image has not been loaded."""
+        if self._loaded:
+            return
+        logging.debug("%s: reading exif of %s", self.__class__.__qualname__, self._path)
+        text = ""
+        for tag, content in exif.ExifInformation(self._path).items():
+            text += (
+                "<tr>"
+                f"<td>{tag}</td>"
+                f"<td style='padding-left: 2ex'>{content}</td>"
+                "</tr>"
+            )
+        self.setText(f"<table>{text}</table>")
+        self._update_geometry()
+        self._loaded = True
+
+    @utils.slot
+    def _on_image_opened(self, path: str):
+        """Load new image and update text if the widget is currently visible."""
+        self._path = path
+        self._loaded = False
+        if self.isVisible():
+            self._update_text()

--- a/vimiv/gui/metadata_widget.py
+++ b/vimiv/gui/metadata_widget.py
@@ -16,94 +16,101 @@ from vimiv.imutils import exif
 from vimiv.config import styles
 
 
-class MetadataWidget(QLabel):
-    """Overlay widget to display image metadata.
+if exif.piexif is not None:
 
-    The display of the widget can be toggled by command. It is filled with exif metadata
-    information of the current image.
+    class MetadataWidget(QLabel):
+        """Overlay widget to display image metadata.
+
+        The display of the widget can be toggled by command. It is filled with exif
+        metadata information of the current image.
 
 
-    Attributes:
-        _mainwindow_bottom: y-coordinate of the bottom of the mainwindow.
-        _mainwindow_width: width of the mainwindow.
-        _path: Absolute path of the current image to load exif metadata of.
-        _loaded: True if metadata has been loaded for the current image.
-    """
+        Attributes:
+            _mainwindow_bottom: y-coordinate of the bottom of the mainwindow.
+            _mainwindow_width: width of the mainwindow.
+            _path: Absolute path of the current image to load exif metadata of.
+            _loaded: True if metadata has been loaded for the current image.
+        """
 
-    STYLESHEET = """
-    QLabel {
-        font: {statusbar.font};
-        color: {statusbar.fg};
-        background: {metadata.bg};
-        padding: {metadata.padding};
-        border-top-left-radius: {metadata.border_radius};
-    }
-    """
+        STYLESHEET = """
+        QLabel {
+            font: {statusbar.font};
+            color: {statusbar.fg};
+            background: {metadata.bg};
+            padding: {metadata.padding};
+            border-top-left-radius: {metadata.border_radius};
+        }
+        """
 
-    @api.objreg.register
-    def __init__(self, parent):
-        super().__init__(parent=parent)
-        styles.apply(self)
+        @api.objreg.register
+        def __init__(self, parent):
+            super().__init__(parent=parent)
+            styles.apply(self)
 
-        self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Minimum)
-        self.setTextFormat(Qt.RichText)
+            self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Minimum)
+            self.setTextFormat(Qt.RichText)
 
-        self._mainwindow_bottom = 0
-        self._mainwindow_width = 0
-        self._path = ""
-        self._loaded = False
+            self._mainwindow_bottom = 0
+            self._mainwindow_width = 0
+            self._path = ""
+            self._loaded = False
 
-        api.signals.new_image_opened.connect(self._on_image_opened)
+            api.signals.new_image_opened.connect(self._on_image_opened)
 
-        self.hide()
-
-    @api.keybindings.register("i", "metadata", mode=api.modes.IMAGE)
-    @api.commands.register(mode=api.modes.IMAGE)
-    @exif.check_piexif()
-    def metadata(self):
-        """Toggle display of metadata of current image."""
-        if self.isVisible():
             self.hide()
-        else:
-            self._update_text()
-            self.raise_()
-            self.show()
 
-    def update_geometry(self, window_width, window_bottom):
-        """Adapt location when main window geometry changes."""
-        self._mainwindow_width = window_width
-        self._mainwindow_bottom = window_bottom
-        self._update_geometry()
+        @api.keybindings.register("i", "metadata", mode=api.modes.IMAGE)
+        @api.commands.register(mode=api.modes.IMAGE)
+        def metadata(self):
+            """Toggle display of exif metadata of current image."""
+            if self.isVisible():
+                self.hide()
+            else:
+                self._update_text()
+                self.raise_()
+                self.show()
 
-    def _update_geometry(self):
-        """Update geometry according to current text content and window location."""
-        self.adjustSize()
-        y = self._mainwindow_bottom - self.height()
-        self.setGeometry(
-            self._mainwindow_width - self.width(), y, self.width(), self.height()
-        )
+        def update_geometry(self, window_width, window_bottom):
+            """Adapt location when main window geometry changes."""
+            self._mainwindow_width = window_width
+            self._mainwindow_bottom = window_bottom
+            self._update_geometry()
 
-    def _update_text(self):
-        """Update the metadata text if the current image has not been loaded."""
-        if self._loaded:
-            return
-        logging.debug("%s: reading exif of %s", self.__class__.__qualname__, self._path)
-        text = ""
-        for tag, content in exif.ExifInformation(self._path).items():
-            text += (
-                "<tr>"
-                f"<td>{tag}</td>"
-                f"<td style='padding-left: 2ex'>{content}</td>"
-                "</tr>"
+        def _update_geometry(self):
+            """Update geometry according to current text content and window location."""
+            self.adjustSize()
+            y = self._mainwindow_bottom - self.height()
+            self.setGeometry(
+                self._mainwindow_width - self.width(), y, self.width(), self.height()
             )
-        self.setText(f"<table>{text}</table>")
-        self._update_geometry()
-        self._loaded = True
 
-    @utils.slot
-    def _on_image_opened(self, path: str):
-        """Load new image and update text if the widget is currently visible."""
-        self._path = path
-        self._loaded = False
-        if self.isVisible():
-            self._update_text()
+        def _update_text(self):
+            """Update the metadata text if the current image has not been loaded."""
+            if self._loaded:
+                return
+            logging.debug(
+                "%s: reading exif of %s", self.__class__.__qualname__, self._path
+            )
+            text = ""
+            for tag, content in exif.ExifInformation(self._path).items():
+                text += (
+                    "<tr>"
+                    f"<td>{tag}</td>"
+                    f"<td style='padding-left: 2ex'>{content}</td>"
+                    "</tr>"
+                )
+            self.setText(f"<table>{text}</table>")
+            self._update_geometry()
+            self._loaded = True
+
+        @utils.slot
+        def _on_image_opened(self, path: str):
+            """Load new image and update text if the widget is currently visible."""
+            self._path = path
+            self._loaded = False
+            if self.isVisible():
+                self._update_text()
+
+
+else:  # No exif support
+    MetadataWidget = None  # type: ignore


### PR DESCRIPTION
This adds:

* The `:metadata` command which toggles an overlay widget in image mode showing basic exif information
* A new keybinding `i` in image mode bound to the `:metadata` command

The information displayed in the widget is still very basic and can be extend in further commits. For this a new issue will be opened.

fixes #17 