### PR TITLE
Add python3.8 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: python
 
 matrix:
   include:
+    # Python 3.6
     - python: 3.6
       env: TOXENV=py36-pyqt59
     - python: 3.6
@@ -22,6 +23,8 @@ matrix:
         apt:
           packages:
           - libxkbcommon-x11-0
+
+    # Python 3.7
     - python: 3.7
       env: TOXENV=py37-pyqt59
     - python: 3.7
@@ -54,6 +57,16 @@ matrix:
     - python: 3.7
       env: TOXENV=packaging
     - python: 3.7
+      env: TOXENV=mypy
+
+    # Python 3.8
+    - python: 3.8-dev
+      env: TOXENV=py38-pyqt513
+      addons:
+        apt:
+          packages:
+          - libxkbcommon-x11-0
+    - python: 3.8-dev
       env: TOXENV=mypy
 
 install:

--- a/tests/end2end/features/conftest.py
+++ b/tests/end2end/features/conftest.py
@@ -132,7 +132,7 @@ def wait_for_working_directory_handler(qtbot):
 @bdd.then("no crash should happen")
 def no_crash(qtbot):
     """Don't do anything, exceptions fail the test anyway."""
-    qtbot.wait(0.01)
+    qtbot.wait(1)
 
 
 @bdd.then(bdd.parsers.parse("the message\n'{message}'\nshould be displayed"))


### PR DESCRIPTION
Adds python3.8 to the standard travis CI and fixes a trivial integer conversion warning.