### PR TITLE
Update decorators using type annotations for pep563

### DIFF
--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -97,7 +97,8 @@ def test_clamp_with_none():
     assert utils.clamp(2, None, None) == 2
 
 
-def test_slot():
+@pytest.mark.parametrize("type_hint", ("int", int))
+def test_slot(type_hint):
     class Dummy(QObject):
 
         signal = pyqtSignal(int)
@@ -109,7 +110,7 @@ def test_slot():
     dummy = Dummy()
 
     @utils.slot
-    def test(x: int):
+    def test(x: type_hint):
         dummy.value = x
 
     dummy.signal.connect(test)

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -7,9 +7,9 @@
 """Tests for vimiv.utils"""
 
 import os
-import inspect
 import typing
 from collections import namedtuple
+from typing import get_type_hints
 
 import pytest
 from PyQt5.QtCore import pyqtSignal, QObject
@@ -121,7 +121,7 @@ def test_slot_ignore_self():
     def test(self, name: str):
         ...
 
-    slot_args = utils._slot_args(inspect.getfullargspec(test), test)
+    slot_args = utils._slot_args(test, get_type_hints(test))
     assert slot_args == [str]
 
 
@@ -129,7 +129,7 @@ def test_slot_add_returntype():
     def test(self, name: str) -> str:
         ...
 
-    slot_kwargs = utils._slot_kwargs(inspect.getfullargspec(test))
+    slot_kwargs = utils._slot_kwargs(get_type_hints(test))
     assert slot_kwargs == {"result": str}
 
 

--- a/vimiv/utils/__init__.py
+++ b/vimiv/utils/__init__.py
@@ -399,7 +399,7 @@ def type_of_optional(typ: typing.Type) -> typing.Any:
     for elem in types:
         if not isinstance(elem, type(None)):
             return elem
-    raise TypeError("{typ} is not of Optional type")
+    raise TypeError(f"{typ} is not of Optional type")
 
 
 class AbstractQObjectMeta(wrappertype, ABCMeta):

--- a/vimiv/utils/__init__.py
+++ b/vimiv/utils/__init__.py
@@ -11,17 +11,6 @@ import inspect
 import re
 from abc import ABCMeta
 import typing
-from typing import (
-    Callable,
-    Optional,
-    List,
-    Any,
-    Iterator,
-    Iterable,
-    Union,
-    Type,
-    cast,
-)
 
 from PyQt5.QtCore import Qt, pyqtSlot, QRunnable, QThreadPool, QProcess
 from PyQt5.QtGui import QPixmap, QColor, QPainter
@@ -83,20 +72,22 @@ def escape_glob(text: str) -> str:
     return re.sub(r"\\[\*\?\[\]]", escape_char, text)
 
 
-def contains_any(sequence: Iterable[AnyT], elems: Union[Iterable[AnyT], AnyT]) -> bool:
+def contains_any(
+    sequence: typing.Iterable[AnyT], elems: typing.Union[typing.Iterable[AnyT], AnyT]
+) -> bool:
     """Return True if the sequence contains any of the elems."""
     if not sequence:
         return False
     try:
-        elems = cast(Iterable[AnyT], elems)
+        elems = typing.cast(typing.Iterable[AnyT], elems)
         iter(elems)
         return bool(set(sequence) & set(elems))
     except TypeError:
-        return cast(AnyT, elems) in sequence
+        return typing.cast(AnyT, elems) in sequence
 
 
 def clamp(
-    value: NumberT, minimum: Optional[NumberT], maximum: Optional[NumberT]
+    value: NumberT, minimum: typing.Optional[NumberT], maximum: typing.Optional[NumberT]
 ) -> NumberT:
     """Clamp a value so it does not exceed boundaries."""
     if minimum is not None:
@@ -115,7 +106,7 @@ def class_that_defined_method(method):
     return getattr(inspect.getmodule(method), method.__qualname__.split(".")[0])
 
 
-def is_method(func: Callable) -> bool:
+def is_method(func: typing.Callable) -> bool:
     """Return True if func is a method owned by a class.
 
     This is used by the decorators for statusbar and command, when the class is
@@ -142,7 +133,7 @@ def cached_method(func):
 class AnnotationNotFound(Exception):
     """Raised if a there is no type annotation to use."""
 
-    def __init__(self, name: str, function: Callable):
+    def __init__(self, name: str, function: typing.Callable):
         message = (
             f"Missing type annotation for parameter '{name}' "
             f"in function '{function.__qualname__}'"
@@ -196,7 +187,7 @@ def _slot_kwargs(annotations):
 class GenericRunnable(QRunnable):
     """Generic QRunnable to run an arbitrary function on a QThreadPool."""
 
-    def __init__(self, function: Callable, *args, **kwargs):
+    def __init__(self, function: typing.Callable, *args, **kwargs):
         super().__init__()
         self.function = function
         self.args = args
@@ -206,19 +197,21 @@ class GenericRunnable(QRunnable):
         self.function(*self.args, **self.kwargs)
 
 
-def asyncrun(function: Callable, *args, pool: QThreadPool = None, **kwargs) -> None:
+def asyncrun(
+    function: typing.Callable, *args, pool: QThreadPool = None, **kwargs
+) -> None:
     """Run function with args and kwargs in parallel on a QThreadPool."""
     pool = pool if pool is not None else Pool.get()
     runnable = GenericRunnable(function, *args, **kwargs)
     pool.start(runnable)
 
 
-def asyncfunc(pool: QThreadPool = None) -> Callable[[FuncNoneT], FuncNoneT]:
+def asyncfunc(pool: QThreadPool = None) -> typing.Callable[[FuncNoneT], FuncNoneT]:
     """Decorator to run function in parallel on a QThreadPool."""
 
     def decorator(function: FuncNoneT) -> FuncNoneT:
         @functools.wraps(function)
-        def inner(*args: Any, **kwargs: Any) -> None:
+        def inner(*args: typing.Any, **kwargs: typing.Any) -> None:
             asyncrun(function, *args, pool=pool, **kwargs)
 
         # Mypy seems to disapprove the *args, **kwargs, but we just wrap the function
@@ -266,12 +259,12 @@ class Pool:
             pool.clear()
 
 
-def flatten(list_of_lists: Iterable[Iterable[AnyT]]) -> List[AnyT]:
+def flatten(list_of_lists: typing.Iterable[typing.Iterable[AnyT]]) -> typing.List[AnyT]:
     """Flatten a list of lists into a single list with all elements."""
     return [elem for sublist in list_of_lists for elem in sublist]
 
 
-def split(a: List[AnyT], n: int) -> Iterator[List[AnyT]]:
+def split(a: typing.List[AnyT], n: int) -> typing.Iterator[typing.List[AnyT]]:
     """Split list into n parts of approximately equal length.
 
     See https://stackoverflow.com/questions/2130016 for details.
@@ -281,8 +274,8 @@ def split(a: List[AnyT], n: int) -> Iterator[List[AnyT]]:
 
 
 def recursive_split(
-    text: str, separator: str, updater: Callable[[str], str]
-) -> List[str]:
+    text: str, separator: str, updater: typing.Callable[[str], str]
+) -> typing.List[str]:
     """Recursively split a string at separator applying an update callable.
 
     The string is split into parts and the update callable is applied to each part. The
@@ -393,14 +386,14 @@ def run_qprocess(cmd: str, *args: str, cwd=None) -> str:
     return str(process.readAllStandardOutput(), "utf-8").strip()  # type: ignore
 
 
-def is_optional_type(typ: Any) -> bool:
+def is_optional_type(typ: typing.Any) -> bool:
     """Return True if typ is of type Optional."""
     origin = getattr(typ, "__origin__", None)
     types = getattr(typ, "__args__", ())
-    return origin is Union and isinstance(None, types)
+    return origin is typing.Union and isinstance(None, types)
 
 
-def type_of_optional(typ: Type) -> Any:
+def type_of_optional(typ: typing.Type) -> typing.Any:
     """Return T if typ is of type Optional[T]."""
     types = getattr(typ, "__args__", ())
     for elem in types:


### PR DESCRIPTION
With [pep 563](https://www.python.org/dev/peps/pep-0563/) annotations will be evaluated on demand, not directly. This means they are stored as string and we cannot use them directly. Instead we call `typing.get_type_hints(...)`. This PR updates
* the `utils.slot` decorator and
* the `api.commands.register` decorator

to use `typing.get_hints` appropriately.