### PR TITLE
Better help with migrating from gtk

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,11 @@ Added:
   separated by a comma. Currently only the ``cr2`` raw format is implemented which
   requires `qt raw <https://gitlab.com/mardy/qtraw>`_.
 * Path completion for the ``:mark`` command.
+* Some help for migrating from the gtk version:
+
+  * All gtk directories are backed up.
+  * The tag files are migrated.
+  * A welcome pop-up linking the :ref:`documentation <migrating>` is displayed.
 
 Changed:
 ^^^^^^^^

--- a/docs/documentation/commands.rst
+++ b/docs/documentation/commands.rst
@@ -1,3 +1,5 @@
+.. _commands:
+
 ########
 Commands
 ########

--- a/docs/documentation/configuration/style.rst
+++ b/docs/documentation/configuration/style.rst
@@ -1,3 +1,5 @@
+.. _styles:
+
 Style
 =====
 There are two default styles: a light and a dark one. They are both based upon

--- a/docs/documentation/index.rst
+++ b/docs/documentation/index.rst
@@ -11,6 +11,7 @@ The following documents are available:
    commands
    configuration/index
    contributing
+   migrating
 
 .. include:: getting_help.rst
 

--- a/docs/documentation/migrating.rst
+++ b/docs/documentation/migrating.rst
@@ -1,0 +1,157 @@
+Migrating from the Gtk Version to Qt
+====================================
+
+Some time ago I decided to rewrite vimiv completely in Qt because I was not happy with
+the Gtk version and the source code. For some more details, you can check
+`the corresponding issue on github <https://github.com/karlch/vimiv/issues/61>`_.
+
+Besides the maintenance improvements for me and cleaner code + tests which should make
+contributing easier, there were a number of major improvements and new feature
+including:
+
+* Much better performance, especially in thumbnail mode.
+* Complete customization with :ref:`styles <styles>`.
+* The possibility to bind key sequences like ``gg``.
+* A keyhint widget popping up after 500 ms to help you with finding the missing part of
+  key sequences.
+* Customization of the statusbar with :ref:`status modules<statusbar>`.
+* A plugin system enabling print support.
+* Automatic reload when the image / directory was changed from the outside.
+* Better synchronization between the various modes.
+
+Overall I hope that the improvements of the Qt version outweigh the inconvenience of a
+lot of breaking changes. The following sections summarize some of the major changes to
+give you a feeling of what will break when migrating. If you have any questions or need
+help, please do not hesitate to open an
+`issue on github <https://github.com/karlch/vimiv-qt/issues/>`_ or
+`contact me directly <karlch@protonmail.com>`_.
+
+.. contents::
+
+Major Changes
+-------------
+
+Key Sequences
+^^^^^^^^^^^^^
+
+It is now possible to bind key sequences like ``gg``. This possibility changed the
+default bindings for switching modes. The library is entered with ``gl`` and toggled
+with ``tl``. Same holds for thumbnail and manipulate mode with ``t`` as suffix instead
+of ``l``. Image mode can only be entered with ``gi``, not toggled, as it is the "normal"
+mode of vimiv. To help you with partial matches, a keyhint widget pops up 500 ms after
+the first key press.
+
+Keybinding Names
+^^^^^^^^^^^^^^^^
+
+* Naming of modifiers has changed to account for key sequences and for consistency.
+
+  * ``Shift+`` is largely replaced by the actual character, e.g. ``Shift+w`` becomes
+    ``W``. Where this is not possible, use ``<shift>``, e.g. ``<shift><tab>``.
+  * ``^q`` becomes ``<ctrl>q``.
+  * ``Alt+l`` becomes ``<alt>l``.
+* If keys have a string representation, this is their keybinding. So ``+``, ``/`` and so
+  forth are the valid keybindings, not ``plus`` or ``slash``. Only exception is
+  ``<colon>`` for ``:`` as this is a valid separator for the configuration file.
+* Special keys with no string representation are always surrounded in ``<>`` brackets
+  and are lower-case.  Therefore ``Escape`` becomes ``<escape>``, ``Return``
+  ``<return>`` and so forth.
+
+.. hint::
+
+    If you want to figure out the name of a specific key or mouse button, run vimiv with
+    ``--debug gui.eventhandler``. You can find the corresponding name in the first
+    output line after pressing/clicking it. For example, when pressing the ``q`` key,
+    you would retrieve something along::
+
+        DEBUG    <gui.eventhandler>   EventHandlerMixin: handling q for mode library
+
+Command Names
+^^^^^^^^^^^^^
+
+Command handling has been redesigned for better scalability. This means that many names
+and/or arguments have changed. You can find
+:ref:`a complete overview of the current commands <commands>` in the documentation.
+If you have trouble finding out how a previous command changed or are missing something,
+please do not hesitate to open an
+`issue on github <https://github.com/karlch/vimiv-qt/issues/>`_ or
+`contact me directly <karlch@protonmail.com>`_.
+
+Settings
+^^^^^^^^
+
+The rewrite has been used to rethink various settings. I hope the names are now clearer
+and the handling is more consistent. This is a brief overview of what happened to the
+settings that were available in the gtk version. The word before the ``.`` indicates the
+section, the one after is the option name.
+
+.. table:: Overview of settings changes
+    :widths: 30 70
+
+    ============================= ===========
+    Setting                       Change
+    ============================= ===========
+    general.start_fullscreen      Removed, use the ``--fullscreen`` command line flag instead
+    general.start_slideshow       Removed, use ``--command slideshow`` instead
+    general.slideshow_delay       Moved to ``slideshow.delay``
+    general.shuffle               Remains the same
+    general.display_bar           Moved to ``statusbar.show``
+    general.default_thumbsize     Moved to ``thumbnail.size``
+    general.geometry              Removed, use ``--geometry`` instead
+    general.recursive             Removed, use the corresponding shell tools instead
+    general.rescale_svg           Removed, this is always done as it is now performant
+    general.overzoom              Moved to ``image.overzoom``
+    general.search_case_sensitive Moved to ``search.ignore_case``
+    general.incsearch             Moved to ``search.incremental``
+    general.copy_to_primary       Removed, the ``:copy-name`` command has an optional ``--primary`` flag instead
+    general.commandline_padding   Removed, use :ref:`styles <styles>` instead
+    general.thumb_padding         Removed, use :ref:`styles <styles>` instead
+    general.completion_height     Removed, use :ref:`styles <styles>` instead
+    general.play_animations       Moved to ``image.autoplay``
+    |
+    library.start_show_library    Moved to ``general.startup_library``
+    library.library_width         Removed, use :ref:`styles <styles>` instead
+    library.expand_lib            Removed, please open an issue if you miss this feature
+    library.border_width          Removed, use :ref:`styles <styles>` instead
+    library.markup                Removed, use :ref:`styles <styles>` instead
+    library.show_hidden           Remains the same
+    library.desktop_start_dir     Removed, please open an issue if you miss this feature
+    library.file_check_amount     Removed, we use the total number of files instead
+    library.tilde_in_statusbar    Moved to ``statusbar.collapse_home``
+    |
+    edit.autosave_images          Moved to ``image.autowrite``
+    ============================= ===========
+
+Marks and Tags
+^^^^^^^^^^^^^^
+
+Your tag files are migrated and should continue working as is. However, the behaviour of
+marks and tags has changed in some ways.
+
+* The ``:mark`` command can now take any number of paths as argument. This includes
+  typical shell wildcards and replaces the unorthodox behaviour of ``:mark-between``. To
+  mark a list of images, pass them or the corresponding wildcard to ``:mark``, e.g.::
+
+      :mark images_1*.jpg
+
+* The ``mark`` command now toggles the mark status of the paths passed. The default
+  binding ``m`` is therefore equivalent to the old ``:mark_toggle`` bound to ``M``.
+* Calling ``:tag-load`` now marks all images in the tag instead of loading them into
+  image mode. To open them in image mode, call ``:open %m`` afterwards.
+
+Manipulate
+^^^^^^^^^^
+
+Navigation in manipulate mode has been redesigned for better scalability. The one letter
+shortcuts to manipulation names were unfortunately rather limiting...
+
+* To focus the next/previous manipulation in the current tab, use ``n``/``p``.
+* To focus the next/previous tab, use ``<tab>``/``<shift><tab>``.
+
+Migration
+---------
+
+When you first launch the qt version and you had a local ``vimivrc`` of the gtk version:
+
+* All ``vimiv`` folders are backed up to ``vimiv-gtk-backup``.
+* Your tags are migrated accordingly.

--- a/docs/documentation/migrating.rst
+++ b/docs/documentation/migrating.rst
@@ -155,3 +155,4 @@ When you first launch the qt version and you had a local ``vimivrc`` of the gtk 
 
 * All ``vimiv`` folders are backed up to ``vimiv-gtk-backup``.
 * Your tags are migrated accordingly.
+* A welcome pop-up with the most important information is shown.

--- a/docs/documentation/migrating.rst
+++ b/docs/documentation/migrating.rst
@@ -1,3 +1,5 @@
+.. _migrating:
+
 Migrating from the Gtk Version to Qt
 ====================================
 

--- a/tests/end2end/features/misc/migration_popup.feature
+++ b/tests/end2end/features/misc/migration_popup.feature
@@ -1,0 +1,6 @@
+Feature: Welcome-to-qt command with pop up window
+
+    Scenario: Show welcome pop up
+        Given I start vimiv
+        When I run welcome-to-qt
+        Then the pop up 'vimiv - welcome to qt' should be displayed

--- a/tests/end2end/features/misc/test_migration_popup_bdd.py
+++ b/tests/end2end/features/misc/test_migration_popup_bdd.py
@@ -1,0 +1,10 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2019 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+import pytest_bdd as bdd
+
+
+bdd.scenarios("migration_popup.feature")

--- a/tests/unit/utils/test_migration.py
+++ b/tests/unit/utils/test_migration.py
@@ -1,0 +1,82 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2019 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+"""Tests for vimiv.utils.migration."""
+
+import os
+
+import pytest
+
+from vimiv.utils import migration, xdg
+
+
+TAGFILE_NAME = "tagfile"
+
+
+@pytest.fixture
+def mock_gtk_version(tmpdir, monkeypatch):
+    """Fixture to mock the xdg directories and fill them with gtk-version-like files."""
+    for name in ("cache", "config", "data"):
+        monkeypatch.setenv(f"XDG_{name.upper()}_HOME", str(tmpdir.mkdir(name)))
+
+    for directory in (
+        xdg.vimiv_config_dir(),
+        xdg.vimiv_cache_dir(),
+        xdg.vimiv_data_dir(),
+    ):
+        assert "home" not in directory, "patching the xdg directories failed"
+        os.makedirs(directory)
+
+    for basename in ("vimivrc", "keys.conf"):
+        abspath = xdg.vimiv_config_dir(basename)
+        with open(abspath, "w") as f:
+            f.write("option: value\n")
+
+    tag_dir = xdg.vimiv_data_dir("Tags")
+    os.mkdir(tag_dir)
+    tag_file = os.path.join(tag_dir, TAGFILE_NAME)
+    with open(tag_file, "w") as f:
+        for i in range(10):
+            f.write("test_{i:02d}.jpg\n")
+
+    yield
+
+
+@pytest.fixture
+def mock_backup(mocker):
+    """Fixture to mock the backup functions."""
+    mocker.patch.object(migration, "backup")
+    mocker.patch.object(migration, "migrate_tags")
+    yield
+
+
+def test_run(mock_gtk_version, mock_backup):
+    migration.run()
+    migration.backup.assert_called_once()
+    migration.migrate_tags.assert_called_once()
+
+
+def test_do_not_run(mocker, mock_backup):
+    mocker.patch.object(migration, "gtk_version_installed", return_value=False)
+    migration.run()
+    migration.backup.assert_not_called()
+
+
+def test_backup_directories(mock_gtk_version):
+    migration.backup()
+    gtk_name = "vimiv-gtk-backup"
+    for directory in (
+        xdg.user_config_dir(gtk_name),
+        xdg.user_cache_dir(gtk_name),
+        xdg.user_data_dir(gtk_name),
+    ):
+        assert os.path.isdir(directory)
+
+
+def test_migrate_tags(mock_gtk_version):
+    migration.migrate_tags(xdg.vimiv_data_dir())
+    assert os.path.isdir(xdg.vimiv_data_dir("tags"))
+    assert os.path.isfile(xdg.vimiv_data_dir("tags", TAGFILE_NAME))

--- a/tests/unit/utils/test_migration.py
+++ b/tests/unit/utils/test_migration.py
@@ -43,6 +43,7 @@ def mock_gtk_version(tmpdir, monkeypatch):
             f.write("test_{i:02d}.jpg\n")
 
     yield
+    migration.WelcomePopUp.gtk_installed = False
 
 
 @pytest.fixture
@@ -57,12 +58,14 @@ def test_run(mock_gtk_version, mock_backup):
     migration.run()
     migration.backup.assert_called_once()
     migration.migrate_tags.assert_called_once()
+    assert migration.WelcomePopUp.gtk_installed
 
 
 def test_do_not_run(mocker, mock_backup):
     mocker.patch.object(migration, "gtk_version_installed", return_value=False)
     migration.run()
     migration.backup.assert_not_called()
+    assert not migration.WelcomePopUp.gtk_installed
 
 
 def test_backup_directories(mock_gtk_version):

--- a/vimiv/gui/mainwindow.py
+++ b/vimiv/gui/mainwindow.py
@@ -11,6 +11,7 @@ from typing import List
 from PyQt5.QtWidgets import QWidget, QStackedWidget, QGridLayout
 
 from vimiv import api, utils
+from vimiv.utils import migration
 
 # Import all GUI widgets used to create the full main window
 from .bar import Bar
@@ -98,6 +99,11 @@ class MainWindow(QWidget):
             * ``--columns``: Number of columns to split the bindings in.
         """
         KeybindingsPopUp(columns, parent=self)
+
+    @api.commands.register()
+    def welcome_to_qt(self):
+        """Show a pop-up with a welcome message for users coming from gtk."""
+        migration.WelcomePopUp(parent=self)
 
     def resizeEvent(self, event):
         """Update resize event to resize overlays and library.

--- a/vimiv/startup.py
+++ b/vimiv/startup.py
@@ -23,7 +23,7 @@ from PyQt5.QtWidgets import QApplication
 from vimiv import app, api, parser, imutils, plugins, version, gui
 from vimiv.commands import runners, search
 from vimiv.config import configfile, keyfile, styles
-from vimiv.utils import xdg, crash_handler, log, trash_manager, customtypes
+from vimiv.utils import xdg, crash_handler, log, trash_manager, customtypes, migration
 
 # Must be imported to create the commands using the decorators
 from vimiv.commands import misccommands  # pylint: disable=unused-import
@@ -60,6 +60,7 @@ def setup_pre_app(argv: List[str]) -> argparse.Namespace:
     if args.version:
         print(version.info(), version.paths(), sep="\n\n")
         sys.exit(customtypes.Exit.success)
+    migration.run()
     init_directories(args)
     log.setup_logging(args.log_level, *args.debug)
     _logger.debug("Start: vimiv %s", " ".join(argv))

--- a/vimiv/startup.py
+++ b/vimiv/startup.py
@@ -130,6 +130,7 @@ def init_ui(args: argparse.Namespace) -> None:
     y = screen_geometry.y() + (screen_geometry.height() - geometry.height()) // 2
     mw.setGeometry(x, y, geometry.width(), geometry.height())
     mw.show()
+    migration.run_welcome_popup(parent=mw)
 
 
 def update_settings(args: argparse.Namespace) -> None:

--- a/vimiv/utils/migration.py
+++ b/vimiv/utils/migration.py
@@ -1,0 +1,69 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2019 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+"""Tools to help with migration from the deprecated gtk version."""
+
+import os
+import shutil
+from typing import NamedTuple, Optional, List
+
+from . import xdg
+
+
+class XdgDirectories(NamedTuple):
+    """Storage class for the relevant vimiv xdg directories."""
+
+    cache_dir: Optional[str]
+    config_dir: Optional[str]
+    data_dir: Optional[str]
+
+
+def gtk_version_installed() -> bool:
+    """Check if the gtk version is installed."""
+    gtk_config_path = xdg.vimiv_config_dir("vimivrc")
+    return os.path.isfile(gtk_config_path)
+
+
+def run() -> None:
+    """Run backup and migration if the gtk version is installed."""
+    if not gtk_version_installed():
+        return
+    print("Trying to migrate existing gtk configuration...")
+    backup_dirs = backup()
+    if backup_dirs.data_dir is not None:  # Error creating backup
+        migrate_tags(backup_dirs.data_dir)
+
+
+def backup() -> XdgDirectories:
+    """Create a backup of all gtk vimiv directories."""
+    backup_str = "-gtk-backup"
+    backup_dirs: List[Optional[str]] = []
+    for dirname in (
+        xdg.vimiv_cache_dir(),
+        xdg.vimiv_config_dir(),
+        xdg.vimiv_data_dir(),
+    ):
+        try:
+            backup_dirname = dirname + backup_str
+            shutil.move(dirname, backup_dirname)
+            print(f"... Created backup of '{dirname}' at '{backup_dirname}'")
+            backup_dirs.append(backup_dirname)
+        except OSError as e:
+            print(f"... Error backing up {dirname}: {e}")
+            backup_dirs.append(None)
+    return XdgDirectories(*backup_dirs)
+
+
+def migrate_tags(gtk_data_dir: str) -> None:
+    """Migrate gtk tag file to the new path.
+
+    Args:
+        gtk_data_dir: Path to the old gtk data directory.
+    """
+    gtk_tagdir = os.path.join(gtk_data_dir, "Tags")
+    if os.path.isdir(gtk_tagdir):
+        shutil.copytree(gtk_tagdir, xdg.vimiv_data_dir("tags"))
+        print("... Moved tag directory")

--- a/vimiv/utils/migration.py
+++ b/vimiv/utils/migration.py
@@ -10,6 +10,11 @@ import os
 import shutil
 from typing import NamedTuple, Optional, List
 
+from PyQt5.QtWidgets import QLabel, QVBoxLayout, QWidget
+
+import vimiv
+from vimiv.widgets import PopUp
+
 from . import xdg
 
 
@@ -35,6 +40,7 @@ def run() -> None:
     backup_dirs = backup()
     if backup_dirs.data_dir is not None:  # Error creating backup
         migrate_tags(backup_dirs.data_dir)
+    WelcomePopUp.gtk_installed = True
 
 
 def backup() -> XdgDirectories:
@@ -67,3 +73,42 @@ def migrate_tags(gtk_data_dir: str) -> None:
     if os.path.isdir(gtk_tagdir):
         shutil.copytree(gtk_tagdir, xdg.vimiv_data_dir("tags"))
         print("... Moved tag directory")
+
+
+def run_welcome_popup(parent: QWidget = None) -> None:
+    """Show pop up at startup if the gtk version was installed."""
+    if WelcomePopUp.gtk_installed:
+        WelcomePopUp(parent=parent)
+
+
+class WelcomePopUp(PopUp):
+    """Pop up that displays a short welcome message for users coming from gtk."""
+
+    gtk_installed = False
+
+    def __init__(self, parent=None):
+        super().__init__(f"{vimiv.__name__} - welcome to qt", parent=parent)
+        url = "https://karlch.github.io/vimiv-qt/documentation/migrating.html"
+        gh_url = "https://github.com/karlch/vimiv-qt/issues"
+        layout = QVBoxLayout()
+        label = QLabel()
+        label.setText(
+            "<h2>Welcome to the new qt version!</h2>"
+            "Looks like this is your first time running the new qt version.<br>"
+            "Following is some information to get you started.<br>"
+            "Much more details on migration are "
+            f"<a href='{url}'>available online</a>.<br><br>"
+            "A backup of your vimiv directories was created and your tags have been<br>"
+            "migrated. Keybindings and commands have largely changed, so<br>"
+            "unfortunately any custom changes are not automatically ported. The<br>"
+            "online documentation should help you migrating. Sorry for the<br>"
+            "inconvenience. I hope the large improvements here will outweigh the<br>"
+            "extra work of migration.<br><br>"
+            "If you have any problems or questions, do not hesitate to<br>"
+            f"<a href='{gh_url}'>open an issue on github</a> or to "
+            "<a href='mailto:karlch@protonmail.com'>contact me directly</a>.<br><br>"
+            "To show this message again, run ':welcome-to-qt'."
+        )
+        layout.addWidget(label)
+        self.setLayout(layout)
+        self.show()


### PR DESCRIPTION
This includes some tools and mainly documentation to aid migrating from the gtk version to this qt port. Namely:
* A dedicated page on the website for migrating
* Automatic backup of the gtk vimiv directories
* Automatic migration of tags to their new location
* A welcoming pop-up with the relevant information and links to the full docs

Ideally this should have been done much earlier, but it never came to my mind. Shame on me :sweat_smile: 