### PR TITLE
:goto improvements

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -33,6 +33,9 @@ Changed:
   ``FilterProxyModel`` is always used for completion filtering. Customization can only
   be done by adding new completion models inheriting from ``BaseModel``.
 * Completion widget is now shown/hidden depending on if there are completions or not.
+* The ``:goto`` command can now be run with count only, e.g. ``:2goto``.
+* The ``:goto`` command now consistently uses the module operator in all modes if the
+  passed number is larger than the allowed maximum.
 
 Fixed:
 ^^^^^^

--- a/tests/end2end/features/library/libraryscroll.feature
+++ b/tests/end2end/features/library/libraryscroll.feature
@@ -72,3 +72,15 @@ Feature: Scrolling the library.
         When I enter thumbnail mode
         And I run goto 2
         Then the library row should be 2
+
+    Scenario: Select row with goto using only count
+        Given I open a directory with 2 paths
+        When I run 2goto
+        Then the library row should be 2
+
+    Scenario: Display error when neither row nor count is passed to goto
+        Given I open a directory with 2 paths
+        When I run goto
+        Then the message
+            'goto: Either row or count is required'
+            should be displayed

--- a/tests/unit/commands/test_commands.py
+++ b/tests/unit/commands/test_commands.py
@@ -23,3 +23,8 @@ from vimiv import commands
 )
 def test_number_for_command(number, count, max_count, expected):
     assert commands.number_for_command(number, count, max_count=max_count) == expected
+
+
+def test_fail_number_for_command():
+    with pytest.raises(ValueError):
+        commands.number_for_command(None, None, max_count=42)

--- a/tests/unit/commands/test_commands.py
+++ b/tests/unit/commands/test_commands.py
@@ -1,0 +1,25 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2019 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+"""Tests for vimiv.commands."""
+
+import pytest
+
+from vimiv import commands
+
+
+@pytest.mark.parametrize(
+    "number, count, max_count, expected",
+    [
+        (1, None, 5, 0),
+        (1, 2, 5, 1),
+        (10, None, 5, 4),
+        (-1, None, 5, 4),
+        (0, None, 5, 0),
+    ],
+)
+def test_number_for_command(number, count, max_count, expected):
+    assert commands.number_for_command(number, count, max_count=max_count) == expected

--- a/vimiv/api/commands.py
+++ b/vimiv/api/commands.py
@@ -250,6 +250,8 @@ class _CommandArguments(argparse.ArgumentParser):
             }
         if argtype == typing.List[str]:
             return {"type": str, "nargs": "*"}
+        if not optional and argtype == typing.Optional[int]:  # Can be replaced by count
+            return {"type": int, "nargs": "?", "default": None}
         if optional and argtype is bool:
             return {"action": "store_true"}
         if optional:

--- a/vimiv/commands/__init__.py
+++ b/vimiv/commands/__init__.py
@@ -6,16 +6,21 @@
 
 """Functions to store and run commands."""
 
+from typing import cast
 
-def number_for_command(number: int, count: int = None, *, max_count: int) -> int:
+
+def number_for_command(number: int = None, count: int = None, *, max_count: int) -> int:
     """Return correct number for command given number, optional count and a maximum.
 
     Count is preferred over the number if it is given. The command expects numbers
     indexed from one but returns a number indexed from zero. If the number exceeds the
     maximum, the modulo operator is used to reduce it accordingly.
     """
+    if number is None and count is None:
+        raise ValueError("Either number or count must be given")
     if count is not None:
         number = count
+    number = cast(int, number)  # Ensured by the two tests above
     if number > 0:
         number -= 1
     return number % max_count

--- a/vimiv/commands/__init__.py
+++ b/vimiv/commands/__init__.py
@@ -5,3 +5,17 @@
 # License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
 
 """Functions to store and run commands."""
+
+
+def number_for_command(number: int, count: int = None, *, max_count: int) -> int:
+    """Return correct number for command given number, optional count and a maximum.
+
+    Count is preferred over the number if it is given. The command expects numbers
+    indexed from one but returns a number indexed from zero. If the number exceeds the
+    maximum, the modulo operator is used to reduce it accordingly.
+    """
+    if count is not None:
+        number = count
+    if number > 0:
+        number -= 1
+    return number % max_count

--- a/vimiv/gui/library.py
+++ b/vimiv/gui/library.py
@@ -15,7 +15,7 @@ from PyQt5.QtWidgets import QStyledItemDelegate, QSizePolicy, QStyle
 from PyQt5.QtGui import QStandardItemModel, QColor, QTextDocument, QStandardItem
 
 from vimiv import api, utils, widgets
-from vimiv.commands import argtypes, search
+from vimiv.commands import argtypes, search, number_for_command
 from vimiv.config import styles
 from vimiv.utils import files, strip_html, clamp, wrap_style_span, log
 from . import eventhandler, synchronize
@@ -251,13 +251,8 @@ class Library(eventhandler.EventHandlerMixin, widgets.FlatTreeView):
 
         **count:** Select [count]th element instead.
         """
-        if row == -1:
-            row = self.model().rowCount()
-        row = count if count is not None else row  # Prefer count
-        if row > 0:
-            row -= 1  # Start indexing at 1
-        row = clamp(row, 0, self.model().rowCount() - 1)
-        self._select_row(row, open_selected)
+        row = number_for_command(row, count, max_count=self.model().rowCount())
+        self._select_row(row, open_selected_image=open_selected)
 
     def update_width(self):
         """Resize width and columns when main window width changes."""

--- a/vimiv/gui/library.py
+++ b/vimiv/gui/library.py
@@ -236,7 +236,12 @@ class Library(eventhandler.EventHandlerMixin, widgets.FlatTreeView):
     @api.keybindings.register("gg", "goto 1", mode=api.modes.LIBRARY)
     @api.keybindings.register("G", "goto -1", mode=api.modes.LIBRARY)
     @api.commands.register(mode=api.modes.LIBRARY)
-    def goto(self, row: int, open_selected: bool = False, count: Optional[int] = None):
+    def goto(
+        self,
+        row: Optional[int],
+        open_selected: bool = False,
+        count: Optional[int] = None,
+    ):
         """Select specific row in current filelist.
 
         **syntax:** ``:goto row``
@@ -251,7 +256,10 @@ class Library(eventhandler.EventHandlerMixin, widgets.FlatTreeView):
 
         **count:** Select [count]th element instead.
         """
-        row = number_for_command(row, count, max_count=self.model().rowCount())
+        try:
+            row = number_for_command(row, count, max_count=self.model().rowCount())
+        except ValueError:
+            raise api.commands.CommandError("Either row or count is required")
         self._select_row(row, open_selected_image=open_selected)
 
     def update_width(self):

--- a/vimiv/gui/thumbnail.py
+++ b/vimiv/gui/thumbnail.py
@@ -280,7 +280,10 @@ class ThumbnailView(eventhandler.EventHandlerMixin, QListWidget):
 
         **count:** Select [count]th thubnail instead.
         """
-        index = number_for_command(index, count, max_count=self.count())
+        try:
+            index = number_for_command(index, count, max_count=self.count())
+        except ValueError:
+            raise api.commands.CommandError("Either index or count is required")
         self._select_item(index)
 
     @api.keybindings.register("-", "zoom out", mode=api.modes.THUMBNAIL)

--- a/vimiv/gui/thumbnail.py
+++ b/vimiv/gui/thumbnail.py
@@ -15,7 +15,7 @@ from PyQt5.QtWidgets import QListWidget, QListWidgetItem, QStyle, QStyledItemDel
 from PyQt5.QtGui import QColor, QIcon
 
 from vimiv import api, utils, imutils
-from vimiv.commands import argtypes, search
+from vimiv.commands import argtypes, search, number_for_command
 from vimiv.config import styles
 from vimiv.utils import create_pixmap, thumbnail_manager, clamp, log
 from . import eventhandler, synchronize
@@ -280,10 +280,7 @@ class ThumbnailView(eventhandler.EventHandlerMixin, QListWidget):
 
         **count:** Select [count]th thubnail instead.
         """
-        index = count if count is not None else index  # Prefer count
-        if index > 0:
-            index -= 1  # Start indexing at 1
-        index = index % self.count()
+        index = number_for_command(index, count, max_count=self.count())
         self._select_item(index)
 
     @api.keybindings.register("-", "zoom out", mode=api.modes.THUMBNAIL)

--- a/vimiv/imutils/filelist.py
+++ b/vimiv/imutils/filelist.py
@@ -17,7 +17,7 @@ from typing import List, Iterable, Optional
 from PyQt5.QtCore import QObject, pyqtSlot
 
 from vimiv import api, utils, imutils
-from vimiv.commands import search
+from vimiv.commands import search, number_for_command
 from vimiv.utils import files, log
 from .slideshow import Slideshow
 
@@ -65,10 +65,8 @@ def goto(index: int, count: Optional[int] = None) -> None:
 
     **count:** Select [count]th image instead.
     """
-    index = count if count is not None else index
-    if index > 0:
-        index -= 1
-    _set_index(index % len(_paths))
+    index = number_for_command(index, count, max_count=len(_paths))
+    _set_index(index)
 
 
 @api.status.module("{abspath}")

--- a/vimiv/imutils/filelist.py
+++ b/vimiv/imutils/filelist.py
@@ -65,7 +65,10 @@ def goto(index: int, count: Optional[int] = None) -> None:
 
     **count:** Select [count]th image instead.
     """
-    index = number_for_command(index, count, max_count=len(_paths))
+    try:
+        index = number_for_command(index, count, max_count=len(_paths))
+    except ValueError:
+        raise api.commands.CommandError("Either index or count is required")
     _set_index(index)
 
 


### PR DESCRIPTION
* `:goto` now consistently uses the modulo operator in all modes if the passed number is larger than the allowed maximum
* `:goto` can now be run with count only, e.g. `:2goto`

fixes #151 