### PR TITLE
Tag name completion for :tag-* commands

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ Added:
 * New widget to display image metadata with the ``:metadata`` command bound to ``i`` in
   image mode by default. It comes with the style options ``metadata.bg``,
   ``metadata.padding`` and ``metadata.border_radius``.
+* Completion of tag names for the ``:tag-*`` commands.
 
 Changed:
 ^^^^^^^^

--- a/tests/end2end/features/completion/completion.feature
+++ b/tests/end2end/features/completion/completion.feature
@@ -32,6 +32,21 @@ Feature: Using completion.
         When I enter command mode with "undelete "
         Then the completion model should be trash
 
+    Scenario: Using tag completion with tag-delete.
+        Given I open any directory
+        When I enter command mode with "tag-delete "
+        Then the completion model should be tag
+
+    Scenario: Using tag completion with tag-load.
+        Given I open any directory
+        When I enter command mode with "tag-load "
+        Then the completion model should be tag
+
+    Scenario: Using tag completion with tag-write.
+        Given I open any directory
+        When I enter command mode with "tag-write "
+        Then the completion model should be tag
+
     Scenario: Crash on path completion with non-existent directory
         Given I open any directory
         When I enter command mode with "open /not/a/valid/path"
@@ -97,3 +112,11 @@ Feature: Using completion.
         When I enter manipulate mode
         And I enter command mode with "undelete "
         Then the completion model should be command
+
+    Scenario: Complete an existing tag
+        Given I start vimiv
+        When I run tag-write my_tag_name
+        And I enter command mode with "tag-load "
+        Then the completion model should be tag
+        And there should be 1 completion options
+        And a possible completion should contain my_tag_name

--- a/tests/end2end/features/completion/test_completion_bdd.py
+++ b/tests/end2end/features/completion/test_completion_bdd.py
@@ -24,6 +24,7 @@ def check_completion_model(model):
         "settings": completionmodels.SettingsModel,
         "settings_option": completionmodels.SettingsOptionModel,
         "trash": completionmodels.TrashModel,
+        "tag": completionmodels.TagModel,
     }
     assert isinstance(completer.instance()._proxy_model.sourceModel(), models[model])
 

--- a/tests/unit/utils/test_files.py
+++ b/tests/unit/utils/test_files.py
@@ -99,3 +99,19 @@ def test_get_size_directory_with_images(mocker):
 def test_get_size_with_permission_error(mocker):
     mocker.patch("os.path.isfile", side_effect=PermissionError)
     assert files.get_size("any") == "N/A"
+
+
+def test_listfiles(tmpdir):
+    tmpdir.join("file0").open("w")  # File in root directory
+    sub0 = tmpdir.mkdir("sub0")  # Sub-directory with two files
+    sub0.join("file0").open("w")
+    sub0.join("file1").open("w")
+    tmpdir.mkdir("sub1").join("file0").open("w")  # Sub-directory with one file
+    tmpdir.mkdir("sub2")  # Sub-directory with no files
+    expected = [
+        "file0",
+        os.path.join("sub0", "file0"),
+        os.path.join("sub0", "file1"),
+        os.path.join("sub1", "file0"),
+    ]
+    assert sorted(expected) == sorted(files.listfiles(str(tmpdir)))

--- a/vimiv/api/_mark.py
+++ b/vimiv/api/_mark.py
@@ -43,6 +43,11 @@ class Mark(QObject):
         self._last_marked: List[str] = []
         self._watcher = cast(QFileSystemWatcher, None)
 
+    @property
+    def tagdir(self) -> str:
+        """Path to the tag directory."""
+        return Tag.dirname()
+
     @keybindings.register("m", "mark %")
     @commands.register()
     def mark(self, paths: List[str]) -> None:

--- a/vimiv/utils/files.py
+++ b/vimiv/utils/files.py
@@ -115,6 +115,22 @@ def is_image(filename: str) -> bool:
         return False
 
 
+def listfiles(directory: str, abspath=False) -> List[str]:
+    """Return list of all files in directory traversing the directory recursively.
+
+    Args:
+        directory: The directory to traverse.
+        abspath: Return the absolute path to the files, not relative to directory.
+    """
+    return [
+        os.path.join(root, fname)
+        if abspath
+        else os.path.join(root.replace(directory, "").lstrip("/"), fname)
+        for root, _, files in os.walk(directory)
+        for fname in files
+    ]
+
+
 # Only add svg check to imghdr if svg available
 if QSvgWidget is not None:
 


### PR DESCRIPTION
This implements tag name completion for the ``:tag-delete``, ``tag-load`` and ``tag-write`` commands.