### PR TITLE
Command chaining

### DIFF
--- a/tests/end2end/features/command/chaining.feature
+++ b/tests/end2end/features/command/chaining.feature
@@ -46,5 +46,6 @@ Feature: Chain commands together.
 
     Scenario: Run a chain of aliases where each alias consists of a chain of commands
         When I run alias double_trouble scroll down \&\& scroll down
-        And I run double_trouble && double_trouble
-        Then the library row should be 5
+        And I run alias reverse_double_trouble scroll up \&\& scroll up
+        And I run double_trouble && double_trouble && reverse_double_trouble
+        Then the library row should be 3

--- a/tests/end2end/features/command/chaining.feature
+++ b/tests/end2end/features/command/chaining.feature
@@ -11,6 +11,10 @@ Feature: Chain commands together.
         When I run scroll down && scroll down && scroll down
         Then the library row should be 4
 
+    Scenario: Chain commands with count together.
+        When I run 2scroll down && scroll down
+        Then the library row should be 4
+
     Scenario: Fail first of two chained commands
         When I run something wrong && scroll down
         Then the library row should be 1

--- a/tests/end2end/features/command/chaining.feature
+++ b/tests/end2end/features/command/chaining.feature
@@ -1,0 +1,33 @@
+Feature: Chain commands together.
+
+    Background:
+        Given I open a directory with 5 paths
+
+    Scenario: Chain two commands together.
+        When I run scroll down && scroll down
+        Then the library row should be 3
+
+    Scenario: Chain three commands together.
+        When I run scroll down && scroll down && scroll down
+        Then the library row should be 4
+
+    Scenario: Fail first of two chained commands
+        When I run something wrong && scroll down
+        Then the library row should be 1
+        And the message
+            'something: unknown command for mode library'
+            should be displayed
+
+    Scenario: Fail second of two chained commands
+        When I run scroll down && something wrong
+        Then the library row should be 2
+        And the message
+            'something: unknown command for mode library'
+            should be displayed
+
+    Scenario: Fail second of three chained commands
+        When I run scroll down && something wrong && scroll down
+        Then the library row should be 2
+        And the message
+            'something: unknown command for mode library'
+            should be displayed

--- a/tests/end2end/features/command/chaining.feature
+++ b/tests/end2end/features/command/chaining.feature
@@ -31,3 +31,16 @@ Feature: Chain commands together.
         And the message
             'something: unknown command for mode library'
             should be displayed
+
+    Scenario: Run an alias of chained commands
+        When I run alias double_trouble scroll down \&\& scroll down
+        And I run double_trouble
+        # Run twice as running once also works if the alias is only aliased to scroll
+        # down and the first scroll down is executed right after the alias command
+        And I run double_trouble
+        Then the library row should be 5
+
+    Scenario: Run a chain of aliases where each alias consists of a chain of commands
+        When I run alias double_trouble scroll down \&\& scroll down
+        And I run double_trouble && double_trouble
+        Then the library row should be 5

--- a/tests/end2end/features/command/test_chaining_bdd.py
+++ b/tests/end2end/features/command/test_chaining_bdd.py
@@ -1,0 +1,10 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2019 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+import pytest_bdd as bdd
+
+
+bdd.scenarios("chaining.feature")

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -105,6 +105,23 @@ def test_flatten():
     assert utils.flatten(list_of_lists) == [1, 2, 3, 4]
 
 
+def test_recursive_split():
+    def updater(text):
+        """Return a text containing two numbers decremented by one, break at 0.
+
+        This results in doubling the number of numbers in every iteration and
+        decrementing all numbers by one. Eventually 2**(N - 1) zeros are left.
+        """
+        number = int(text) - 1
+        if number > 0:
+            return f"{number}.{number}"
+        return "0"
+
+    for number in range(1, 6):
+        expected = ["0"] * 2 ** (number - 1)
+        assert utils.recursive_split(str(number), ".", updater) == expected
+
+
 def test_remove_prefix():
     assert utils.remove_prefix("start hello", "start") == " hello"
 

--- a/vimiv/commands/aliases.py
+++ b/vimiv/commands/aliases.py
@@ -26,6 +26,7 @@ class Aliases(collections.UserDict):
         # Add defaults
         self[api.modes.GLOBAL]["q"] = "quit"
         self[api.modes.IMAGE]["w"] = "write"
+        self[api.modes.IMAGE]["wq"] = "write && quit"
 
     def get(self, mode):
         """Return all aliases for one mode."""

--- a/vimiv/utils/__init__.py
+++ b/vimiv/utils/__init__.py
@@ -175,6 +175,21 @@ def flatten(list_of_lists: List[List[Any]]) -> List[Any]:
     return [elem for sublist in list_of_lists for elem in sublist]
 
 
+def recursive_split(
+    text: str, separator: str, updater: Callable[[str], str]
+) -> List[str]:
+    """Recursively split a string at separator applying an update callable.
+
+    The string is split into parts and the update callable is applied to each part. The
+    function is then called again on the updated text until no more separators remain.
+    """
+    splits = updater(text).split(separator)
+    if len(splits) == 1:  # Updater did not add any new separators
+        return splits
+    nested = [recursive_split(part, separator, updater) for part in splits]
+    return flatten(nested)
+
+
 def remove_prefix(text: str, prefix: str) -> str:
     """Remove a prefix of a given string."""
     if text.startswith(prefix):


### PR DESCRIPTION
This allows chaining multiple commands using ``&&``.

Useful examples:
```
# Write the current image to disk and quit, aliased to wq
:write && quit
# In case the statusbar is usually visible, this hides the statusbar for fullscreen mode
:fullscreen && set statusbar.show!
```

Aliasing to chained commands is possible even recursively. Unfortunately the alias ``tag-open`` is still not very useful as the remaining argument, namely the tag NAME, would require to be in the middle of the alias (``tag-load NAME && open %m``) which is not supported by simple aliases.

fixes #73 