### PR TITLE
Various improvements for startup performance

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -57,3 +57,5 @@ max-args=10
 valid-metaclass-classmethod-first-arg=cls
 
 [TYPECHECK]
+# __setattr__ magic that confuses pylint
+ignored-modules=vimiv.utils.log

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,3 +14,5 @@ include misc/vimiv.1
 include misc/vimiv.desktop
 include misc/vimiv.appdata.xml
 graft misc/requirements
+
+include fastentrypoints.py

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,12 @@ Added:
 * Panning images with the left mouse button.
 * Zooming images with control+mouse-wheel.
 
+Changed:
+^^^^^^^^
+
+* External commands started with ``!`` no longer run in a sub-shell. To run commands
+  with a sub-shell use ``:spawn`` instead.
+
 Fixed:
 ^^^^^^
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -27,6 +27,7 @@ Fixed:
 * XDG related directories such as XDG_CONFIG_HOME are created with mode 700 as expected
   by the XDG standard if they do not exist.
 * Writing image changes on quit.
+* Crash when running transform-related commands without valid pixmap.
 
 
 v0.3.0 (2019-11-01)

--- a/docs/documentation/getting_started.rst
+++ b/docs/documentation/getting_started.rst
@@ -121,6 +121,13 @@ all lines are checked for images and these are opened.
 Example: ``:!find ~/Images -ctime -5 -type f |`` opens all files in
 ``~/Images`` younger than five days.
 
+.. note::
+
+    External commands started with ``!`` do not run in a sub-shell for security and
+    performance reasons. This means that redirection with ``|`` or ``>`` as well as any
+    other shell specifics do not work. If you require to run with a sub-shell, use the
+    ``:spawn`` command instead.
+
 Command line history is saved to ``$XDG_DATA_HOME/vimiv/history``. History can
 be navigated and searched through using the ``<control>p/<control>n`` and
 ``<up>/<down>`` keys.

--- a/fastentrypoints.py
+++ b/fastentrypoints.py
@@ -1,0 +1,115 @@
+# noqa: D300,D400
+
+# This file is part of vimiv.
+# Copyright 2017-2019 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+# Copyright (c) 2016, Aaron Christianson
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+# IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+# TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+Monkey patch setuptools to write faster console_scripts with this format:
+    import sys
+    from mymodule import entry_function
+    sys.exit(entry_function())
+This is better.
+(c) 2016, Aaron Christianson
+http://github.com/ninjaaron/fast-entry_points
+"""
+from setuptools.command import easy_install
+import re
+
+TEMPLATE = r"""
+# -*- coding: utf-8 -*-
+# EASY-INSTALL-ENTRY-SCRIPT: '{3}','{4}','{5}'
+__requires__ = '{3}'
+import re
+import sys
+from {0} import {1}
+if __name__ == '__main__':
+    sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0])
+    sys.exit({2}())
+""".lstrip()
+
+
+@classmethod
+def get_args(cls, dist, header=None):  # noqa: D205,D400
+    """
+    Yield write_script() argument tuples for a distribution's
+    console_scripts and gui_scripts entry points.
+    """
+    if header is None:
+        # pylint: disable=E1101
+        header = cls.get_header()
+    spec = str(dist.as_requirement())
+    for type_ in "console", "gui":
+        group = type_ + "_scripts"
+        for name, ep in dist.get_entry_map(group).items():
+            # ensure_safe_name
+            if re.search(r"[\\/]", name):
+                raise ValueError("Path separators not allowed in script names")
+            script_text = TEMPLATE.format(
+                ep.module_name, ep.attrs[0], ".".join(ep.attrs), spec, group, name
+            )
+            # pylint: disable=E1101
+            args = cls._get_script_args(type_, name, header, script_text)
+            for res in args:
+                yield res
+
+
+# pylint: disable=E1101
+easy_install.ScriptWriter.get_args = get_args
+
+
+def main():
+    import os
+    import re
+    import shutil
+    import sys
+
+    dests = sys.argv[1:] or ["."]
+    filename = re.sub(r"\.pyc$", ".py", __file__)
+
+    for dst in dests:
+        shutil.copy(filename, dst)
+        manifest_path = os.path.join(dst, "MANIFEST.in")
+        setup_path = os.path.join(dst, "setup.py")
+
+        # Insert the include statement to MANIFEST.in if not present
+        with open(manifest_path, "a+") as manifest:
+            manifest.seek(0)
+            manifest_content = manifest.read()
+            if "include fastentrypoints.py" not in manifest_content:
+                manifest.write(
+                    ("\n" if manifest_content else "") + "include fastentrypoints.py"
+                )
+
+        # Insert the import statement to setup.py if not present
+        with open(setup_path, "a+") as setup:
+            setup.seek(0)
+            setup_content = setup.read()
+            if "import fastentrypoints" not in setup_content:
+                setup.seek(0)
+                setup.truncate()
+                setup.write("import fastentrypoints\n" + setup_content)

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,8 @@ import os
 import re
 import setuptools
 
+import fastentrypoints
+
 # C extensions
 manipulate_module = setuptools.Extension(
     "vimiv.imutils._c_manipulate", sources=["c-extension/manipulate.c"]

--- a/tests/end2end/conftest.py
+++ b/tests/end2end/conftest.py
@@ -51,6 +51,8 @@ def cleanup():
     runners._last_command.clear()
     filelist._paths = []
     filelist._index = 0
+    for mode in api.modes.ALL:
+        mode._entered = False
 
 
 @pytest.fixture(autouse=True, scope="module")

--- a/tests/end2end/features/command/expand_wildcards.feature
+++ b/tests/end2end/features/command/expand_wildcards.feature
@@ -19,7 +19,6 @@ Feature: Expand wildcards when running commands
         Then the directory child_01_bak should not exist
         And a message should be displayed
 
-    @skip
     Scenario: Expand * to the list of paths in the library
         Given I open a directory with 2 paths
         When I run !rmdir *
@@ -27,7 +26,6 @@ Feature: Expand wildcards when running commands
         Then the directory child_01 should not exist
         And the directory child_02 should not exist
 
-    @skip
     Scenario: Expand * to the list of images in image mode
         Given I open 2 images
         When I run !rm *
@@ -35,7 +33,6 @@ Feature: Expand wildcards when running commands
         Then the file image_01.jpg should not exist
         And the file image_02.jpg should not exist
 
-    @skip
     Scenario: Do not expand * when escaped
         Given I open a directory with 2 paths
         When I run !rmdir \*

--- a/tests/end2end/features/command/expand_wildcards.feature
+++ b/tests/end2end/features/command/expand_wildcards.feature
@@ -19,13 +19,15 @@ Feature: Expand wildcards when running commands
         Then the directory child_01_bak should not exist
         And a message should be displayed
 
+    @skip
     Scenario: Expand * to the list of paths in the library
         Given I open a directory with 2 paths
         When I run !rmdir *
         And I wait for the command to complete
-        Then the directory child_1 should not exist
-        And the directory child_2 should not exist
+        Then the directory child_01 should not exist
+        And the directory child_02 should not exist
 
+    @skip
     Scenario: Expand * to the list of images in image mode
         Given I open 2 images
         When I run !rm *
@@ -33,6 +35,7 @@ Feature: Expand wildcards when running commands
         Then the file image_01.jpg should not exist
         And the file image_02.jpg should not exist
 
+    @skip
     Scenario: Do not expand * when escaped
         Given I open a directory with 2 paths
         When I run !rmdir \*

--- a/tests/end2end/features/command/external.feature
+++ b/tests/end2end/features/command/external.feature
@@ -12,8 +12,9 @@ Feature: Running external commands.
     Scenario: Fail an external command.
         When I run !not-a-shell-command
         And I wait for the command to complete
-        # Error message may vary between OS
-        Then a message should be displayed
+        Then the message
+            'Error running 'not-a-shell-command': command not found or not executable'
+            should be displayed
 
     @flaky
     Scenario: Pipe directory to vimiv.
@@ -29,3 +30,8 @@ Feature: Running external commands.
         Then the message
             'ls: No paths from pipe'
             should be displayed
+
+    Scenario: Use spawn with sub-shell
+        When I run spawn echo anything > test.txt
+        And I wait for the command to complete
+        Then the file test.txt should exist

--- a/tests/end2end/features/conftest.py
+++ b/tests/end2end/features/conftest.py
@@ -8,7 +8,7 @@
 
 import os
 
-from PyQt5.QtCore import Qt, QThreadPool
+from PyQt5.QtCore import Qt, QProcess
 from PyQt5.QtWidgets import QApplication
 
 import pytest
@@ -103,10 +103,12 @@ def resize_main_window(mainwindow, size):
 @bdd.when("I wait for the command to complete")
 def wait_for_external_command(qtbot):
     """Wait until the external process has completed."""
-    message = "external command timed out"
+    runner = runners.external._impl
+    if runner is None:
+        return
 
     def external_finished():
-        assert QThreadPool.globalInstance().activeThreadCount() == 0, message
+        assert runner.state() == QProcess.NotRunning, "external command timed out"
 
     qtbot.waitUntil(external_finished, timeout=100)
 

--- a/tests/end2end/features/statusbar/test_message_bdd.py
+++ b/tests/end2end/features/statusbar/test_message_bdd.py
@@ -4,11 +4,10 @@
 # Copyright 2017-2019 Christian Karl (karlch) <karlch at protonmail dot com>
 # License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
 
-import logging
-
 import pytest_bdd as bdd
 
 from vimiv import api
+from vimiv.utils import log
 
 
 bdd.scenarios("message.feature")
@@ -16,7 +15,7 @@ bdd.scenarios("message.feature")
 
 @bdd.when(bdd.parsers.parse("I log the warning '{message}'"))
 def log_warning(message, qtbot):
-    logging.warning(message)
+    log.warning(message)
 
 
 @bdd.when("I clear the status")

--- a/tests/end2end/mockdecorators.py
+++ b/tests/end2end/mockdecorators.py
@@ -25,8 +25,8 @@ def mockregister(component_init):
 
 def mockregister_cleanup():
     for cls in _known_classes:
-        # Mark instance is stored as a global variable in api
-        if "Mark" not in cls.__qualname__:
+        # Instances stored as a global variable
+        if cls.__qualname__ not in ("Mark", "ExternalRunner"):
             cls.instance = None
 
 

--- a/tests/unit/utils/test_debug.py
+++ b/tests/unit/utils/test_debug.py
@@ -1,0 +1,39 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2019 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+"""Tests for vimiv.utils.debug"""
+
+import time
+
+import pytest
+
+from vimiv.utils import debug, log
+
+
+def test_profiler(capsys):
+    with debug.profile(5):
+        pass
+    assert "function calls" in capsys.readouterr().out
+
+
+def test_timed(mocker):
+    mocker.patch("vimiv.utils.log.info")
+    expected = 42
+    sleep_time_ms = 1
+
+    @debug.timed
+    def func():
+        time.sleep(sleep_time_ms / 1000)
+        return expected
+
+    result = func()
+
+    assert result == expected  # Ensure the result is preserved
+    log.info.assert_called_once()  # Ensure a message was logged
+    # Ensure the message contains the elapsed time
+    message_args = log.info.call_args[0]
+    message_time = message_args[-1]
+    assert message_time == pytest.approx(sleep_time_ms, sleep_time_ms)

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -53,6 +53,23 @@ def test_wrap_style_span():
     )
 
 
+@pytest.mark.parametrize(
+    "sequence, elems, expected",
+    [
+        ("abc", "a", True),
+        ("abc", "d", False),
+        ("abc", "bc", True),
+        (range(5), 4, True),
+        (range(5), 10, False),
+        (range(5), (2, 3), True),
+        ("", "52", False),
+        ("imag*", "*?[]", True),
+    ],
+)
+def test_contains_any(sequence, elems, expected):
+    assert utils.contains_any(sequence, elems) == expected
+
+
 def test_clamp_with_min_and_max():
     assert utils.clamp(2, 0, 5) == 2
     assert utils.clamp(2, 3, 5) == 3

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -70,6 +70,12 @@ def test_contains_any(sequence, elems, expected):
     assert utils.contains_any(sequence, elems) == expected
 
 
+@pytest.mark.parametrize("char", "*?[]")
+def test_glob_escape(char):
+    assert utils.escape_glob(rf"test{char}.jpg") == f"test{char}.jpg"
+    assert utils.escape_glob(rf"test\{char}.jpg") == f"test[{char}].jpg"
+
+
 def test_clamp_with_min_and_max():
     assert utils.clamp(2, 0, 5) == 2
     assert utils.clamp(2, 3, 5) == 3

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -6,6 +6,7 @@
 
 """Tests for vimiv.utils"""
 
+import os
 import inspect
 from collections import namedtuple
 
@@ -205,3 +206,17 @@ def test_cached_calls_expensive_once(cached_method_cls):
     cached_method_cls.method()
     cached_method_cls.method()
     cached_method_cls.mock.assert_called_once()
+
+
+def test_run_qprocess():
+    assert utils.run_qprocess("pwd") == os.getcwd()
+
+
+def test_run_qprocess_in_other_dir(tmpdir):
+    directory = str(tmpdir.mkdir("directory"))
+    assert utils.run_qprocess("pwd", cwd=directory) == directory
+
+
+def test_fail_run_qprocess_raises_oserror():
+    with pytest.raises(OSError):
+        utils.run_qprocess("NoTaCoMmAnD")

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -7,7 +7,6 @@
 """Tests for vimiv.utils"""
 
 import inspect
-import time
 from collections import namedtuple
 
 import pytest
@@ -117,12 +116,6 @@ def test_slot_fails_without_type_annotations():
             ...
 
 
-def test_profiler(capsys):
-    with utils.profile(5):
-        pass
-    assert "function calls" in capsys.readouterr().out
-
-
 def test_flatten():
     list_of_lists = [[1, 2], [3, 4]]
     assert utils.flatten(list_of_lists) == [1, 2, 3, 4]
@@ -212,23 +205,3 @@ def test_cached_calls_expensive_once(cached_method_cls):
     cached_method_cls.method()
     cached_method_cls.method()
     cached_method_cls.mock.assert_called_once()
-
-
-def test_timed(mocker):
-    mocker.patch("vimiv.utils.log.info")
-    expected = 42
-    sleep_time_ms = 1
-
-    @utils.timed
-    def func():
-        time.sleep(sleep_time_ms / 1000)
-        return expected
-
-    result = func()
-
-    assert result == expected  # Ensure the result is preserved
-    utils.log.info.assert_called_once()  # Ensure a message was logged
-    # Ensure the message contains the elapsed time
-    message_args = utils.log.info.call_args[0]
-    message_time = message_args[-1]
-    assert message_time == pytest.approx(sleep_time_ms, sleep_time_ms)

--- a/vimiv/api/_mark.py
+++ b/vimiv/api/_mark.py
@@ -9,10 +9,9 @@
 
 import os
 import shutil
-from datetime import datetime
 from typing import Any, Callable, List, cast
 
-from PyQt5.QtCore import QObject, pyqtSignal, QFileSystemWatcher
+from PyQt5.QtCore import QObject, pyqtSignal, QFileSystemWatcher, QDateTime
 
 from vimiv.config import styles
 from vimiv.utils import files, xdg, remove_prefix, wrap_style_span, slot, log
@@ -333,8 +332,8 @@ class Tag:
     def _write_header(self) -> None:
         """Write header to a new tag file."""
         self._write_comment("vimiv tag file")
-        now = datetime.now()
-        formatted_time = now.strftime("%Y-%m-%d %H:%M")
+        now = QDateTime.currentDateTime()
+        formatted_time = now.toString("yyyy-MM-dd HH:mm")
         self._write_comment(f"created: {formatted_time}")
 
     def _write_comment(self, comment: str) -> None:

--- a/vimiv/api/_modules.py
+++ b/vimiv/api/_modules.py
@@ -10,11 +10,11 @@ These should not be used anywhere else and are only imported to register the
 corresponding objects.
 """
 
-import datetime
 import os
 from contextlib import suppress
 from typing import List
 
+from PyQt5.QtCore import QDateTime
 from PyQt5.QtGui import QGuiApplication, QClipboard
 
 import vimiv
@@ -253,5 +253,5 @@ def modified() -> str:
         mtime = os.path.getmtime(api.current_path())
     except OSError:
         return "N/A"
-    d = datetime.datetime.fromtimestamp(mtime)
-    return d.strftime("%y-%m-%d %H:%M")
+    date_time = QDateTime.fromSecsSinceEpoch(int(mtime))
+    return date_time.toString("yyyy-MM-dd HH:mm")

--- a/vimiv/api/commands.py
+++ b/vimiv/api/commands.py
@@ -75,6 +75,7 @@ import inspect
 import os
 import typing
 from contextlib import suppress
+from functools import partial
 
 from vimiv.utils import (
     class_that_defined_method,
@@ -88,48 +89,22 @@ from vimiv.utils import (
 from . import modes
 
 
-# hook function is either a function with no arguments or a method which takes self
-HookFunction = typing.Callable[[], None]
-HookMethod = typing.Callable[[typing.Any], None]
-Hook = typing.Union[HookFunction, HookMethod]
 _logger = log.module_logger(__name__)
 
 
 def register(
-    mode: modes.Mode = modes.GLOBAL,
-    hide: bool = False,
-    hook: Hook = lambda *args: None,
-    store: bool = True,
+    mode: modes.Mode = modes.GLOBAL, hide: bool = False, store: bool = True,
 ) -> typing.Callable[[customtypes.FuncT], customtypes.FuncT]:
     """Decorator to store a command in the registry.
 
     Args:
         mode: Mode in which the command can be executed.
         hide: Hide command from command line.
-        hook: Function to run before executing the command.
         store: Save command to allow repeating with '.'.
     """
 
     def decorator(func: customtypes.FuncT) -> customtypes.FuncT:
-        name = _get_command_name(func)
-        description = inspect.getdoc(func)
-        if description is None:
-            log.error("Command %s for %s is missing docstring.", name, func)
-            description = short_description = ""
-        else:
-            short_description = description.split("\n", maxsplit=1)[0]
-        arguments = _CommandArguments(name, description, func)
-        cmd = _Command(
-            name,
-            func,
-            arguments,
-            mode=mode,
-            description=short_description,
-            hide=hide,
-            hook=hook,
-            store=store,
-        )
-        _registry[mode][name] = cmd
+        _Command(func, mode=mode, hide=hide, store=store)
         return func
 
     return decorator
@@ -284,35 +259,40 @@ class _Command:  # pylint: disable=too-many-instance-attributes
     """Skeleton for a command.
 
     Attributes:
-        arguments: _CommandArguments argument parser.
+        name: Name of the command as string.
         func: Corresponding executable to call.
         mode: Mode in which the command can be executed.
-        name: Name of the command as string.
-        description: Description of the command for help.
         hide: Hide command from command line.
-        hook: Function to run before executing the command.
         store: Save command to allow repeating with '.'.
+        description: Brief command description.
+
+        _argparser: Argument parser used when the command is called.
+        _long_description: Full command description.
     """
 
     def __init__(
         self,
-        name: str,
         func: typing.Callable,
-        arguments: _CommandArguments,
         mode: modes.Mode = modes.GLOBAL,
-        description: str = "",
         hide: bool = False,
-        hook: Hook = lambda *args: None,
         store: bool = True,
     ):
-        self.name = name
+        self._argparser: typing.Optional[_CommandArguments] = None
+        self.name = _get_command_name(func)
         self.func = func
-        self.arguments = arguments
         self.mode = mode
-        self.description = description
         self.hide = hide
-        self.hook = hook
         self.store = store
+        # Retrieve description from docstring
+        docstr = inspect.getdoc(func)
+        if docstr is None:
+            log.error("Command %s for %s is missing docstring.", self.name, func)
+            self.description = self.long_description = ""
+        else:
+            self.description = docstr.split("\n", maxsplit=1)[0]
+            self.long_description = docstr
+        # Store command in the global registry
+        _registry[mode][self.name] = self
 
     def __call__(self, args: typing.List[str], count: str) -> None:
         """Parse arguments and call func.
@@ -321,11 +301,23 @@ class _Command:  # pylint: disable=too-many-instance-attributes
             args: List of arguments for argparser to parse.
             count: Count passed to the command.
         """
-        parsed_args = self.arguments.parse_args(args)
+        parsed_args = self.argparser.parse_args(args)
         kwargs = vars(parsed_args)
         self._parse_count(count, kwargs)
         func = self._create_func(self.func)
         func(**kwargs)
+
+    @property
+    def argparser(self) -> _CommandArguments:
+        """The initialized argument parser.
+
+        This is used so the parser is lazily created upon first command call.
+        """
+        if self._argparser is None:
+            self._argparser = _CommandArguments(
+                self.name, self.long_description, self.func
+            )
+        return self._argparser
 
     def _parse_count(self, count: str, kwargs: typing.Dict[str, typing.Any]) -> None:
         """Add count to kwargs if supported."""
@@ -339,9 +331,9 @@ class _Command:  # pylint: disable=too-many-instance-attributes
     def _create_func(self, func: typing.Callable) -> typing.Callable:
         """Create function to call for a command function.
 
-        This processes hooks and retrieves the instance of a class object for
-        methods and sets it as first argument (the 'self' argument) of a
-        lambda. For standard functions nothing is done.
+        This retrieves the instance of a class object for methods and sets it as first
+        argument (the 'self' argument) of a lambda. For standard functions nothing is
+        done.
 
         Returns:
             A function to be called with any keyword arguments.
@@ -350,10 +342,8 @@ class _Command:  # pylint: disable=too-many-instance-attributes
         if is_method(func):
             cls = class_that_defined_method(func)
             instance = cls.instance
-            hook_method = typing.cast(HookMethod, self.hook)  # Takes self as argument
-            return lambda **kwargs: (hook_method(instance), func(instance, **kwargs))
-        hook_function = typing.cast(HookFunction, self.hook)  # Takes no arguments
-        return lambda **kwargs: (hook_function(), func(**kwargs))
+            return partial(func, instance)
+        return func
 
 
 def _get_command_name(func: typing.Callable) -> str:

--- a/vimiv/api/commands.py
+++ b/vimiv/api/commands.py
@@ -84,6 +84,7 @@ from vimiv.utils import (
     flatten,
     log,
     customtypes,
+    escape_glob,
 )
 
 from . import modes
@@ -242,7 +243,9 @@ class _CommandArguments(argparse.ArgumentParser):
         argtype = argument.annotation
         if argument.name == "paths":
             return {
-                "type": lambda x: glob.glob(os.path.expanduser(x), recursive=True),
+                "type": lambda x: glob.glob(
+                    os.path.expanduser(escape_glob(x)), recursive=True
+                ),
                 "nargs": "+",
             }
         if argtype == typing.List[str]:

--- a/vimiv/api/keybindings.py
+++ b/vimiv/api/keybindings.py
@@ -33,7 +33,6 @@ earth with ``ge`` we could use::
         print("hello", name)
 """
 
-from contextlib import suppress
 from typing import Callable, ItemsView, List, Union, Tuple, Iterable
 
 from vimiv.utils import customtypes
@@ -90,12 +89,7 @@ def _check_duplicate_binding(keybinding: str, command: str, mode: modes.Mode) ->
 
     If an identical keybinding is found, a ValueError is raised.
     """
-    existing_command = None
-    with suppress(KeyError):
-        existing_command = _registry[mode][keybinding]
-    if mode in modes.GLOBALS:
-        with suppress(KeyError):
-            existing_command = _registry[modes.GLOBAL][keybinding]
+    existing_command = get(mode).get(keybinding)
     if existing_command is not None:
         raise ValueError(
             f"Duplicate keybinding for '{keybinding}', "

--- a/vimiv/app.py
+++ b/vimiv/app.py
@@ -39,7 +39,6 @@ class Application(QApplication):
     @staticmethod
     def preexit(returncode: int) -> None:
         """Prepare exit by finalizing any running threads."""
-        QApplication.instance().aboutToQuit.emit()  # type: ignore
         # Do not start any new threads
         utils.Pool.clear()
         # Wait for any running threads to exit safely

--- a/vimiv/commands/external.py
+++ b/vimiv/commands/external.py
@@ -124,7 +124,7 @@ class _ExternalRunnerImpl(QProcess):
     def _process_pipe(self) -> None:
         """Open paths from stdout."""
         _logger.debug("Opening paths from '%s'...", self.program())
-        stdout = str(self.readAllStandardOutput(), "utf-8")
+        stdout = str(self.readAllStandardOutput(), "utf-8")  # type: ignore
         try:
             api.open(path for path in stdout.split("\n") if os.path.exists(path))
             _logger.debug("... opened paths from pipe")

--- a/vimiv/commands/external.py
+++ b/vimiv/commands/external.py
@@ -106,11 +106,12 @@ class _ExternalRunnerImpl(QProcess):
             log.warning("Closing running process '%s'", self.program())
             self.close()
         self._pipe = pipe
-        args = flatten(
-            glob.glob(arg) if contains_any(arg, "*?[]") else (arg,) for arg in args
+        arglist: List[str] = flatten(
+            glob.glob(arg) if contains_any(arg, "*?[]") else (arg,)  # type: ignore
+            for arg in args
         )
-        _logger.debug("Running external command '%s' with '%r'", command, args)
-        self.start(command, args)
+        _logger.debug("Running external command '%s' with '%r'", command, arglist)
+        self.start(command, arglist)
 
     def _on_finished(self, exitcode, exitstatus):
         """Check exit status and possibly process standard output on completion."""

--- a/vimiv/commands/external.py
+++ b/vimiv/commands/external.py
@@ -1,0 +1,144 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2019 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+"""Runner for external commands."""
+
+import os
+import shlex
+from typing import List
+
+from PyQt5.QtCore import QProcess, QCoreApplication
+
+from vimiv import api
+from vimiv.utils import log
+
+
+_logger = log.module_logger(__name__)
+
+
+class ExternalRunner:
+    """Runner for external commands.
+
+    The runner makes use of the implementation class below which is created on-demand.
+    There are two methods to run external commands:
+        * The ``run`` function which starts a subprocess of the given command.
+        * The ``spawn`` function which starts a shell subprocess with the passed
+          arguments.
+
+    Run is preferred in general, as no sub-shell is required, but cannot deal with
+    wildcards or redirection.
+
+    Attributes:
+        _impl: The implementation class used to run external commands.
+    """
+
+    @api.objreg.register
+    def __init__(self):
+        self._impl = None
+
+    def __call__(self, *args, **kwargs):
+        """Wrapper function to pass arguments to initialized implementation class."""
+        if self._impl is None:
+            self._impl = _ExternalRunnerImpl()
+        return self._impl(*args, **kwargs)
+
+    def run(self, text: str):
+        """Run an external command text."""
+        text = text.strip()
+        pipe = text.endswith("|")
+        split = shlex.split(text.rstrip("|"))
+        command, args = split[0], split[1:]
+        self(command, *args, pipe=pipe)
+
+    @api.commands.register()
+    def spawn(self, command: List[str], shell: str = "sh", shellarg: str = "-c"):
+        """Spawn a command in a sub-shell.
+
+        **syntax:** ``:spawn command [--shell=shell --shellarg=shellarg]``
+
+        positional arguments:
+            * ``command``: Full command with arguments to pass to the shell.
+
+        optional arguments:
+            * ``--shell``: The program to use as sub-shell. Default: ``sh``.
+            * ``--shellarg``: Argument to prepend for the shell. Default: ``-c``.
+
+        The difference to running commands with ! is that an actual shell is involved
+        instead of running the program directly. This means that shell wildcards,
+        redirection etc. will work in spawn, but not with !. Nevertheless ! is
+        recommended in general for performance and security reasons.
+        """
+        if not command:
+            raise api.commands.CommandError("No command to run")
+        # Join as the full command is the argument to the shell process
+        self(shell, shellarg, " ".join(command))
+
+
+class _ExternalRunnerImpl(QProcess):
+    """Runner for external commands."""
+
+    error_messages = {
+        QProcess.FailedToStart: "command not found or not executable",
+        QProcess.Crashed: "process crashed after startup",
+        QProcess.Timedout: "process timed out",
+        QProcess.WriteError: "cannot write to process",
+        QProcess.ReadError: "cannot read from process",
+        QProcess.UnknownError: "unknown",
+    }
+
+    _instance = None
+
+    def __init__(self):
+        super().__init__()
+        self._pipe = False
+        self.finished.connect(self._on_finished)
+        self.errorOccurred.connect(self._on_error)
+        QCoreApplication.instance().aboutToQuit.connect(self._on_quit)
+        _logger.debug("Created implementation of external runner")
+
+    def __call__(self, command: str, *args: str, pipe=False) -> None:
+        """Run external command with arguments."""
+        if self.state() == QProcess.Running:
+            log.warning("Closing running process '%s'", self.program())
+            self.close()
+        self._pipe = pipe
+        _logger.debug("Running external command '%s' with '%r'", command, args)
+        self.start(command, args)
+
+    def _on_finished(self, exitcode, exitstatus):
+        """Check exit status and possibly process standard output on completion."""
+        if exitstatus != QProcess.NormalExit or exitcode != 0:
+            log.error(
+                "Error running external process '%s':\n%s",
+                self.program(),
+                str(self.readAllStandardError(), "utf-8").strip(),
+            )
+        elif self._pipe:
+            self._process_pipe()
+        else:
+            _logger.debug("Finished external process '%s' succesfully", self.program())
+
+    def _process_pipe(self) -> None:
+        """Open paths from stdout."""
+        _logger.debug("Opening paths from '%s'...", self.program())
+        stdout = str(self.readAllStandardOutput(), "utf-8")
+        try:
+            api.open(path for path in stdout.split("\n") if os.path.exists(path))
+            _logger.debug("... opened paths from pipe")
+            api.status.update()
+        except api.commands.CommandError:
+            log.warning("%s: No paths from pipe", self.program())
+
+    def _on_error(self, error):
+        log.error("Error running '%s': %s", self.program(), self.error_messages[error])
+
+    def _on_quit(self):
+        if self.state() == QProcess.Running:
+            log.warning(
+                "Decoupling external command '%s' with pid %d",
+                self.program(),
+                self.pid(),
+            )

--- a/vimiv/commands/misccommands.py
+++ b/vimiv/commands/misccommands.py
@@ -30,7 +30,7 @@ def log(level: str, message: List[str]):
         log_level = getattr(logging, level.upper())
     except AttributeError:
         raise api.commands.CommandError(f"Unknown log level '{level}'")
-    logging.log(log_level, " ".join(message))
+    utils.log.log(log_level, " ".join(message))
 
 
 @api.commands.register()

--- a/vimiv/completion/completer.py
+++ b/vimiv/completion/completer.py
@@ -28,6 +28,8 @@ class Completer(QObject):
     @api.objreg.register
     def __init__(self, commandline, completion):
         super().__init__()
+        completionmodels.init()
+
         self._proxy_model = None
         self._cmd = commandline
         self._completion = completion

--- a/vimiv/completion/completer.py
+++ b/vimiv/completion/completer.py
@@ -28,17 +28,21 @@ class Completer(QObject):
     @api.objreg.register
     def __init__(self, commandline, completion):
         super().__init__()
-        completionmodels.init()
 
         self._proxy_model = None
         self._cmd = commandline
         self._completion = completion
 
         self._completion.activated.connect(self._on_completion)
+        api.modes.COMMAND.first_entered.connect(self._init_models)
         api.modes.COMMAND.entered.connect(self._on_entered)
         api.modes.COMMAND.left.connect(self._on_left)
         self._cmd.textEdited.connect(self._on_text_changed)
         self._cmd.editingFinished.connect(self._on_editing_finished)
+
+    @utils.slot
+    def _init_models(self):
+        completionmodels.init()
 
     @utils.slot
     def _on_entered(self):

--- a/vimiv/config/__init__.py
+++ b/vimiv/config/__init__.py
@@ -7,12 +7,11 @@
 """Functions to store, read and change configurations."""
 
 import configparser
-import logging
 import os
 import sys
 from typing import Optional, Callable
 
-from vimiv.utils import xdg, customtypes
+from vimiv.utils import xdg, customtypes, log
 
 
 def parse_config(
@@ -43,7 +42,7 @@ def parse_config(
 
 
 def read_log_exception(
-    parser: configparser.ConfigParser, logger: logging.Logger, *files: str
+    parser: configparser.ConfigParser, logger: log.LazyLogger, *files: str
 ) -> None:
     """Read configuration files using parser logging any critical exceptions.
 

--- a/vimiv/gui/mainwindow.py
+++ b/vimiv/gui/mainwindow.py
@@ -8,7 +8,7 @@
 
 from typing import List
 
-from PyQt5.QtWidgets import QWidget, QStackedLayout, QGridLayout
+from PyQt5.QtWidgets import QWidget, QStackedWidget, QGridLayout
 
 from vimiv import api, utils
 from vimiv.completion import completer
@@ -46,7 +46,7 @@ class MainWindow(QWidget):
         grid = QGridLayout(self)
         grid.setSpacing(0)
         grid.setContentsMargins(0, 0, 0, 0)
-        grid.addLayout(ImageThumbnailLayout(), 0, 1, 1, 1)
+        grid.addWidget(ImageThumbnailStack(), 0, 1, 1, 1)
         grid.addWidget(Library(self), 0, 0, 1, 1)
         grid.addWidget(self._bar, 1, 0, 1, 2)
         # Add overlay widgets
@@ -142,8 +142,8 @@ class MainWindow(QWidget):
         self.setWindowTitle(api.status.evaluate(title))
 
 
-class ImageThumbnailLayout(QStackedLayout):
-    """QStackedLayout to toggle between image and thumbnail mode.
+class ImageThumbnailStack(QStackedWidget):
+    """QStackedWidget to toggle between image and thumbnail mode.
 
     Attributes:
         image: The image widget.
@@ -156,7 +156,6 @@ class ImageThumbnailLayout(QStackedLayout):
         self.thumbnail = ThumbnailView()
         self.addWidget(self.image)
         self.addWidget(self.thumbnail)
-        self.setCurrentWidget(self.image)
 
         api.modes.IMAGE.entered.connect(self._enter_image)
         api.modes.THUMBNAIL.entered.connect(self._enter_thumbnail)
@@ -164,8 +163,10 @@ class ImageThumbnailLayout(QStackedLayout):
         # possible to leave for the library
         api.modes.THUMBNAIL.left.connect(self._enter_image)
 
+    @utils.slot
     def _enter_thumbnail(self):
         self.setCurrentWidget(self.thumbnail)
 
+    @utils.slot
     def _enter_image(self):
         self.setCurrentWidget(self.image)

--- a/vimiv/imutils/_file_handler.py
+++ b/vimiv/imutils/_file_handler.py
@@ -150,7 +150,7 @@ class ImageFileHandler(QObject):
         """Reload the current image."""
         self._load(self._path, reload_only=True)
 
-    def _maybe_write(self, path):
+    def _maybe_write(self, path, parallel=True):
         """Write image to disk if requested and it has changed.
 
         Args:
@@ -161,12 +161,12 @@ class ImageFileHandler(QObject):
         elif self.transform.changed or (
             self.manipulate is not None and self.manipulate.changed
         ):
-            self.write_pixmap(self.current, path, path)
+            self.write_pixmap(self.current, path, original_path=path, parallel=parallel)
 
     @utils.slot
     def _on_quit(self):
         """Possibly write changes to disk on quit."""
-        self._maybe_write(self._path)
+        self._maybe_write(self._path, parallel=False)
 
     @utils.slot
     def _init_manipulate(self):

--- a/vimiv/imutils/imtransform.py
+++ b/vimiv/imutils/imtransform.py
@@ -48,6 +48,7 @@ class Transform:
 
         **count:** multiplier
         """
+        self._ensure_editable()
         angle = 90 * count * -1 if counter_clockwise else 90 * count
         self._rotation_angle = (self._rotation_angle + angle) % 360
         self._transform.rotate(angle)
@@ -64,6 +65,7 @@ class Transform:
         optional arguments:
             * ``--vertical``: Flip image vertically instead of horizontally.
         """
+        self._ensure_editable()
         # Vertical flip but image rotated by 90 degrees
         if vertical and self._rotation_angle % 180:
             self._transform.scale(-1, 1)
@@ -88,6 +90,10 @@ class Transform:
         self._handler().transformed = self._handler().original.transformed(
             self._transform, mode=Qt.SmoothTransformation
         )
+
+    def _ensure_editable(self):
+        if not self._handler().editable:
+            raise api.commands.CommandError("File format does not support transform")
 
     @property
     def changed(self):

--- a/vimiv/startup.py
+++ b/vimiv/startup.py
@@ -58,13 +58,11 @@ def setup_pre_app(argv: List[str]) -> argparse.Namespace:
     """
     args = parser.get_argparser().parse_args(argv)
     if args.version:
-        print(version.info())
+        print(version.info(), version.paths(), sep="\n\n")
         sys.exit(customtypes.Exit.success)
     init_directories(args)
     log.setup_logging(args.log_level, *args.debug)
     _logger.debug("Start: vimiv %s", " ".join(argv))
-    _logger.debug("%s\n", version.info())
-    _logger.debug("%s\n", version.paths())
     update_settings(args)
     trash_manager.init()
     return args

--- a/vimiv/startup.py
+++ b/vimiv/startup.py
@@ -21,7 +21,6 @@ from PyQt5.QtWidgets import QApplication
 
 from vimiv import app, api, parser, imutils, plugins, version, gui
 from vimiv.commands import runners, search
-from vimiv.completion import completionmodels
 from vimiv.config import configfile, keyfile, styles
 from vimiv.utils import xdg, crash_handler, log, trash_manager, customtypes
 
@@ -73,7 +72,6 @@ def setup_post_app(args: argparse.Namespace) -> None:
     api.working_directory.init()
     api.mark.watch()
     imutils.init()
-    completionmodels.init()
     init_ui(args)
     # Must be done after UI so the search signals are processed after the widgets have
     # been updated

--- a/vimiv/utils/__init__.py
+++ b/vimiv/utils/__init__.py
@@ -13,7 +13,7 @@ from abc import ABCMeta
 from contextlib import suppress
 from typing import Callable, Optional, List, Any, Iterator, Dict
 
-from PyQt5.QtCore import Qt, pyqtSlot, QRunnable, QThreadPool
+from PyQt5.QtCore import Qt, pyqtSlot, QRunnable, QThreadPool, QProcess
 from PyQt5.QtGui import QPixmap, QColor, QPainter
 
 from .customtypes import AnyT, FuncT, FuncNoneT, NumberT
@@ -343,6 +343,29 @@ def create_pixmap(
     width = height = pixmap.width() - 2 * frame_size
     painter.drawRect(x, y, width, height)
     return pixmap
+
+
+def run_qprocess(cmd: str, *args: str, cwd=None) -> str:
+    """Run a shell command synchronously using QProcess.
+
+    Args:
+        cmd: The command to run.
+        args: Any arguments passed to the command.
+        cwd: Directory of the command to run in.
+    Returns:
+        The starndard output of the command.
+    Raises:
+        OSError on failure.
+    """
+    process = QProcess()
+    if cwd is not None:
+        process.setWorkingDirectory(cwd)
+    process.start(cmd, args)
+    if not process.waitForFinished():
+        raise OSError("Error waiting for process")
+    if process.exitStatus() != QProcess.NormalExit:
+        raise OSError(str(process.readAllStandardError(), "utf-8").strip())
+    return str(process.readAllStandardOutput(), "utf-8").strip()
 
 
 class AbstractQObjectMeta(wrappertype, ABCMeta):

--- a/vimiv/utils/__init__.py
+++ b/vimiv/utils/__init__.py
@@ -63,6 +63,16 @@ def escape_html(text: str) -> str:
     return text.replace("<", "&lt;").replace(">", "&gt;")
 
 
+def escape_glob(text: str) -> str:
+    r"""Escape special characters prefixed by \ for glob using [character]."""
+
+    def escape_char(match):
+        char = match.group()[-1]
+        return f"[{char}]"
+
+    return re.sub(r"\\[\*\?\[\]]", escape_char, text)
+
+
 def contains_any(sequence: Iterable[AnyT], elems: Union[Iterable[AnyT], AnyT]) -> bool:
     """Return True if the sequence contains any of the elems."""
     if not sequence:

--- a/vimiv/utils/__init__.py
+++ b/vimiv/utils/__init__.py
@@ -364,8 +364,9 @@ def run_qprocess(cmd: str, *args: str, cwd=None) -> str:
     if not process.waitForFinished():
         raise OSError("Error waiting for process")
     if process.exitStatus() != QProcess.NormalExit:
-        raise OSError(str(process.readAllStandardError(), "utf-8").strip())
-    return str(process.readAllStandardOutput(), "utf-8").strip()
+        stderr = str(process.readAllStandardError(), "utf-8").strip()  # type: ignore
+        raise OSError(stderr)
+    return str(process.readAllStandardOutput(), "utf-8").strip()  # type: ignore
 
 
 class AbstractQObjectMeta(wrappertype, ABCMeta):

--- a/vimiv/utils/__init__.py
+++ b/vimiv/utils/__init__.py
@@ -11,7 +11,7 @@ import inspect
 import re
 from abc import ABCMeta
 from contextlib import suppress
-from typing import Callable, Optional, List, Any, Iterator, Dict, Iterable, Union
+from typing import Callable, Optional, List, Any, Iterator, Dict, Iterable, Union, cast
 
 from PyQt5.QtCore import Qt, pyqtSlot, QRunnable, QThreadPool, QProcess
 from PyQt5.QtGui import QPixmap, QColor, QPainter
@@ -78,10 +78,11 @@ def contains_any(sequence: Iterable[AnyT], elems: Union[Iterable[AnyT], AnyT]) -
     if not sequence:
         return False
     try:
+        elems = cast(Iterable[AnyT], elems)
         iter(elems)
         return bool(set(sequence) & set(elems))
     except TypeError:
-        return elems in sequence
+        return cast(AnyT, elems) in sequence
 
 
 def clamp(
@@ -263,7 +264,7 @@ class Pool:
             pool.clear()
 
 
-def flatten(list_of_lists: List[List[Any]]) -> List[Any]:
+def flatten(list_of_lists: Iterable[Iterable[AnyT]]) -> List[AnyT]:
     """Flatten a list of lists into a single list with all elements."""
     return [elem for sublist in list_of_lists for elem in sublist]
 

--- a/vimiv/utils/__init__.py
+++ b/vimiv/utils/__init__.py
@@ -11,7 +11,7 @@ import inspect
 import re
 from abc import ABCMeta
 from contextlib import suppress
-from typing import Callable, Optional, List, Any, Iterator, Dict
+from typing import Callable, Optional, List, Any, Iterator, Dict, Iterable, Union
 
 from PyQt5.QtCore import Qt, pyqtSlot, QRunnable, QThreadPool, QProcess
 from PyQt5.QtGui import QPixmap, QColor, QPainter
@@ -61,6 +61,17 @@ def strip_html(text: str) -> str:
 
 def escape_html(text: str) -> str:
     return text.replace("<", "&lt;").replace(">", "&gt;")
+
+
+def contains_any(sequence: Iterable[AnyT], elems: Union[Iterable[AnyT], AnyT]) -> bool:
+    """Return True if the sequence contains any of the elems."""
+    if not sequence:
+        return False
+    try:
+        iter(elems)
+        return bool(set(sequence) & set(elems))
+    except TypeError:
+        return elems in sequence
 
 
 def clamp(

--- a/vimiv/utils/debug.py
+++ b/vimiv/utils/debug.py
@@ -1,0 +1,58 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2019 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+"""Various utility functions for debugging and profiling."""
+
+import cProfile
+import functools
+from contextlib import contextmanager
+from datetime import datetime
+from pstats import Stats
+from typing import Any, Iterator
+
+from . import log
+from .customtypes import FuncT
+
+
+def timed(function: FuncT) -> FuncT:
+    """Decorator to time a function and log evaluation time."""
+
+    @functools.wraps(function)
+    def inner(*args: Any, **kwargs: Any) -> Any:
+        """Wrap decorated function and add timing."""
+        start = datetime.now()
+        return_value = function(*args, **kwargs)
+        elapsed_in_ms = (datetime.now() - start).total_seconds() * 1000
+        log.info("%s: took %.3f ms", function.__qualname__, elapsed_in_ms)
+        return return_value
+
+    # Mypy seems to disapprove the *args, **kwargs, but we just wrap the function
+    return inner  # type: ignore
+
+
+@contextmanager
+def profile(amount: int = 15) -> Iterator[None]:
+    """Contextmanager to profile code secions.
+
+    Starts a cProfile.Profile upon entry, disables it on exit and prints profiling
+    information.
+
+    Usage:
+        with profile(amount=10):
+            # your code to profile here
+            ...
+        # This is no longer profiled
+
+    Args:
+        amount: Number of lines to restrict the output to.
+    """
+    cprofile = cProfile.Profile()
+    cprofile.enable()
+    yield
+    cprofile.disable()
+    stats = Stats(cprofile)
+    stats.sort_stats("cumulative").print_stats(amount)
+    stats.sort_stats("time").print_stats(amount)

--- a/vimiv/utils/debug.py
+++ b/vimiv/utils/debug.py
@@ -8,8 +8,8 @@
 
 import cProfile
 import functools
+import time
 from contextlib import contextmanager
-from datetime import datetime
 from pstats import Stats
 from typing import Any, Iterator
 
@@ -23,9 +23,9 @@ def timed(function: FuncT) -> FuncT:
     @functools.wraps(function)
     def inner(*args: Any, **kwargs: Any) -> Any:
         """Wrap decorated function and add timing."""
-        start = datetime.now()
+        start = time.time()
         return_value = function(*args, **kwargs)
-        elapsed_in_ms = (datetime.now() - start).total_seconds() * 1000
+        elapsed_in_ms = (time.time() - start) * 1000
         log.info("%s: took %.3f ms", function.__qualname__, elapsed_in_ms)
         return return_value
 

--- a/vimiv/utils/log.py
+++ b/vimiv/utils/log.py
@@ -37,11 +37,6 @@ Three log handlers are currently used:
 * One to save the output in a log file located in
   ``$XDG_DATA_HOME/vimiv/vimiv.log``
 * One to print log messages to the statusbar (only for application-wide logger)
-
-Module Attributes:
-    statusbar_loghandler: Instance of the log handler connecting to the statusbar.
-
-    _module_loggers: Dictionary mapping module names to their corresponding logger.
 """
 
 import logging
@@ -56,33 +51,28 @@ from . import xdg
 
 _module_loggers: Dict[str, logging.Logger] = {}
 formatter = logging.Formatter(
-    "[{asctime}] {levelname:8} {name:20} {message}", datefmt="%H:%M:%S", style="{"
+    "[{relativeCreated:.0f}] {levelname:8} {name:20} {message}", style="{"
 )
 
 
-def debug(msg: str, *args, **kwargs) -> None:
-    """Log a debug message using the application-wide logger."""
-    logging.getLogger(f"<{vimiv.__name__}>").debug(msg, *args, **kwargs)
+def debug(msg: str, *args, **kwargs):
+    log(logging.DEBUG, msg, *args, **kwargs)
 
 
-def info(msg: str, *args, **kwargs) -> None:
-    """Log an info message using the application-wide logger."""
-    logging.getLogger(f"<{vimiv.__name__}>").info(msg, *args, **kwargs)
+def info(msg: str, *args, **kwargs):
+    log(logging.INFO, msg, *args, **kwargs)
 
 
-def warning(msg: str, *args, **kwargs) -> None:
-    """Log a warning message using the application-wide logger."""
-    logging.getLogger(f"<{vimiv.__name__}>").warning(msg, *args, **kwargs)
+def warning(msg: str, *args, **kwargs):
+    log(logging.WARNING, msg, *args, **kwargs)
 
 
-def error(msg: str, *args, **kwargs) -> None:
-    """Log an error message using the application-wide logger."""
-    logging.getLogger(f"<{vimiv.__name__}>").error(msg, *args, **kwargs)
+def error(msg: str, *args, **kwargs):
+    log(logging.ERROR, msg, *args, **kwargs)
 
 
-def critical(msg: str, *args, **kwargs) -> None:
-    """Log a critical message using the application-wide logger."""
-    logging.getLogger(f"<{vimiv.__name__}>").critical(msg, *args, **kwargs)
+def critical(msg: str, *args, **kwargs):
+    log(logging.CRITICAL, msg, *args, **kwargs)
 
 
 fatal = critical
@@ -96,9 +86,6 @@ def setup_logging(level: int, *debug_modules: str) -> None:
     $XDG_DATA_HOME/vimiv/vimiv.log. The application-wide logger sends messages with a
     level higher than debug to the statusbar in addition.
 
-    All log messages are always sent to the log file. The level for the console and
-    statusbar handlers depend on the level passed to this function.
-
     No logging should be performed in this function as the logging header comes directly
     after it.
 
@@ -106,29 +93,24 @@ def setup_logging(level: int, *debug_modules: str) -> None:
         level: Integer log level set for the console handler.
         debug_modules: Module names for which debug messages are forced to be shown.
     """
-    # Configure the root logger
+    # Enable logging at debug level in general
+    logging.getLogger().setLevel(logging.DEBUG)
+    # Configure handlers
     console_handler = logging.StreamHandler()
     console_handler.setFormatter(formatter)
     # mode=w creates a new file for every new vimiv process
     file_handler = logging.FileHandler(xdg.vimiv_data_dir("vimiv.log"), mode="w")
     file_handler.setFormatter(formatter)
-
-    root_logger = logging.getLogger()
-    root_logger.handlers = [file_handler, console_handler, statusbar_loghandler]
-
-    root_logger.setLevel(logging.DEBUG)
-    console_handler.setLevel(level)
-    statusbar_loghandler.setLevel(level)
-    # Setup debug logging for specific modules
+    # Configure app logger
+    _app_logger.level = level
+    _app_logger.handlers = [file_handler, console_handler, statusbar_loghandler]
+    # Setup debug logging for specific module loggers
     for name, logger in _module_loggers.items():
-        logger.setLevel(logging.DEBUG)  # Activate logger in general
-        for handler in logger.handlers:
-            handler.setLevel(logging.DEBUG if name in debug_modules else level)
-        # Append file handler here to ensure logging to one file
-        logger.handlers.append(file_handler)
+        logger.level = logging.DEBUG if name in debug_modules else level
+        logger.handlers = [console_handler, file_handler]
 
 
-def module_logger(name: str) -> logging.Logger:
+def module_logger(name: str) -> "LazyLogger":
     """Create a module-level logger.
 
     Module-level loggers log to the vimiv log-file as well as the console. The file
@@ -140,21 +122,51 @@ def module_logger(name: str) -> logging.Logger:
     Returns:
         The created logger object.
     """
-    name = name.replace("vimiv.", "")
+    return LazyLogger(name, is_module_logger=True)
 
-    if name in _module_loggers:
-        return _module_loggers[name]
 
-    console_handler = logging.StreamHandler()
-    console_handler.setFormatter(formatter)
+class LazyLogger:
+    """Logger class with lazy initialization of the logger object.
 
-    logger = logging.getLogger(f"<{name}>")
-    logger.setLevel(logging.CRITICAL)  # No logging before the module has been set up
-    logger.propagate = False
-    logger.handlers = [console_handler]
+    The class supports logging using a underlying logging.Logger object and provides the
+    regular, log, debug, ... functions. The object itself however is only created on an
+    is-needed basis.
+    """
 
-    _module_loggers[name] = logger
-    return logger
+    def __init__(self, name, is_module_logger=False):
+        self.handlers = []
+        self.level = logging.CRITICAL
+        self._logger = None
+        self._name = name.replace("vimiv.", "") if is_module_logger else name
+        if is_module_logger:
+            _module_loggers[self._name] = self
+
+    def log(self, level: int, msg: str, *args, **kwargs) -> None:
+        """Log a message creating the logger instance if needed."""
+        if level < self.level:
+            return
+        if self._logger is None:
+            self._logger = logging.getLogger(f"<{self._name}>")
+            self._logger.propagate = False
+            self._logger.handlers = self.handlers
+        self._logger.log(level, msg, *args, **kwargs)
+
+    def debug(self, msg: str, *args, **kwargs):
+        self.log(logging.DEBUG, msg, *args, **kwargs)
+
+    def info(self, msg: str, *args, **kwargs):
+        self.log(logging.INFO, msg, *args, **kwargs)
+
+    def warning(self, msg: str, *args, **kwargs):
+        self.log(logging.WARNING, msg, *args, **kwargs)
+
+    def error(self, msg: str, *args, **kwargs):
+        self.log(logging.ERROR, msg, *args, **kwargs)
+
+    def critical(self, msg: str, *args, **kwargs):
+        self.log(logging.CRITICAL, msg, *args, **kwargs)
+
+    fatal = critical
 
 
 class StatusbarLogHandler(QObject, logging.NullHandler):
@@ -173,4 +185,6 @@ class StatusbarLogHandler(QObject, logging.NullHandler):
             self.message.emit(record.levelname.lower(), record.message)
 
 
+_app_logger = LazyLogger(f"{vimiv.__name__}")
+log = _app_logger.log
 statusbar_loghandler = StatusbarLogHandler()

--- a/vimiv/utils/log.py
+++ b/vimiv/utils/log.py
@@ -45,7 +45,6 @@ Module Attributes:
 """
 
 import logging
-import logging.handlers
 from typing import Dict
 
 from PyQt5.QtCore import pyqtSignal, QObject

--- a/vimiv/utils/trash_manager.py
+++ b/vimiv/utils/trash_manager.py
@@ -37,8 +37,8 @@ _last_deleted: List[str] = []
 def init() -> None:
     """Create the necessary directories."""
     global _files_directory, _info_directory
-    _files_directory = os.path.join(xdg.user_data_dir(), "Trash/files")
-    _info_directory = os.path.join(xdg.user_data_dir(), "Trash/info")
+    _files_directory = xdg.user_data_dir("Trash", "files")
+    _info_directory = xdg.user_data_dir("Trash", "info")
     xdg.makedirs(_files_directory, _info_directory)
 
 

--- a/vimiv/version.py
+++ b/vimiv/version.py
@@ -11,7 +11,6 @@ Module Attributes:
 """
 
 import os
-import subprocess
 import sys
 from functools import lru_cache
 from typing import Optional
@@ -19,7 +18,7 @@ from typing import Optional
 from PyQt5.QtCore import QT_VERSION_STR, PYQT_VERSION_STR
 
 import vimiv
-from vimiv.utils import xdg
+from vimiv.utils import xdg, run_qprocess
 
 # Optional imports to check if these features are supported
 try:
@@ -89,17 +88,20 @@ def _git_info() -> Optional[str]:
     if not os.path.isdir(os.path.join(gitdir, ".git")):
         return None
 
-    def _get_cmd_out(*args: str) -> str:
-        """Return output of git shell command ran with args."""
-        out = subprocess.run(args, cwd=gitdir, stdout=subprocess.PIPE, check=True)
-        return out.stdout.decode("utf-8").strip()
-
     try:
-        commit = _get_cmd_out(
-            "git", "describe", "--match=NoMaTcH", "--always", "--abbrev=40", "--dirty"
+        commit = run_qprocess(
+            "git",
+            "describe",
+            "--match=NoMaTcH",
+            "--always",
+            "--abbrev=40",
+            "--dirty",
+            cwd=gitdir,
         )
-        date = _get_cmd_out("git", "show", "-s", "--format=%cd", "--date=short", "HEAD")
-    except (subprocess.CalledProcessError, OSError):
+        date = run_qprocess(
+            "git", "show", "-s", "--format=%cd", "--date=short", "HEAD", cwd=gitdir
+        )
+    except OSError:
         return None
     return f"Git: {commit} ({date})"
 


### PR DESCRIPTION
Various little tweaks to work on startup performance:
* Replace some python modules by the Qt equivalent
* Lazier logic in logging and manipulate
* fastentrypoints hack

Bugs found were fixed on the fly.

Ideas for further improvement:
* Lazy initialization of thumbnail mode
* Further import cleanup or even lazy imports, we still spend ~50 % of the startup time on imports