### PR TITLE
Add keybindings command

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,9 @@ Added:
 * Library and thumbnail selection color is dimmed when the corresponding widget is not
   focused. It comes with the style options ``library.selected.bg.unfocus`` and
   ``thumbnail.selected.bg.unfocus``.
+* Pop-up window to show keybindings for current mode. It can be shown with the
+  ``:keybindings`` command and comes with the style options
+  ``keybindings.bindings.color`` and ``keybindings.highlight.color``.
 
 Changed:
 ^^^^^^^^

--- a/docs/documentation/getting_started.rst
+++ b/docs/documentation/getting_started.rst
@@ -11,7 +11,7 @@ Vimiv is, as one would expect from an application with vim-like keybindings,
 completely keyboard driven. To get you started some of the most important
 keybindings for controlling vimiv are explained below. For a complete list of
 them take a look at the ``keys.conf`` file which is generated upon startup in
-``$XDG_CONFIG_HOME/vimiv/``.
+``$XDG_CONFIG_HOME/vimiv/`` or open the keybindings pop-up by running ``:keybindings``.
 
 Basics
 ------

--- a/tests/end2end/features/misc/keybindings_popup.feature
+++ b/tests/end2end/features/misc/keybindings_popup.feature
@@ -1,0 +1,33 @@
+Feature: Keybindings command with pop up window with the keybindings for current mode
+
+    Scenario: Display the keybindings pop up for library mode.
+        Given I start vimiv
+        When I run keybindings
+        Then the keybindings pop up should contain 'set library.width'
+        And the pop up 'vimiv - keybindings' should be displayed
+
+    Scenario: Display the keybindings pop up for image mode.
+        Given I open 2 images
+        When I run keybindings
+        Then the keybindings pop up should contain 'flip'
+        And the pop up 'vimiv - keybindings' should be displayed
+
+    Scenario: Display the keybindings pop up for thumbnail mode.
+        Given I open 2 images
+        When I enter thumbnail mode
+        And I run keybindings
+        Then the keybindings pop up should contain 'zoom in'
+        And the pop up 'vimiv - keybindings' should be displayed
+
+    Scenario: Display the keybindings pop up for manipulate mode.
+        Given I open 2 images
+        When I enter manipulate mode
+        And I run keybindings
+        Then the keybindings pop up should contain 'accept'
+        And the pop up 'vimiv - keybindings' should be displayed
+
+    Scenario: Search the keybindins pop up
+        Given I start vimiv
+        When I run keybindings
+        And I type 'comm' in the pop up
+        Then 'comm' should be highlighted in 'command'

--- a/tests/end2end/features/misc/keybindings_popup.feature
+++ b/tests/end2end/features/misc/keybindings_popup.feature
@@ -31,3 +31,10 @@ Feature: Keybindings command with pop up window with the keybindings for current
         When I run keybindings
         And I type 'comm' in the pop up
         Then 'comm' should be highlighted in 'command'
+        Then the keybindings pop up should describe 'command'
+
+    Scenario: Do not describe single command matches
+        Given I start vimiv
+        When I run keybindings
+        And I type 'a' in the pop up
+        Then the keybindings pop up description should be empty

--- a/tests/end2end/features/misc/test_keybindings_popup_bdd.py
+++ b/tests/end2end/features/misc/test_keybindings_popup_bdd.py
@@ -1,0 +1,41 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2019 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+import pytest
+import pytest_bdd as bdd
+
+import vimiv.gui.keybindings_popup
+from vimiv import utils
+
+bdd.scenarios("keybindings_popup.feature")
+
+
+@pytest.fixture()
+def keybindings_popup(mainwindow):
+    """Fixture to retrieve the current keybindings pop-up."""
+    for widget in mainwindow.children():
+        if isinstance(widget, vimiv.gui.keybindings_popup.KeybindingsPopUp):
+            return widget
+    raise AssertionError("No keybindings pop-up open")
+
+
+@bdd.when(bdd.parsers.parse("I type '{keys}' in the pop up"))
+def press_keys_popup(keybindings_popup, qtbot, keys):
+    qtbot.keyClicks(keybindings_popup._search, keys)
+
+
+@bdd.then(bdd.parsers.parse("the keybindings pop up should contain '{text}'"))
+def check_keybindings_popup_text(keybindings_popup, text):
+    assert text in keybindings_popup.text
+
+
+@bdd.then(bdd.parsers.parse("'{search}' should be highlighted in '{command}'"))
+def check_keybindings_popup_highlighting(keybindings_popup, search, command):
+    highlight = keybindings_popup.highlighted_search_str(search)
+    # Ensure the search_str is the actual highlighted string
+    assert utils.strip_html(highlight) == search
+    # Ensure the highlighted command is in the pop up text
+    assert command.replace(search, highlight) in keybindings_popup.text

--- a/tests/end2end/features/misc/test_keybindings_popup_bdd.py
+++ b/tests/end2end/features/misc/test_keybindings_popup_bdd.py
@@ -8,7 +8,7 @@ import pytest
 import pytest_bdd as bdd
 
 import vimiv.gui.keybindings_popup
-from vimiv import utils
+from vimiv import api, utils
 
 bdd.scenarios("keybindings_popup.feature")
 
@@ -30,6 +30,17 @@ def press_keys_popup(keybindings_popup, qtbot, keys):
 @bdd.then(bdd.parsers.parse("the keybindings pop up should contain '{text}'"))
 def check_keybindings_popup_text(keybindings_popup, text):
     assert text in keybindings_popup.text
+
+
+@bdd.then(bdd.parsers.parse("the keybindings pop up should describe '{command}'"))
+def check_keybindings_popup_description(keybindings_popup, command):
+    description = api.commands.get(command, api.modes.current()).description
+    assert description in keybindings_popup.description
+
+
+@bdd.then("the keybindings pop up description should be empty")
+def check_keybindings_popup_description_empty(keybindings_popup):
+    assert not keybindings_popup.description
 
 
 @bdd.then(bdd.parsers.parse("'{search}' should be highlighted in '{command}'"))

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -16,7 +16,11 @@ from vimiv import utils
 
 
 def test_add_html():
-    assert utils.add_html("b", "hello") == "<b>hello</b>"
+    assert utils.add_html("hello", "b") == "<b>hello</b>"
+
+
+def test_add_html_multiple():
+    assert utils.add_html("hello", "b", "i") == "<i><b>hello</b></i>"
 
 
 def test_strip_html():

--- a/vimiv/config/styles.py
+++ b/vimiv/config/styles.py
@@ -129,6 +129,9 @@ class Style(dict):
         self["manipulate.image.border.color"] = "{base0c}"
         # Mark
         self["mark.color"] = "{base0e}"
+        # Keybindings popup
+        self["keybindings.bindings.color"] = "{keyhint.suffix_color}"
+        self["keybindings.highlight.color"] = "{mark.color}"
         # Metadata overlay
         self["metadata.bg"] = self.add_alpha(self["{statusbar.bg}"], "AA")
         self["metadata.padding"] = "{keyhint.padding}"
@@ -150,7 +153,7 @@ class Style(dict):
     @staticmethod
     def is_color_option(name: str):
         """Return True if the style option name corresponds to a color."""
-        return name.strip("{}").endswith((".fg", ".bg"))
+        return name.strip("{}").endswith((".fg", ".bg", ".color"))
 
     @staticmethod
     def check_valid_color(color: str):

--- a/vimiv/gui/keybindings_popup.py
+++ b/vimiv/gui/keybindings_popup.py
@@ -121,7 +121,9 @@ class KeybindingsPopUp(PopUp):
 
     def highlighted_search_str(self, search: str) -> str:
         """Current search string wrapped in a highlight color span."""
-        return utils.wrap_style_span(f"color: {self._highlight_color}", search)
+        return utils.add_html(
+            utils.wrap_style_span(f"color: {self._highlight_color}", search), "b", "u"
+        )
 
     def _update_text(self, search: str = None) -> None:
         """Update keybinding-command text for all columns.

--- a/vimiv/gui/keybindings_popup.py
+++ b/vimiv/gui/keybindings_popup.py
@@ -1,0 +1,141 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2019 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+"""Pop-up window to display keybindings of current mode."""
+
+from typing import List, Tuple, Iterator
+
+from PyQt5.QtWidgets import QLabel, QHBoxLayout, QVBoxLayout, QLayout, QLineEdit
+
+import vimiv
+from vimiv import api, utils
+from vimiv.config import styles
+from vimiv.widgets import PopUp
+
+
+_logger = utils.log.module_logger(__name__)
+
+
+class KeybindingsPopUp(PopUp):
+    """Pop up that displays keybinding information.
+
+    All available keybindings are displayed with the corresponding command. It is
+    possible to search through the commands using the line edit.
+
+    Class Attributes:
+        TITLE: Window title used for the pop up.
+
+    Attributes:
+        _bindings_color: Color used to highlight the keybindings.
+        _highlight_color: Color used to highlight matching search results.
+        _labels: List of labels to display keybinding-command text per column.
+        _search: Line edit widget to search for commands.
+    """
+
+    TITLE = f"{vimiv.__name__} - keybindings"
+
+    # fmt: off
+    STYLESHEET = PopUp.STYLESHEET + """
+    QLineEdit {
+        font: {statusbar.font};
+        background-color: {statusbar.bg};
+        color: {statusbar.fg};
+        border: 0px solid;
+        padding: {statusbar.padding};
+    }
+    """
+    # fmt: on
+
+    def __init__(self, columns: int = 2, parent=None):
+        super().__init__(self.TITLE, parent=parent)
+
+        self._bindings_color = styles.get("keybindings.bindings.color")
+        self._highlight_color = styles.get("keybindings.highlight.color")
+        self._labels: List[QLabel] = []
+        self._search = QLineEdit()
+
+        self._search.setPlaceholderText("search")
+
+        layout = QVBoxLayout()
+        layout.setSizeConstraint(QLayout.SetFixedSize)
+        content_layout = QHBoxLayout()
+        for _ in range(columns):
+            label = QLabel()
+            self._labels.append(label)
+            content_layout.addWidget(label)
+        layout.addLayout(content_layout)
+        layout.addWidget(self._search)
+        self.setLayout(layout)
+
+        self._search.textChanged.connect(self._update_text)
+        for mode in api.modes.ALL:
+            mode.entered.connect(self._update_text)
+
+        self._update_text()
+        self._search.setFocus()
+        self.show()
+
+    @property
+    def text(self) -> str:
+        """Complete keybinding/command text displayed in all columns."""
+        return "\n".join(label.text() for label in self._labels)
+
+    @property
+    def column_count(self) -> int:
+        """Number of columns to split the bindings in."""
+        return len(self._labels)
+
+    def column_bindings(self) -> Iterator[List[Tuple[str, str]]]:
+        """Return html-safe keybindings for each column sorted by command name."""
+        bindings = api.keybindings.get(api.modes.current())
+        formatted_bindings = [
+            (utils.escape_html(binding), command)
+            for binding, command in sorted(bindings.items(), key=lambda x: x[1])
+        ]
+        return utils.split(formatted_bindings, self.column_count)
+
+    def column_text(
+        self, search: str, highlight: str, bindings: List[Tuple[str, str]]
+    ) -> str:
+        """Return the formatted keybinding-command text for one column.
+
+        Args:
+            search: Current search string.
+            highlight: Search string wrapped in a highlight color span.
+            bindings: List of bindings to put into this column
+        """
+        text = ""
+        for binding, command in bindings:
+            if search:
+                command = command.replace(search, highlight)
+            text += (
+                "<tr>"
+                f"<td style='color: {self._bindings_color}'>{binding}</td>"
+                f"<td style='padding-left: 2ex'>{command}</td>"
+                "</tr>"
+            )
+        return text
+
+    def highlighted_search_str(self, search: str) -> str:
+        """Current search string wrapped in a highlight color span."""
+        return utils.wrap_style_span(f"color: {self._highlight_color}", search)
+
+    def _update_text(self, search: str = None) -> None:
+        """Update keybinding-command text for all columns.
+
+        This retrieves all keybindings for the current mode, splits them upon the
+        available columns and formats them neatly. If there is a search, then the
+        matching command parts are highlighted.
+
+        Args:
+            search: Current search string from the line edit.
+        """
+        search = search if search is not None else self._search.text()
+        search = search.strip()
+        highlight = self.highlighted_search_str(search)
+
+        for label, bindings in zip(self._labels, self.column_bindings()):
+            label.setText(self.column_text(search, highlight, bindings))

--- a/vimiv/gui/library.py
+++ b/vimiv/gui/library.py
@@ -392,7 +392,7 @@ class LibraryModel(QStandardItemModel):
             name = os.path.basename(path)
             marked = path in api.mark.paths
             if are_directories:
-                name = utils.add_html("b", name + "/")
+                name = utils.add_html(name + "/", "b")
             with suppress(FileNotFoundError):  # Has been deleted in the meantime
                 size = files.get_size(path)
                 self.appendRow(

--- a/vimiv/gui/mainwindow.py
+++ b/vimiv/gui/mainwindow.py
@@ -23,6 +23,7 @@ from .manipulate import Manipulate, ManipulateImage
 from .thumbnail import ThumbnailView
 from .version_popup import VersionPopUp
 from .metadata_widget import MetadataWidget
+from .keybindings_popup import KeybindingsPopUp
 
 
 class MainWindow(QWidget):
@@ -88,6 +89,18 @@ class MainWindow(QWidget):
             VersionPopUp.copy_to_clipboard()
         else:
             VersionPopUp(parent=self)
+
+    @api.commands.register(mode=api.modes.MANIPULATE)
+    @api.commands.register()
+    def keybindings(self, columns: int = 2):
+        """Show a pop-up with keybindings information.
+
+        **syntax:** ``:keybindings [--columns=N]``
+
+        optional arguments:
+            * ``--columns``: Number of columns to split the bindings in.
+        """
+        KeybindingsPopUp(columns, parent=self)
 
     def resizeEvent(self, event):
         """Update resize event to resize overlays and library.

--- a/vimiv/gui/version_popup.py
+++ b/vimiv/gui/version_popup.py
@@ -6,15 +6,14 @@
 
 """Pop-up window to display version information."""
 
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QDialog, QLabel, QVBoxLayout, QPushButton
+from PyQt5.QtWidgets import QLabel, QVBoxLayout, QPushButton
 from PyQt5.QtGui import QGuiApplication
 
 import vimiv
-from vimiv.config import styles
+from vimiv.widgets import PopUp
 
 
-class VersionPopUp(QDialog):
+class VersionPopUp(PopUp):
     """Pop up that displays version information on initialization.
 
     Class Attributes:
@@ -22,35 +21,12 @@ class VersionPopUp(QDialog):
         URL: Url to the vimiv website.
     """
 
-    STYLESHEET = """
-    QDialog {
-        background: {image.bg};
-    }
-    QLabel {
-        color: {statusbar.fg};
-        font: {library.font}
-    }
-    QPushButton {
-        font: {statusbar.font};
-        background-color: {statusbar.bg};
-        border: 0px;
-        padding: 4px;
-        color: {statusbar.fg};
-    }
-    QPushButton:pressed {
-        background-color: {library.selected.bg};
-    }
-    """
-
     TITLE = f"{vimiv.__name__} - version"
     URL = "https://karlch.github.io/vimiv-qt/"
 
     def __init__(self, parent=None):
-        super().__init__(parent=parent)
+        super().__init__(self.TITLE, parent=parent)
         self._init_content()
-        self.setWindowTitle(self.TITLE)
-        self.setWindowFlags(self.windowFlags() | Qt.Tool)
-        styles.apply(self)
         self.show()
 
     def _init_content(self):

--- a/vimiv/utils/__init__.py
+++ b/vimiv/utils/__init__.py
@@ -64,6 +64,10 @@ def strip_html(text: str) -> str:
     return re.sub(stripper, "", text)
 
 
+def escape_html(text: str) -> str:
+    return text.replace("<", "&lt;").replace(">", "&gt;")
+
+
 def clamp(
     value: Number, minimum: Optional[Number], maximum: Optional[Number]
 ) -> Number:
@@ -245,6 +249,15 @@ class Pool:
 def flatten(list_of_lists: List[List[Any]]) -> List[Any]:
     """Flatten a list of lists into a single list with all elements."""
     return [elem for sublist in list_of_lists for elem in sublist]
+
+
+def split(a, n):
+    """Split list into n parts of approximately equal length.
+
+    See https://stackoverflow.com/questions/2130016 for details.
+    """
+    k, m = divmod(len(a), n)
+    return (a[i * k + min(i, m) : (i + 1) * k + min(i + 1, m)] for i in range(n))
 
 
 def recursive_split(

--- a/vimiv/utils/__init__.py
+++ b/vimiv/utils/__init__.py
@@ -32,14 +32,16 @@ except ImportError:
 Number = TypeVar("Number", int, float)
 
 
-def add_html(tag: str, text: str) -> str:
-    """Surround text in a html tag.
+def add_html(text: str, *tags: str) -> str:
+    """Surround text html tags.
 
     Args:
-        tag: Tag to use, e.g. b.
         text: The text to surround.
+        tags: Tuple of tags to use, e.g. "b", "i".
     """
-    return f"<{tag}>{text}</{tag}>"
+    for tag in tags:
+        text = f"<{tag}>{text}</{tag}>"
+    return text
 
 
 def wrap_style_span(style: str, text: str) -> str:

--- a/vimiv/widgets.py
+++ b/vimiv/widgets.py
@@ -8,7 +8,7 @@
 
 from PyQt5.QtCore import QItemSelectionModel, Qt
 from PyQt5.QtGui import QPainter, QFontMetrics
-from PyQt5.QtWidgets import QTreeView, QAbstractItemView, QSlider
+from PyQt5.QtWidgets import QTreeView, QAbstractItemView, QSlider, QDialog
 
 from vimiv.config import styles
 from vimiv.utils import cached_method
@@ -120,3 +120,38 @@ class SliderWithValue(QSlider):
         }}
         """
         styles.apply(self, append=sheet)
+
+
+class PopUp(QDialog):
+    """Base class for pop-up windows to ensure consistent styling and behaviour."""
+
+    STYLESHEET = """
+    QDialog {
+        background: {image.bg};
+    }
+    QLabel {
+        color: {statusbar.fg};
+        font: {library.font}
+    }
+    QPushButton {
+        font: {statusbar.font};
+        background-color: {statusbar.bg};
+        border: 0px;
+        padding: 4px;
+        color: {statusbar.fg};
+    }
+    QPushButton:pressed {
+        background-color: {library.selected.bg};
+    }
+    """
+
+    def __init__(self, title: str, parent=None):
+        super().__init__(parent=parent)
+        self.setWindowTitle(title)
+        self.setWindowFlags(self.windowFlags() | Qt.Tool)  # type: ignore
+        styles.apply(self)
+
+    def reject(self):
+        """Override reject to additionally delete the QObject."""
+        super().reject()
+        self.deleteLater()


### PR DESCRIPTION
The `:keybindings` command displays a pop-up window with the keybindings valid for the current mode. In addition it is searchable, search matches are highlighted and a description is shown for matching commands.

fixes #97