### PR TITLE
Implement :help command

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,8 @@ Added:
   ``keybindings.bindings.color`` and ``keybindings.highlight.color``.
 * Default left statusbar setting for manipulate mode showing basename, image size,
   modification date and the processing indicator.
+* New ``:help`` command to display help messages on commands, settings and some general
+  information.
 
 Changed:
 ^^^^^^^^

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setuptools.setup(
     description=read_from_init("description"),
     long_description=read_file(os.path.join(BASEDIR, "README.md")),
     long_description_content_type="text/markdown",
-    url="https://karlch.github.io/vimiv-qt/",
+    url=read_from_init("url"),
     project_urls={
         "Source Code": "https://github.com/karlch/vimiv-qt",
         "Bug Tracker": "https://github.com/karlch/vimiv-qt/issues",

--- a/tests/end2end/features/commandline/commandline.feature
+++ b/tests/end2end/features/commandline/commandline.feature
@@ -60,3 +60,19 @@ Feature: Use the command line.
         When I run command --text='open-selected -h'
         And I activate the command line
         Then the help for 'open-selected' should be displayed
+
+    Scenario Outline: Show help using help command
+        When I run help <topic>
+        Then the help for '<topic>' should be displayed
+
+        Examples:
+            | topic          |
+            | :open-selected |
+            | vimiv          |
+            | library.width  |
+
+    Scenario: Fail help command with unknown topic
+        When I run help invalid_topic
+        Then the message
+            'help: Unknown topic 'invalid_topic''
+            should be displayed

--- a/tests/end2end/features/commandline/test_commandline_bdd.py
+++ b/tests/end2end/features/commandline/test_commandline_bdd.py
@@ -5,12 +5,15 @@
 # License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
 
 import inspect
+from contextlib import suppress
 
 from PyQt5.QtCore import Qt
 
 import pytest_bdd as bdd
 
+import vimiv
 from vimiv import api
+from vimiv.commands import runners
 from vimiv.gui import statusbar
 
 
@@ -24,6 +27,11 @@ def hit_backspace(commandline, qtbot):
     qtbot.wait(10)
 
 
+@bdd.when("I run help <topic>")
+def run_help(topic):
+    runners.run(f"help {topic}", mode=api.modes.current())
+
+
 @bdd.then(bdd.parsers.parse("the text in the command line should be {text}"))
 def check_commandline_text(commandline, text):
     assert commandline.text() == text
@@ -34,8 +42,20 @@ def check_commandline_closed():
     assert api.modes.current() != api.modes.COMMAND
 
 
-@bdd.then(bdd.parsers.parse("the help for '{commandname}' should be displayed"))
-def check_command_help(commandname):
-    command = api.commands.get(commandname, mode=api.modes.current())
-    docstring = inspect.getdoc(command.func)
-    assert docstring in statusbar.statusbar.message.text()
+@bdd.then(bdd.parsers.parse("the help for '{topic}' should be displayed"))
+@bdd.then("the help for '<topic>' should be displayed")
+def check_help(topic):
+    if topic == "vimiv":
+        assert vimiv.__description__ in statusbar.statusbar.message.text()
+        return
+    topic = topic.lower().lstrip(":")
+    with suppress(api.commands.CommandNotFound):
+        command = api.commands.get(topic, mode=api.modes.current())
+        docstring = inspect.getdoc(command.func)
+        assert docstring in statusbar.statusbar.message.text()
+        return
+    with suppress(KeyError):
+        setting = api.settings.get(topic)
+        assert setting.desc in statusbar.statusbar.message.text()
+        return
+    raise AssertionError(f"Topic '{topic}' not found")

--- a/tests/end2end/features/completion/completion.feature
+++ b/tests/end2end/features/completion/completion.feature
@@ -47,6 +47,14 @@ Feature: Using completion.
         When I enter command mode with "tag-write "
         Then the completion model should be tag
 
+    Scenario: Using help completion
+        Given I open any directory
+        When I enter command mode with "help "
+        Then the completion model should be help
+        And a possible completion should contain :open-selected
+        And a possible completion should contain library.width
+        And a possible completion should contain vimiv
+
     Scenario: Crash on path completion with non-existent directory
         Given I open any directory
         When I enter command mode with "open /not/a/valid/path"

--- a/tests/end2end/features/completion/test_completion_bdd.py
+++ b/tests/end2end/features/completion/test_completion_bdd.py
@@ -36,6 +36,7 @@ def check_completion_model(completer, model):
         "settings_option": completionmodels.SettingsOptionModel,
         "trash": completionmodels.TrashModel,
         "tag": completionmodels.TagModel,
+        "help": completionmodels.HelpModel,
     }
     assert isinstance(completer._proxy_model.sourceModel(), models[model])
 

--- a/vimiv/__init__.py
+++ b/vimiv/__init__.py
@@ -15,3 +15,4 @@ __author__ = "Christian Karl"
 __maintainer__ = __author__
 __email__ = "karlch@protonmail.com"
 __description__ = "An image viewer with vim-like keybindings."
+__url__ = "https://karlch.github.io/vimiv-qt/"

--- a/vimiv/api/_modules.py
+++ b/vimiv/api/_modules.py
@@ -12,11 +12,13 @@ corresponding objects.
 
 import datetime
 import os
+from contextlib import suppress
 
 from PyQt5.QtGui import QGuiApplication, QClipboard
 
+import vimiv
 from vimiv import api
-from vimiv.utils import files
+from vimiv.utils import files, log
 
 
 ###############################################################################
@@ -88,6 +90,49 @@ def paste_name(primary: bool = True) -> None:
     clipboard = QGuiApplication.clipboard()
     mode = QClipboard.Selection if primary else QClipboard.Clipboard
     api.open([clipboard.text(mode=mode)])
+
+
+# We want to use the name help here as it is the best name for the command
+@api.commands.register(mode=api.modes.MANIPULATE)
+@api.commands.register()
+def help(topic: str) -> None:  # pylint: disable=redefined-builtin
+    """Show help on a command or setting.
+
+    **syntax:** ``:help topic``
+
+    positional arguments:
+        * ``topic``: Either a valid :command or a valid setting name.
+
+    .. hint:: For commands ``help :command`` is the same as ``command -h``.
+    """
+    topic = topic.lower().lstrip(":")
+    if topic == "vimiv":
+        log.info(
+            "%s: %s\n\n"
+            "Website: %s\n\n"
+            "For an overview of keybindings, run :keybindings.\n"
+            "To retrieve help on a command or setting run :help topic.",
+            vimiv.__name__,
+            vimiv.__description__,
+            vimiv.__url__,
+        )
+        return
+    with suppress(api.commands.CommandNotFound):
+        command = api.commands.get(topic, mode=api.modes.current())
+        command(["-h"], "")
+        return
+    with suppress(KeyError):
+        setting = api.settings.get(topic)
+        log.info(
+            "%s: %s\n\nType: %s\nDefault: %s\nSuggestions: %s",
+            setting.name,
+            setting.desc,
+            setting,
+            setting.default,
+            ", ".join(setting.suggestions()),
+        )
+        return
+    raise api.commands.CommandError(f"Unknown topic '{topic}'")
 
 
 ###############################################################################

--- a/vimiv/gui/version_popup.py
+++ b/vimiv/gui/version_popup.py
@@ -18,11 +18,9 @@ class VersionPopUp(PopUp):
 
     Class Attributes:
         TITLE: Window title used for the pop up.
-        URL: Url to the vimiv website.
     """
 
     TITLE = f"{vimiv.__name__} - version"
-    URL = "https://karlch.github.io/vimiv-qt/"
 
     def __init__(self, parent=None):
         super().__init__(self.TITLE, parent=parent)
@@ -34,7 +32,7 @@ class VersionPopUp(PopUp):
         layout = QVBoxLayout()
         layout.addWidget(QLabel(vimiv.version.detailed_info()))
         layout.addWidget(
-            QLabel("Website: <a href='{url}'>{url}</a>".format(url=self.URL))
+            QLabel("Website: <a href='{url}'>{url}</a>".format(url=vimiv.__url__))
         )
         button = QPushButton("&Copy version info to clipboard")
         button.clicked.connect(self.copy_to_clipboard)


### PR DESCRIPTION
The `:help` command displays information on commands, settings or a general description in the statusbar. It comes with its own completion model.