### PR TITLE
Reference external resources in config file

### DIFF
--- a/docs/documentation/configuration/settings.rst
+++ b/docs/documentation/configuration/settings.rst
@@ -12,6 +12,21 @@ There are two ways to change a setting:
 The configuration file is ``$XDG_CONFIG_HOME/vimiv/vimiv.conf`` where
 ``$XDG_CONFIG_HOME`` is usually ``~/.config/`` if you have not updated it.
 
+.. _external_resources:
+
+Referring to external resources
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In the configuration file, it is possible to refer to external resources using the
+``option = ${RESOURCE:variable}``
+syntax. Here ``RESOURCE`` defines the type of external resource, and ``variable`` is the
+corresponding variable name. The following options are available:
+
+* ``${env:VARIABLE}`` to retrieve the value of the environment variable ``$VARIABLE``
+
+Overview of all settings
+^^^^^^^^^^^^^^^^^^^^^^^^
+
 The following table explains all available settings.
 
 .. include:: settings_table.rstsrc

--- a/docs/documentation/configuration/style.rst
+++ b/docs/documentation/configuration/style.rst
@@ -31,5 +31,8 @@ Creating your own style is easy:
    for example to use a different base color for mark-related things you can use
    ``mark.color = {base0a}``.
 
+.. hint:: As for settings, you can refer to
+    :ref:`external resources <external_resources>`.
+
 .. hint:: The python configparser module is not case sensitive. Therefore it is
-   a good idea to keep all your styles in lower case.
+   a good idea to keep all your style options in lower case.

--- a/tests/unit/config/test_external_configparser.py
+++ b/tests/unit/config/test_external_configparser.py
@@ -1,0 +1,86 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2019 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+"""Unit tests for vimiv.config.external_configparser."""
+
+import configparser
+import os
+from collections import namedtuple
+
+import pytest
+
+from vimiv.config import external_configparser
+
+
+ENV_VARIABLE = namedtuple("EnvironmentVariable", ["name", "value"])("COLOR0", "#121212")
+SECTION_NAME = "default".upper()
+OPTION_NAME = ENV_VARIABLE.name.lower()
+
+
+@pytest.fixture()
+def parser():
+    yield external_configparser.get_parser()
+
+
+@pytest.fixture()
+def config(tmpdir):
+    """Fixture to retrieve a written config file with external references."""
+    parser = configparser.ConfigParser()
+    parser[SECTION_NAME][OPTION_NAME] = "${env:" + ENV_VARIABLE.name + "}"
+    path = tmpdir.join("config.ini")
+    with open(path, "w") as f:
+        parser.write(f)
+    yield str(path)
+
+
+@pytest.fixture()
+def setup_env():
+    """Fixture to add and clean up an environment variable."""
+    variable, value = ENV_VARIABLE
+    os.environ[variable] = value
+    yield
+    del os.environ[variable]
+
+
+@pytest.mark.parametrize(
+    "pattern, expected",
+    [
+        ("${test}", "test"),
+        ("${}", ""),
+        ("${", None),
+        ("$}", None),
+        ("$(anything)", None),
+    ],
+)
+def test_variable_match_regex(pattern, expected):
+    match = external_configparser.VARIABLE_RE.match(pattern)
+    if match is None:
+        assert expected is None
+    else:
+        assert match.group(0) == "${" + expected + "}"
+        assert match.group(1) == expected
+
+
+def test_update_variable_from_env(setup_env):
+    variable, expected = ENV_VARIABLE
+    option = "${env:" + variable + "}"
+    assert external_configparser.ExternalInterpolation.update(option) == expected
+
+
+@pytest.mark.parametrize("variable", ["", ":", ":test", "something:test"])
+def test_fail_update_variable_invalid_prefix(variable):
+    with pytest.raises(configparser.Error, match="Invalid variable name"):
+        external_configparser.ExternalInterpolation.update("${" + variable + "}")
+
+
+def test_fail_update_variable_from_env():
+    with pytest.raises(configparser.Error, match="not found in environment"):
+        external_configparser.ExternalInterpolation.update("${env:not_in_env}")
+
+
+def test_read_env_variable_from_config(config, parser):
+    parser.read(config)
+    assert parser.get(SECTION_NAME, OPTION_NAME) == ENV_VARIABLE.value

--- a/vimiv/config/configfile.py
+++ b/vimiv/config/configfile.py
@@ -12,7 +12,7 @@ from vimiv import api, plugins
 from vimiv.commands import aliases
 from vimiv.utils import log
 
-from . import read_log_exception, parse_config
+from . import read_log_exception, parse_config, external_configparser
 
 
 _logger = log.module_logger(__name__)
@@ -49,7 +49,7 @@ def get_default_parser() -> configparser.ConfigParser:
 
 def read(path: str) -> None:
     """Read config from path into settings."""
-    parser = _setup_parser()
+    parser = external_configparser.get_parser()
     read_log_exception(parser, _logger, path)
     # Try to update every single setting
     for name, _ in api.settings.items():
@@ -101,12 +101,6 @@ def _add_statusbar_formatters(configsection):
         if name in possible:
             _logger.debug("Adding statusbar formatter '%s' with '%s'", name, value)
             api.settings.StrSetting(f"statusbar.{name}", value)
-
-
-def _setup_parser():
-    """Setup config file parser."""
-    parser = configparser.ConfigParser()
-    return parser
 
 
 def _get_section_option(name):

--- a/vimiv/config/external_configparser.py
+++ b/vimiv/config/external_configparser.py
@@ -1,0 +1,98 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2019 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+"""Custom configparser able to retrieve variables from external resources.
+
+Values in the configuration file with the syntax ${PREFIX:variable} are updated with the
+value of the variable in the context corresponding to PREFIX. A valid example is
+${env:variable} where the value of the environment variable $variable is retrieved.
+
+To add more resources::
+
+    * Implement the conversion function that retrieves the value of the variable, e.g.
+      ``os.getenv(variable)``.
+    * Add the conversion function with the corresponding prefix to
+      ``ExternalInterpolation.CONVERTERS``.
+"""
+
+import configparser
+import os
+import re
+from functools import lru_cache
+
+from vimiv.utils import log
+
+_logger = log.module_logger(__name__)
+VARIABLE_RE = re.compile(r"\${(.*)}")
+
+
+def get_parser() -> configparser.ConfigParser:
+    """Return the custom configparser with support for external variables."""
+    return configparser.ConfigParser(interpolation=ExternalInterpolation())
+
+
+def getenv(variable: str) -> str:
+    """Return the value of an environment variable.
+
+    Used as converter function for parser and therefore raises configparser.Error on
+    failure.
+    """
+    try:
+        return os.environ[variable]
+    except KeyError:
+        raise configparser.Error(f"Variable '{variable}' not found in environment")
+
+
+class ExternalInterpolation(configparser.Interpolation):
+    """Configparser interpolation to update values from external resources.
+
+    Class Attributes:
+        CONVERTERS: Dictionary mapping variable prefixes to converter functions.
+        PREFIXES: List of all valid variable converter prefixes.
+    """
+
+    CONVERTERS = {"env:": getenv}
+    PREFIXES = ", ".join(CONVERTERS)
+
+    def before_get(self, _parser, _section, _option, value: str, _defaults) -> str:
+        """Update value from configfile with external resources."""
+        return self.update(value)
+
+    @staticmethod
+    @lru_cache(None)
+    def update(value: str) -> str:
+        """Update value from configfile with external resources.
+
+        If the value contains a variable with a valid converter prefix, the variable is
+        replaced with the value of the corresponding converter function.
+
+        Args:
+            value: Value of config option possibly containing external variables.
+        Returns:
+            The value with any external variables replaced by their value.
+        """
+        match = VARIABLE_RE.match(value)
+        if match is None:
+            return value
+
+        full_match, variable = match.group(0), match.group(1)
+        _logger.debug("Updating config value '%s' using '%s'", value, full_match)
+
+        for prefix, converter in ExternalInterpolation.CONVERTERS.items():
+            if variable.lower().startswith(prefix):
+                variable_value = converter(variable[len(prefix) :])
+                _logger.debug(
+                    "Updated '%s' = '%s' using '%s' converter",
+                    full_match,
+                    variable_value,
+                    prefix.rstrip(":"),
+                )
+                return value.replace(full_match, variable_value)
+
+        raise configparser.Error(
+            f"Invalid variable name '{variable}', "
+            f"must start with one of '{ExternalInterpolation.PREFIXES}'"
+        )

--- a/vimiv/config/styles.py
+++ b/vimiv/config/styles.py
@@ -24,7 +24,7 @@ from typing import cast
 from vimiv import api
 from vimiv.utils import xdg, log, customtypes
 
-from . import read_log_exception
+from . import read_log_exception, external_configparser
 
 
 NAME_DEFAULT = "default"
@@ -286,7 +286,7 @@ def read(path: str) -> Style:
         path: Name of the styles file to read
     """
     _logger.debug("Reading style from file '%s'", path)
-    parser = configparser.ConfigParser()
+    parser = external_configparser.get_parser()
     read_log_exception(parser, _logger, path)
     # Retrieve the STYLE section
     try:


### PR DESCRIPTION
Implements a custom configparser interpolation to allow referring to external resources via `${RESOURCE:variable}`. Currently only `${env:VARIABLE}` is implemented for environment variables, but extending is simple and can be used for #113.