### PR TITLE
Mouse click and double click binding support

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,13 @@ All notable changes to vimiv are documented in this file.
 v0.5.0 (unreleased)
 -------------------
 
+Added:
+^^^^^^
+
+* Basic support for binding mouse clicks and double clicks to commands. The relevant
+  names are ``<button-NAME>`` and ``<double-button-NAME>``. Here ``NAME`` stands for the
+  name of the mouse button to bind, e.g. ``left``, ``middle`` or ``right``.
+
 Changed:
 ^^^^^^^^
 

--- a/docs/documentation/configuration/keybindings.rst
+++ b/docs/documentation/configuration/keybindings.rst
@@ -32,6 +32,19 @@ bind ``f : flip``. To remove a default keybinding, map the key to the special
    `the python documentation <https://docs.python.org/3/library/configparser.html#interpolation-of-values>`_
    for details.
 
+It is also possible to bind mouse clicks and double clicks. The relevant names are
+``<button-NAME>`` and ``<double-button-NAME>``. Here ``NAME`` stands for the name of the
+mouse button to bind, e.g. ``left``, ``middle`` or ``right``.
+
+.. hint::
+
+    If you want to figure out the name of a specific key or mouse button, run vimiv with
+    ``--debug gui.eventhandler``. You can find the corresponding name in the first
+    output line after pressing/clicking it. For example, when pressing the ``q`` key,
+    you would retrieve something along::
+
+        DEBUG    <gui.eventhandler>   EventHandlerMixin: handling q for mode library
+
 The following table lists all default keybindings.
 
 .. include:: keybindings_table.rstsrc

--- a/tests/end2end/features/misc/test_keyhint_bdd.py
+++ b/tests/end2end/features/misc/test_keyhint_bdd.py
@@ -29,7 +29,7 @@ def update_keyhint():
     yield
     api.settings.keyhint.delay.value = delay
     api.settings.keyhint.timeout.value = timeout
-    eventhandler.KeyHandler.partial_handler.clear_keys()
+    eventhandler.EventHandler.partial_handler.clear_keys()
 
 
 @bdd.when("I wait for the keyhint widget")
@@ -40,7 +40,9 @@ def wait_for_keyhint_widget(keyhint, qtbot):
 
 @bdd.when("I wait for the keyhint widget timeout")
 def wait_for_keyhint_widget_timeout(qtbot):
-    with qtbot.waitSignal(eventhandler.KeyHandler.partial_handler.partial_cleared, 500):
+    with qtbot.waitSignal(
+        eventhandler.EventHandler.partial_handler.partial_cleared, 500
+    ):
         pass
 
 

--- a/tests/end2end/features/misc/test_keyhint_bdd.py
+++ b/tests/end2end/features/misc/test_keyhint_bdd.py
@@ -29,7 +29,7 @@ def update_keyhint():
     yield
     api.settings.keyhint.delay.value = delay
     api.settings.keyhint.timeout.value = timeout
-    eventhandler.EventHandler.partial_handler.clear_keys()
+    eventhandler.EventHandlerMixin.partial_handler.clear_keys()
 
 
 @bdd.when("I wait for the keyhint widget")
@@ -41,7 +41,7 @@ def wait_for_keyhint_widget(keyhint, qtbot):
 @bdd.when("I wait for the keyhint widget timeout")
 def wait_for_keyhint_widget_timeout(qtbot):
     with qtbot.waitSignal(
-        eventhandler.EventHandler.partial_handler.partial_cleared, 500
+        eventhandler.EventHandlerMixin.partial_handler.partial_cleared, 500
     ):
         pass
 

--- a/tests/unit/gui/test_eventhandler.py
+++ b/tests/unit/gui/test_eventhandler.py
@@ -8,8 +8,8 @@
 
 import pytest
 
-from PyQt5.QtCore import QEvent, Qt
-from PyQt5.QtGui import QKeyEvent
+from PyQt5.QtCore import QEvent, Qt, QPoint
+from PyQt5.QtGui import QKeyEvent, QMouseEvent
 
 from vimiv.gui import eventhandler
 
@@ -78,3 +78,24 @@ def test_keyevent_to_string_for_only_modifier():
 def test_keyevent_to_string_for_colon():
     event = QKeyEvent(QEvent.KeyPress, Qt.Key_Colon, Qt.NoModifier, ":")
     assert eventhandler.keyevent_to_string(event) == "<colon>"
+
+
+def test_mouse_event_to_string():
+    event = _create_mouse_event(Qt.LeftButton)
+    assert eventhandler.mouseevent_to_string(event) == "<button-left>"
+
+
+def test_mouse_event_to_string_unnamed_button():
+    event = _create_mouse_event(Qt.ExtraButton7)
+    assert eventhandler.mouseevent_to_string(event) == f"<button-{Qt.ExtraButton7:d}>"
+
+
+def test_mouse_event_to_string_with_modifier():
+    event = _create_mouse_event(Qt.LeftButton, Qt.ControlModifier)
+    assert eventhandler.mouseevent_to_string(event) == "<ctrl><button-left>"
+
+
+def _create_mouse_event(button, modifier=Qt.NoModifier):
+    return QMouseEvent(
+        QEvent.MouseButtonPress, QPoint(0, 0), QPoint(0, 0), button, button, modifier
+    )

--- a/vimiv/gui/commandline.py
+++ b/vimiv/gui/commandline.py
@@ -14,10 +14,10 @@ from PyQt5.QtWidgets import QLineEdit
 from vimiv import api, utils
 from vimiv.commands import history, argtypes, runners, search
 from vimiv.config import styles
-from .eventhandler import KeyHandler
+from .eventhandler import EventHandler
 
 
-class CommandLine(KeyHandler, QLineEdit):
+class CommandLine(EventHandler, QLineEdit):
     """Commandline widget in the bar.
 
     Class Attributes:

--- a/vimiv/gui/commandline.py
+++ b/vimiv/gui/commandline.py
@@ -14,10 +14,10 @@ from PyQt5.QtWidgets import QLineEdit
 from vimiv import api, utils
 from vimiv.commands import history, argtypes, runners, search
 from vimiv.config import styles
-from .eventhandler import EventHandler
+from .eventhandler import EventHandlerMixin
 
 
-class CommandLine(EventHandler, QLineEdit):
+class CommandLine(EventHandlerMixin, QLineEdit):
     """Commandline widget in the bar.
 
     Class Attributes:

--- a/vimiv/gui/eventhandler.py
+++ b/vimiv/gui/eventhandler.py
@@ -161,10 +161,6 @@ class EventHandler:
         return EventHandler.partial_handler.get_keys()
 
 
-def on_mouse_click(event):
-    raise NotImplementedError
-
-
 def keyevent_to_string(event):
     """Convert QKeyEvent to meaningful string.
 

--- a/vimiv/gui/eventhandler.py
+++ b/vimiv/gui/eventhandler.py
@@ -65,7 +65,7 @@ class TempKeyStorage(QTimer):
 
 
 class PartialHandler(QObject):
-    """Handle partial matches and counts for KeyHandler.
+    """Handle partial matches and counts for EventHandler.
 
     Attributes:
         count: TempKeyStorage for counts.
@@ -97,8 +97,8 @@ class PartialHandler(QObject):
         return self.count.text + self.keys.text
 
 
-class KeyHandler:
-    """Deal with keyPressEvent events for gui widgets.
+class EventHandler:
+    """Deal with key and mouse events for gui widgets.
 
     This class is used by gui classes as first parent, second being some
     QWidget, to handle the keyPressEvent slot.
@@ -158,7 +158,7 @@ class KeyHandler:
     @api.status.module("{keys}")
     def unprocessed_keys():
         """Unprocessed keys that were pressed."""
-        return KeyHandler.partial_handler.get_keys()
+        return EventHandler.partial_handler.get_keys()
 
 
 def on_mouse_click(event):

--- a/vimiv/gui/eventhandler.py
+++ b/vimiv/gui/eventhandler.py
@@ -108,11 +108,7 @@ class EventHandler:
     partial_handler = PartialHandler()
 
     def keyPressEvent(self, event: QKeyEvent):
-        """Handle key press event for the widget.
-
-        Args:
-            event: QKeyEvent that activated the keyPressEvent.
-        """
+        """Handle key press event for the widget."""
         api.status.clear("KeyPressEvent")
         try:
             keyname = keyevent_to_string(event)
@@ -134,6 +130,22 @@ class EventHandler:
         elif not self._process_event(keyname, mode=mode):
             # super() is the parent Qt widget
             super().keyPressEvent(event)  # type: ignore  # pylint: disable=no-member
+
+    def mousePressEvent(self, event: QMouseEvent):
+        """Handle mouse press event for the widget."""
+        api.status.clear("MousePressEvent")
+        if not self._process_event(mouseevent_to_string(event)):
+            # super() is the parent Qt widget
+            super().mousePressEvent(event)  # type: ignore  # pylint: disable=no-member
+
+    def mouseDoubleClickEvent(self, event: QMouseEvent):
+        """Handle mouse press event for the widget."""
+        api.status.clear("MouseDoubleClickEvent")
+        if not self._process_event(mouseevent_to_string(event, prefix="double-button")):
+            # super() is the parent Qt widget
+            super().mouseDoubleClickEvent(  # type: ignore  # pylint: disable=no-member
+                event
+            )
 
     def _process_event(self, name: str, mode: api.modes.Mode = None) -> bool:
         """Process event by name.

--- a/vimiv/gui/image.py
+++ b/vimiv/gui/image.py
@@ -24,7 +24,7 @@ from vimiv import api, imutils, utils
 from vimiv.commands.argtypes import Direction, ImageScale, ImageScaleFloat, Zoom
 from vimiv.config import styles
 
-from .eventhandler import KeyHandler
+from .eventhandler import EventHandler
 
 # We need the check as svg support is optional
 try:
@@ -36,7 +36,7 @@ except ImportError:
 INF = float("inf")
 
 
-class ScrollableImage(KeyHandler, QGraphicsView):
+class ScrollableImage(EventHandler, QGraphicsView):
     """QGraphicsView to display Image or Animation.
 
     Connects to the *_loaded signals to create the appropriate child widget.

--- a/vimiv/gui/image.py
+++ b/vimiv/gui/image.py
@@ -24,7 +24,7 @@ from vimiv import api, imutils, utils
 from vimiv.commands.argtypes import Direction, ImageScale, ImageScaleFloat, Zoom
 from vimiv.config import styles
 
-from .eventhandler import EventHandler
+from .eventhandler import EventHandlerMixin
 
 # We need the check as svg support is optional
 try:
@@ -36,7 +36,7 @@ except ImportError:
 INF = float("inf")
 
 
-class ScrollableImage(EventHandler, QGraphicsView):
+class ScrollableImage(EventHandlerMixin, QGraphicsView):
     """QGraphicsView to display Image or Animation.
 
     Connects to the *_loaded signals to create the appropriate child widget.

--- a/vimiv/gui/keyhint_widget.py
+++ b/vimiv/gui/keyhint_widget.py
@@ -13,7 +13,7 @@ from PyQt5.QtWidgets import QLabel, QSizePolicy
 
 from vimiv import api, utils
 from vimiv.config import styles
-from .eventhandler import KeyHandler
+from .eventhandler import EventHandler
 
 
 class KeyhintWidget(QLabel):
@@ -53,8 +53,8 @@ class KeyhintWidget(QLabel):
         self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Minimum)
         self.setTextFormat(Qt.RichText)
 
-        KeyHandler.partial_handler.partial_matches.connect(self._on_partial_matches)
-        KeyHandler.partial_handler.partial_cleared.connect(self._on_partial_cleared)
+        EventHandler.partial_handler.partial_matches.connect(self._on_partial_matches)
+        EventHandler.partial_handler.partial_cleared.connect(self._on_partial_cleared)
         api.settings.keyhint.delay.changed.connect(self._on_delay_changed)
 
         self.hide()

--- a/vimiv/gui/keyhint_widget.py
+++ b/vimiv/gui/keyhint_widget.py
@@ -13,7 +13,7 @@ from PyQt5.QtWidgets import QLabel, QSizePolicy
 
 from vimiv import api, utils
 from vimiv.config import styles
-from .eventhandler import EventHandler
+from .eventhandler import EventHandlerMixin
 
 
 class KeyhintWidget(QLabel):
@@ -53,8 +53,9 @@ class KeyhintWidget(QLabel):
         self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Minimum)
         self.setTextFormat(Qt.RichText)
 
-        EventHandler.partial_handler.partial_matches.connect(self._on_partial_matches)
-        EventHandler.partial_handler.partial_cleared.connect(self._on_partial_cleared)
+        partial_handler = EventHandlerMixin.partial_handler
+        partial_handler.partial_matches.connect(self._on_partial_matches)
+        partial_handler.partial_cleared.connect(self._on_partial_cleared)
         api.settings.keyhint.delay.changed.connect(self._on_delay_changed)
 
         self.hide()

--- a/vimiv/gui/library.py
+++ b/vimiv/gui/library.py
@@ -21,7 +21,7 @@ from vimiv.utils import files, strip_html, clamp, wrap_style_span, log
 from . import eventhandler, synchronize
 
 
-class Library(eventhandler.KeyHandler, widgets.FlatTreeView):
+class Library(eventhandler.EventHandler, widgets.FlatTreeView):
     """Library widget.
 
     Attributes:

--- a/vimiv/gui/library.py
+++ b/vimiv/gui/library.py
@@ -21,7 +21,7 @@ from vimiv.utils import files, strip_html, clamp, wrap_style_span, log
 from . import eventhandler, synchronize
 
 
-class Library(eventhandler.EventHandler, widgets.FlatTreeView):
+class Library(eventhandler.EventHandlerMixin, widgets.FlatTreeView):
     """Library widget.
 
     Attributes:

--- a/vimiv/gui/manipulate.py
+++ b/vimiv/gui/manipulate.py
@@ -16,10 +16,10 @@ from vimiv import api, utils, imutils
 from vimiv.config import styles
 from vimiv.imutils import immanipulate
 from vimiv.utils import slot
-from .eventhandler import EventHandler
+from .eventhandler import EventHandlerMixin
 
 
-class Manipulate(EventHandler, QTabWidget):
+class Manipulate(EventHandlerMixin, QTabWidget):
     """Manipulate widget displaying progress bars and labels.
 
     Attributes:

--- a/vimiv/gui/manipulate.py
+++ b/vimiv/gui/manipulate.py
@@ -16,10 +16,10 @@ from vimiv import api, utils, imutils
 from vimiv.config import styles
 from vimiv.imutils import immanipulate
 from vimiv.utils import slot
-from .eventhandler import KeyHandler
+from .eventhandler import EventHandler
 
 
-class Manipulate(KeyHandler, QTabWidget):
+class Manipulate(EventHandler, QTabWidget):
     """Manipulate widget displaying progress bars and labels.
 
     Attributes:

--- a/vimiv/gui/thumbnail.py
+++ b/vimiv/gui/thumbnail.py
@@ -24,7 +24,7 @@ from . import eventhandler, synchronize
 _logger = log.module_logger(__name__)
 
 
-class ThumbnailView(eventhandler.EventHandler, QListWidget):
+class ThumbnailView(eventhandler.EventHandlerMixin, QListWidget):
     """Thumbnail widget.
 
     Attributes:

--- a/vimiv/gui/thumbnail.py
+++ b/vimiv/gui/thumbnail.py
@@ -24,7 +24,7 @@ from . import eventhandler, synchronize
 _logger = log.module_logger(__name__)
 
 
-class ThumbnailView(eventhandler.KeyHandler, QListWidget):
+class ThumbnailView(eventhandler.EventHandler, QListWidget):
     """Thumbnail widget.
 
     Attributes:


### PR DESCRIPTION
Adds support for binding mouse clicks and mouse double clicks to commands. This works the same way as for keybindings, the relevant names are:
* `<button-NAME>`
* `<double-button-NAME>`
where `NAME` is the name of the mouse button, e.g. `left`.

This solves parts of #47 but does not add any mouse bindings.