### PR TITLE
Refactor and add transformations

### DIFF
--- a/tests/end2end/features/edit/test_transform_bdd.py
+++ b/tests/end2end/features/edit/test_transform_bdd.py
@@ -6,6 +6,8 @@
 
 import pytest_bdd as bdd
 
+from vimiv.parser import geometry
+
 
 bdd.scenarios("transform.feature")
 
@@ -20,3 +22,11 @@ def ensure_orientation(image, orientation):
         assert scenerect.height() > scenerect.width()
     else:
         raise ValueError(f"Unkown orientation {orientation}")
+
+
+@bdd.then(bdd.parsers.parse("the image size should be {size}"))
+def ensure_size(size, image):
+    expected = geometry(size)
+    image_rect = image.sceneRect()
+    assert expected.width() == image_rect.width()
+    assert expected.height() == image_rect.height()

--- a/tests/end2end/features/edit/transform.feature
+++ b/tests/end2end/features/edit/transform.feature
@@ -20,3 +20,23 @@ Feature: Transform an image.
         Given I open any image of size 200x300
         When I run 3rotate --counter-clockwise
         Then the orientation should be landscape
+
+    Scenario: Rescale image
+        Given I open any image of size 300x200
+        When I run rescale 2
+        Then the image size should be 600x400
+
+    Scenario: Rescale image changing the aspect ratio
+        Given I open any image of size 300x200
+        When I run rescale 2 1
+        Then the image size should be 600x200
+
+    Scenario: Resize image
+        Given I open any image of size 300x200
+        When I run resize 150
+        Then the image size should be 150x100
+
+    Scenario: Resize image changing the aspect ratio
+        Given I open any image of size 300x200
+        When I run resize 150 200
+        Then the image size should be 150x200

--- a/tests/end2end/features/edit/transform.feature
+++ b/tests/end2end/features/edit/transform.feature
@@ -41,8 +41,8 @@ Feature: Transform an image.
         When I run resize 150 200
         Then the image size should be 150x200
 
-    Scenario: Reset transformations
+    Scenario: Undo transformations
         Given I open any image of size 300x200
         When I run resize 150
-        And I run reset-transformations
+        And I run undo-transformations
         Then the image size should be 300x200

--- a/tests/end2end/features/edit/transform.feature
+++ b/tests/end2end/features/edit/transform.feature
@@ -40,3 +40,9 @@ Feature: Transform an image.
         Given I open any image of size 300x200
         When I run resize 150 200
         Then the image size should be 150x200
+
+    Scenario: Reset transformations
+        Given I open any image of size 300x200
+        When I run resize 150
+        And I run reset-transformations
+        Then the image size should be 300x200

--- a/tests/unit/imutils/test_imtransform.py
+++ b/tests/unit/imutils/test_imtransform.py
@@ -1,0 +1,72 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2020 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+"""Tests for vimiv.imutils.imtransform."""
+
+from functools import partial
+from unittest import mock
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QPixmap
+
+import pytest
+
+from vimiv.imutils import imtransform
+
+
+class MockHandler(mock.MagicMock):
+    """Stub used as file handler for Transform.
+
+    Provides a generic pixmap for all pixmaps and is always editable.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._pixmap = QPixmap(300, 300)
+        self._pixmap.fill(Qt.black)
+
+    @property
+    def editable(self):
+        return True
+
+    @property
+    def transformed(self):
+        return self._pixmap
+
+    @transformed.setter
+    def transformed(self, value):
+        pass
+
+    original = current = transformed
+
+
+ACTIONS = (
+    imtransform.Transform.rotate_command,
+    imtransform.Transform.flip,
+    partial(imtransform.Transform.resize, width=400, height=400),
+    partial(imtransform.Transform.rescale, dx=2, dy=2),
+)
+
+
+@pytest.fixture(scope="function")
+def transform(qtbot):
+    """Fixture to retrieve a clean Transform instance."""
+    transform.handler = MockHandler()  # Keep as reference here due to weakref
+    return imtransform.Transform(transform.handler)
+
+
+@pytest.fixture(params=ACTIONS)
+def action(transform, request):
+    action = request.param
+    return partial(action, self=transform)
+
+
+def test_change_and_reset(action, transform):
+    """Ensure every action leads to a change and is appropriately reset."""
+    action()
+    assert transform.changed
+    transform.reset()
+    assert not transform.changed

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -8,6 +8,7 @@
 
 import os
 import inspect
+import typing
 from collections import namedtuple
 
 import pytest
@@ -243,3 +244,21 @@ def test_run_qprocess_in_other_dir(tmpdir):
 def test_fail_run_qprocess_raises_oserror():
     with pytest.raises(OSError):
         utils.run_qprocess("NoTaCoMmAnD")
+
+
+@pytest.mark.parametrize("typ", (int, float, str, bool))
+def test_is_optional_type(typ):
+    optional_type = typing.Optional[typ]
+    assert utils.is_optional_type(optional_type)
+    assert not utils.is_optional_type(typ)
+
+
+@pytest.mark.parametrize("typ", (int, float, str, bool))
+def test_type_of_optional(typ):
+    optional_type = typing.Optional[typ]
+    assert utils.type_of_optional(optional_type) == typ
+
+
+def test_fail_type_of_optional():
+    with pytest.raises(TypeError, match="is not of Optional type"):
+        assert utils.type_of_optional(int)

--- a/vimiv/api/commands.py
+++ b/vimiv/api/commands.py
@@ -85,6 +85,8 @@ from vimiv.utils import (
     log,
     customtypes,
     escape_glob,
+    is_optional_type,
+    type_of_optional,
 )
 
 from . import modes
@@ -254,8 +256,8 @@ class _CommandArguments(argparse.ArgumentParser):
             }
         if argtype == typing.List[str]:
             return {"type": str, "nargs": "*"}
-        if not optional and argtype == typing.Optional[int]:  # Can be replaced by count
-            return {"type": int, "nargs": "?", "default": None}
+        if not optional and is_optional_type(argtype):
+            return {"type": type_of_optional(argtype), "nargs": "?", "default": None}
         if optional and argtype is bool:
             return {"action": "store_true"}
         if optional:

--- a/vimiv/api/commands.py
+++ b/vimiv/api/commands.py
@@ -298,7 +298,7 @@ class _Command:  # pylint: disable=too-many-instance-attributes
         # Retrieve description from docstring
         docstr = inspect.getdoc(func)
         if docstr is None:
-            log.error("Command %s for %s is missing docstring.", self.name, func)
+            _logger.error("Command %s for %s is missing docstring.", self.name, func)
             self.description = self.long_description = ""
         else:
             self.description = docstr.split("\n", maxsplit=1)[0]

--- a/vimiv/imutils/imtransform.py
+++ b/vimiv/imutils/imtransform.py
@@ -183,3 +183,11 @@ class Transform:
         self._rotation_angle = 0
         self._flip_horizontal = self._flip_vertical = False
         self._scale.reset()
+
+    @api.commands.register(mode=api.modes.IMAGE)
+    def reset_transformations(self):
+        """Reset all performed transformations to default."""
+        # We call reset and update the handler as reset is usually called by the handler
+        # which updates the images itself
+        self.reset()
+        self._handler().transformed = self._handler().original

--- a/vimiv/imutils/imtransform.py
+++ b/vimiv/imutils/imtransform.py
@@ -149,9 +149,7 @@ class Transform(QTransform):
         return not self.isIdentity()
 
     @api.commands.register(mode=api.modes.IMAGE)
-    def reset_transformations(self):
-        """Reset all performed transformations to default."""
-        # We call reset and update the handler as reset is usually called by the handler
-        # which updates the images itself
+    def undo_transformations(self):
+        """Undo any transformation applied to the current image."""
         self.reset()
         self._handler().transformed = self._handler().original

--- a/vimiv/imutils/imtransform.py
+++ b/vimiv/imutils/imtransform.py
@@ -6,6 +6,8 @@
 
 """*imtransform - transformations such as rotate and flip*."""
 
+import functools
+import math
 import weakref
 from typing import Optional
 
@@ -19,50 +21,48 @@ from vimiv.utils import log
 _logger = log.module_logger(__name__)
 
 
-class Scale:
-    """Helper class to store the current scale of an image."""
+def register_transform_command(**kwargs):
+    """Wrap commands.register to ensure image is editable and apply transformations."""
 
-    def __init__(self):
-        self.x = self.y = 1
+    def decorator(func):
+        @functools.wraps(func)
+        def inner(self, *args, **kwargs):
+            # Only used to wrap methods of transform
+            # pylint: disable=protected-access
+            self._ensure_editable()
+            func(self, *args, **kwargs)
+            self._apply_transformations()
 
-    @property
-    def changed(self) -> bool:
-        return self.x != 1 or self.y != 1
+        return api.commands.register(mode=api.modes.IMAGE, **kwargs)(inner)
 
-    def rescale(self, dx: float, dy: float):
-        self.x *= dx
-        self.y *= dy
-
-    def reset(self):
-        self.x = self.y = 1
+    return decorator
 
 
-class Transform:
+class Transform(QTransform):
     """Apply transformations to an image.
 
-    Provides the :rotate and :flip commands and applies transformations to a
-    given pixmap.
+    Provides the commands related to transformation such as rotate and flip and is used
+    to apply these transformations to the pixmap given by the handler.
 
     Attributes:
         _handler: weak reference to ImageFileHandler used to retrieve/set updated files.
-        _transform: QTransform object used to apply transformations.
-        _rotation_angle: Currently applied rotation angle in degrees.
-        _flip_horizontal: Flip the image horizontally.
-        _flip_vertical: Flip the image vertically.
     """
 
     @api.objreg.register
     def __init__(self, handler):
+        super().__init__()
         self._handler = weakref.ref(handler)
-        self._transform = QTransform()
-        self._rotation_angle = 0
-        self._flip_horizontal = self._flip_vertical = False
-        self._scale = Scale()
+
+    @property
+    def angle(self) -> int:
+        """Current rotation angle in degrees."""
+        x, y = self.map(0, 1)
+        return int(math.atan2(x, y) / math.pi * 180)
 
     @api.keybindings.register("<", "rotate --counter-clockwise", mode=api.modes.IMAGE)
     @api.keybindings.register(">", "rotate", mode=api.modes.IMAGE)
-    @api.commands.register(mode=api.modes.IMAGE)
-    def rotate(self, counter_clockwise: bool = False, count: int = 1):
+    @register_transform_command(name="rotate")
+    def rotate_command(self, counter_clockwise: bool = False, count: int = 1):
         """Rotate the image.
 
         **syntax:** ``:rotate [--counter-clockwise]``
@@ -72,15 +72,12 @@ class Transform:
 
         **count:** multiplier
         """
-        self._ensure_editable()
-        angle = 90 * count * -1 if counter_clockwise else 90 * count
-        self._transform.rotate(angle)
-        if self._apply_transformations():
-            self._rotation_angle = (self._rotation_angle + angle) % 360
+        angle = 90 * count
+        self.rotate(-angle if counter_clockwise else angle)
 
     @api.keybindings.register("_", "flip --vertical", mode=api.modes.IMAGE)
     @api.keybindings.register("|", "flip", mode=api.modes.IMAGE)
-    @api.commands.register(mode=api.modes.IMAGE)
+    @register_transform_command()
     def flip(self, vertical: bool = False):
         """Flip the image.
 
@@ -89,27 +86,15 @@ class Transform:
         optional arguments:
             * ``--vertical``: Flip image vertically instead of horizontally.
         """
-        self._ensure_editable()
-        # Vertical flip but image rotated by 90 degrees
-        if vertical and self._rotation_angle % 180:
-            self._transform.scale(-1, 1)
-        # Standard vertical flip
-        elif vertical:
-            self._transform.scale(1, -1)
-        # Horizontal flip but image rotated by 90 degrees
-        elif self._rotation_angle % 180:
-            self._transform.scale(1, -1)
-        # Standard horizontal flip
+        # Change direction if image is rotated by 90/270 degrees
+        if self.angle % 180:
+            vertical = not vertical
+        if vertical:
+            self.scale(1, -1)
         else:
-            self._transform.scale(-1, 1)
-        if self._apply_transformations():
-            # Store changes
-            if vertical:
-                self._flip_vertical = not self._flip_vertical
-            else:
-                self._flip_horizontal = not self._flip_horizontal
+            self.scale(-1, 1)
 
-    @api.commands.register(mode=api.modes.IMAGE)
+    @register_transform_command()
     def resize(self, width: int, height: Optional[int]):
         """Resize the original image to a new size.
 
@@ -124,9 +109,9 @@ class Transform:
         """
         dx = width / self._handler().transformed.width()
         dy = dx if height is None else height / self._handler().transformed.height()
-        self.rescale(dx, dy)
+        self.scale(dx, dy)
 
-    @api.commands.register(mode=api.modes.IMAGE)
+    @register_transform_command()
     def rescale(self, dx: float, dy: Optional[float]):
         """Rescale the original image to a new size.
 
@@ -140,28 +125,19 @@ class Transform:
         .. note:: This transforms the original image and writes to disk.
         """
         dy = dy if dy is not None else dx
-        self._transform.scale(dx, dy)
-        if self._apply_transformations():
-            self._scale.rescale(dx, dy)
-            _logger.debug("Updated scale to %.2fx%.2f", self._scale.x, self._scale.y)
+        self.scale(dx, dy)
 
-    def _apply_transformations(self) -> bool:
-        """Apply all transformations to the original pixmap.
-
-        Returns:
-            True if the application was successfull, False otherwise.
-        """
+    def _apply_transformations(self):
+        """Apply all transformations to the original pixmap."""
         transformed = self._handler().original.transformed(
-            self._transform, mode=Qt.SmoothTransformation
+            self, mode=Qt.SmoothTransformation
         )
         if transformed.isNull():
-            log.error(
+            raise api.commands.CommandError(
                 "Error transforming image, ignoring transformation.\n"
                 "Is the resulting image too large? Zero?."
             )
-            return False
         self._handler().transformed = transformed
-        return True
 
     def _ensure_editable(self):
         if not self._handler().editable:
@@ -170,19 +146,7 @@ class Transform:
     @property
     def changed(self):
         """True if transformations have been applied."""
-        return (
-            self._rotation_angle
-            or self._flip_horizontal
-            or self._flip_vertical
-            or self._scale.changed
-        )
-
-    def reset(self):
-        """Reset transformations."""
-        self._transform.reset()
-        self._rotation_angle = 0
-        self._flip_horizontal = self._flip_vertical = False
-        self._scale.reset()
+        return not self.isIdentity()
 
     @api.commands.register(mode=api.modes.IMAGE)
     def reset_transformations(self):

--- a/vimiv/utils/__init__.py
+++ b/vimiv/utils/__init__.py
@@ -11,7 +11,18 @@ import inspect
 import re
 from abc import ABCMeta
 from contextlib import suppress
-from typing import Callable, Optional, List, Any, Iterator, Dict, Iterable, Union, cast
+from typing import (
+    Callable,
+    Optional,
+    List,
+    Any,
+    Iterator,
+    Dict,
+    Iterable,
+    Union,
+    Type,
+    cast,
+)
 
 from PyQt5.QtCore import Qt, pyqtSlot, QRunnable, QThreadPool, QProcess
 from PyQt5.QtGui import QPixmap, QColor, QPainter
@@ -385,6 +396,22 @@ def run_qprocess(cmd: str, *args: str, cwd=None) -> str:
         stderr = str(process.readAllStandardError(), "utf-8").strip()  # type: ignore
         raise OSError(stderr)
     return str(process.readAllStandardOutput(), "utf-8").strip()  # type: ignore
+
+
+def is_optional_type(typ: Any) -> bool:
+    """Return True if typ is of type Optional."""
+    origin = getattr(typ, "__origin__", None)
+    types = getattr(typ, "__args__", ())
+    return origin is Union and isinstance(None, types)
+
+
+def type_of_optional(typ: Type) -> Any:
+    """Return T if typ is of type Optional[T]."""
+    types = getattr(typ, "__args__", ())
+    for elem in types:
+        if not isinstance(elem, type(None)):
+            return elem
+    raise TypeError("{typ} is not of Optional type")
 
 
 class AbstractQObjectMeta(wrappertype, ABCMeta):


### PR DESCRIPTION
This PR consists of multiple parts related to transformations:
* Refactor transformation class to:
    * Remove a bunch of unneeded attributes
    * Simplify check for changed
* Implement new `:rescale` and `:resize` commands to change the dimensions of the original image. These are transformations and therefore can be written to file.
* New `:undo-transformations` command to reset the image to the original.
* Add unit and end2end tests accordingly.