### PR TITLE
Tasks for non-GUI blocking function calls

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,11 @@ Added:
 
 * Elements in library and thumbnail can be selected with a mouse double click.
 
+Fixed:
+^^^^^^
+
+* The UI no longer blocks when processing working directory changes.
+
 
 v0.2.0 (2019-10-01)
 -------------------

--- a/tests/unit/utils/test_task.py
+++ b/tests/unit/utils/test_task.py
@@ -1,0 +1,110 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2019 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+"""Unit tests for vimiv.utils.task."""
+
+import functools
+import time
+from multiprocessing import Pool
+from multiprocessing.pool import ThreadPool
+
+import pytest
+
+from vimiv.utils import task
+
+
+def test_retrieve_from_task_func(qtbot):
+    """Ensure the async function returns the value back to the generator."""
+    expected = 42
+
+    def helper():
+        return expected
+
+    @task.register()
+    def local_task():
+        value = yield task.func(helper)
+        assert value == expected
+
+    local_task()
+
+
+def test_retrieve_multiple_from_task_func(qtbot):
+    """Ensure the async function returns multiple values back to the generator."""
+    expected = 42
+    n_yields = 5
+
+    def helper(i):
+        return i * expected
+
+    expected_values = [i * expected for i in range(n_yields)]
+    values = []
+
+    @task.register()
+    def local_task():
+        for i in range(n_yields):
+            value = yield task.func(helper, i)
+            values.append(value)
+
+    local_task()
+    assert values == expected_values
+
+
+def test_fail_wrapping_non_generator():
+    """Ensure wrapping a function that is not a generator fails."""
+
+    @task.register()
+    def anything():
+        """Function that is not a generator."""
+
+    with pytest.raises(TypeError, match="must wrap a generator"):
+        anything()
+
+
+def test_task_sleep(qtbot):
+    """Ensure async sleep takes as long as expected in the task."""
+
+    @task.register()
+    def local_task():
+        start = time.time()
+        duration = 0.001
+        yield task.sleep(duration)
+        elapsed = time.time() - start
+        assert elapsed >= duration
+
+    local_task()
+
+
+@pytest.mark.parametrize("n_calls", (1, 16))
+@pytest.mark.flaky
+def test_call_single_task_once(qtbot, n_calls):
+    """Ensure single type tasks only continue for the last scheduled task."""
+    repeat_task(n_calls, single=True)
+
+
+@pytest.mark.parametrize("n_calls", (1, 16))
+@pytest.mark.flaky
+def test_call_task_multiple(qtbot, n_calls):
+    """Ensure multiple type tasks continue for all scheduled tasks."""
+    repeat_task(n_calls, single=False)
+
+
+def repeat_task(n_times, single=False):
+    """Helper function to repeat a task n_times."""
+    sleep_duration = 0.001
+    future_timeout = sleep_duration / 10
+    calls = []
+
+    @task.register(single=single)
+    def local_task(number):
+        yield task.sleep(sleep_duration, future_timeout=future_timeout)
+        calls.append(number)
+
+    with ThreadPool(n_times) as pool:
+        pool.map(local_task, range(n_times))
+
+    # Only the last call for single mode, all of them otherwise
+    expected = [n_times - 1] if single else list(range(n_times))
+    assert sorted(calls) == expected, f"Error for single={single}"

--- a/vimiv/utils/task.py
+++ b/vimiv/utils/task.py
@@ -1,0 +1,119 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2019 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+"""Utilities to convert functions to tasks which can call non-GUI-blocking functions."""
+
+import time
+import types
+from concurrent import futures
+from contextlib import suppress
+from functools import wraps
+
+from PyQt5.QtCore import QCoreApplication, QEventLoop
+
+
+def register(single=False):
+    """Decorator to convert function into task that can call non-GUI-blocking functions.
+
+    Usage:
+        >>> @task.register()
+        >>> def my_function():
+        >>>     ...
+        >>>     result = yield task.func(other_function, arg, kwarg=kwarg)
+        >>>     ...
+
+    Args:
+        single: Only send the last non-blocking function result back to the generator.
+    """
+
+    def decorator(wrapped_func):
+        wrapped_func.call_id = 0
+
+        def advance(generator, local_id=None):
+            if not isinstance(generator, types.GeneratorType):
+                raise TypeError("task must wrap a generator")
+            with suppress(StopIteration):
+                result = next(generator)
+                while True:
+                    if local_id is not None and local_id != wrapped_func.call_id:
+                        return
+                    result = generator.send(result)
+
+        @wraps(wrapped_func)
+        def inner_all(*args, **kwargs):
+            generator = wrapped_func(*args, **kwargs)
+            advance(generator)
+
+        @wraps(wrapped_func)
+        def inner_single(*args, **kwargs):
+            generator = wrapped_func(*args, **kwargs)
+            wrapped_func.call_id += 1
+            advance(generator, wrapped_func.call_id)
+
+        if single:
+            return inner_single
+        return inner_all
+
+    return decorator
+
+
+def func(
+    function,
+    *args,
+    executor_class=futures.ThreadPoolExecutor,
+    future_timeout=0.01,
+    **kwargs,
+):
+    """Non-GUI-blocking function call.
+
+    Can be used by functions decorated with the :func:``register`` decorator to turn a
+    regular function call into a non-GUI-blocking one.
+
+    Usage:
+        >>> # Regular call
+        >>> result = myfunc(arg, kwarg=kwarg)
+        >>> # Non-blocking call
+        >>> result = yield task.func(myfunc, arg, kwarg=kwarg)
+
+    Args:
+        function: The blocking function converted into a non-block one.
+        *args: Any arguments passed to the function.
+        executor_class: Executor from futures module to use for async functionality.
+        future_timeout: Time to wait for the function before giving control to the GUI.
+        **kwargs: Any keyword arguments passed to the function.
+    """
+    with executor_class() as executor:
+        future = executor.submit(function, *args, **kwargs)
+        while True:
+            try:
+                result = future.result(future_timeout)
+            except futures.TimeoutError:
+                advance_gui(future_timeout)
+            else:
+                return result
+
+
+def sleep(duration, executor_class=futures.ThreadPoolExecutor, future_timeout=0.01):
+    """Non-GUI blocking sleep.
+
+    See :func:``func`` for implementation details.
+
+    Args:
+        duration: The number of seconds to sleep.
+        executor_class: Executor from futures module to use for async functionality.
+        future_timeout: Time to wait for the function before giving control to the GUI.
+    """
+    func(
+        time.sleep,
+        duration,
+        executor_class=executor_class,
+        future_timeout=future_timeout,
+    )
+
+
+def advance_gui(maxtime):
+    """Advance the Qt main loop for maxtime seconds."""
+    QCoreApplication.instance().processEvents(QEventLoop.AllEvents, maxtime)


### PR DESCRIPTION
The new `utils.task` module allows turning functions into tasks which can call non-GUI blocking functions. First use-case of this is to no longer block the GUI when processing working directory changes. Can be useful for further IO bound options.