### PR TITLE
Refactor api.settings

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,11 @@ Changed:
   with the python builtin. Using ``api.open`` directly is deprecated and will be removed
   in `v0.7.0`.
 
+Fixed:
+^^^^^^
+
+* Always writing changed images to disk regardless of the ``image.autowrite`` setting.
+
 
 v0.5.0 (2020-01-05)
 -------------------

--- a/tests/integration/test_read_settings.py
+++ b/tests/integration/test_read_settings.py
@@ -116,4 +116,5 @@ def test_read_invalid_setting(mock_logger, configpath):
         assert set(args) & setting_names
     # Ensure all settings are at default value
     for name in setting_names:
-        assert api.settings.get(name).is_default()
+        setting = api.settings.get(name)
+        assert setting.value == setting.default

--- a/tests/unit/api/test_settings.py
+++ b/tests/unit/api/test_settings.py
@@ -28,6 +28,7 @@ def test_set_bool_setting(mocker, value):
     b = settings.BoolSetting("bool", True)
     b.value = value
     assert not b.value
+    assert not b
 
 
 def test_toggle_bool_setting():

--- a/tests/unit/api/test_settings.py
+++ b/tests/unit/api/test_settings.py
@@ -15,13 +15,11 @@ def test_init_setting():
     b = settings.BoolSetting("bool", True)
     assert b.default
     assert b.value
-    assert b.is_default()
 
 
 def test_check_default_after_change_for_setting(mocker):
     b = settings.BoolSetting("bool", True)
     b.value = False
-    assert not b.is_default()
     assert b.default
 
 

--- a/tests/unit/api/test_settings.py
+++ b/tests/unit/api/test_settings.py
@@ -23,15 +23,10 @@ def test_check_default_after_change_for_setting(mocker):
     assert b.default
 
 
-def test_set_bool_setting(mocker):
+@pytest.mark.parametrize("value", (False, "False", "no"))
+def test_set_bool_setting(mocker, value):
     b = settings.BoolSetting("bool", True)
-    b.value = False
-    assert not b.value
-
-
-def test_set_bool_setting_str(mocker):
-    b = settings.BoolSetting("bool", True)
-    b.value = "False"
+    b.value = value
     assert not b.value
 
 
@@ -41,15 +36,10 @@ def test_toggle_bool_setting():
     assert b.value
 
 
-def test_set_int_setting(mocker):
+@pytest.mark.parametrize("value", (2, "2", 2.0))
+def test_set_int_setting(mocker, value):
     i = settings.IntSetting("int", 1)
-    i.value = 2
-    assert i.value == 2
-
-
-def test_set_int_setting_str(mocker):
-    i = settings.IntSetting("int", 1)
-    i.value = "2"
+    i.value = value
     assert i.value == 2
 
 
@@ -65,15 +55,10 @@ def test_multiply_int_setting(mocker):
     assert i.value == 10
 
 
-def test_set_float_setting(mocker):
+@pytest.mark.parametrize("value", (3.3, "3.3"))
+def test_set_float_setting(mocker, value):
     f = settings.FloatSetting("float", 2.2)
-    f.value = 3.3
-    assert f.value == pytest.approx(3.3)
-
-
-def test_set_float_setting_str(mocker):
-    f = settings.FloatSetting("float", 2.2)
-    f.value = "3.3"
+    f.value = value
     assert f.value == pytest.approx(3.3)
 
 
@@ -89,15 +74,10 @@ def test_multiply_float_setting(mocker):
     assert f.value == pytest.approx(2.1)
 
 
-def test_set_thumbnail_setting(mocker):
+@pytest.mark.parametrize("value", (64, "64"))
+def test_set_thumbnail_setting(mocker, value):
     t = settings.ThumbnailSizeSetting("thumb", 128)
-    t.value = 64
-    assert t.value == 64
-
-
-def test_set_thumbnail_setting_str(mocker):
-    t = settings.ThumbnailSizeSetting("thumb", 128)
-    t.value = "64"
+    t.value = value
     assert t.value == 64
 
 

--- a/tests/unit/api/test_settings.py
+++ b/tests/unit/api/test_settings.py
@@ -145,12 +145,6 @@ def test_set_str_setting():
     assert s.value == "new"
 
 
-def test_fail_set_str_setting():
-    s = settings.StrSetting("string", "default")
-    with pytest.raises(ValueError, match="can only convert String"):
-        s.value = 12
-
-
 def test_fail_get_unstored_setting():
     with pytest.raises(KeyError):
         settings.get("any")

--- a/tests/unit/api/test_settings.py
+++ b/tests/unit/api/test_settings.py
@@ -113,28 +113,14 @@ def test_fail_set_thumbnail_setting_wrong_int(mocker):
         t.value = 13
 
 
-def test_increase_thumbnail_size():
-    t = settings.ThumbnailSizeSetting("thumb", 128)
-    t.increase()
-    assert t.value == 256
-
-
-def test_increase_thumbnail_size_at_limit():
-    t = settings.ThumbnailSizeSetting("thumb", 512)
-    t.increase()
-    assert t.value == 512
-
-
-def test_decrease_thumbnail_size():
-    t = settings.ThumbnailSizeSetting("thumb", 128)
-    t.decrease()
-    assert t.value == 64
-
-
-def test_decrease_thumbnail_size_at_limit():
-    t = settings.ThumbnailSizeSetting("thumb", 64)
-    t.decrease()
-    assert t.value == 64
+@pytest.mark.parametrize(
+    "start, up, expected",
+    [(128, True, 256), (512, True, 512), (128, False, 64), (64, False, 64)],
+)
+def test_step_thumbnail_size(start, up, expected):
+    t = settings.ThumbnailSizeSetting("thumb", start)
+    t.step(up=up)
+    assert t.value == expected
 
 
 def test_set_str_setting():

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -123,9 +123,6 @@ class Setting(QObject, metaclass=AbstractQObjectMeta):
         _logger.debug("Setting '%s' to '%s'", self.name, value)
         self.changed.emit(self._value)
 
-    def is_default(self) -> bool:
-        return self.value == self.default
-
     def set_to_default(self) -> None:
         self._value = self.default
 

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -119,7 +119,7 @@ class Setting(QObject, metaclass=AbstractQObjectMeta):
 
     @value.setter
     def value(self, value: Any) -> Any:
-        self._value = self.hook(value)
+        self._value = self.convert(value)
         _logger.debug("Setting '%s' to '%s'", self.name, value)
         self.changed.emit(self._value)
 
@@ -146,10 +146,6 @@ class Setting(QObject, metaclass=AbstractQObjectMeta):
 
     def convertstr(self, value: str) -> Any:
         return self.typ(value)
-
-    def hook(self, value: Any) -> Any:
-        """Function called before a value is set."""
-        return self.convert(value)
 
 
 class BoolSetting(Setting):
@@ -203,16 +199,16 @@ class NumberSetting(Setting):  # pylint: disable=abstract-method  # Still abstra
 
     def __iadd__(self, value: customtypes.NumberStr) -> "NumberSetting":
         """Add a value to the currently stored number."""
-        self.value += self.convert(value)
+        self.value += super().convert(value)
         return self
 
     def __imul__(self, value: customtypes.NumberStr) -> "NumberSetting":
         """Multiply the currently stored number with a value."""
-        self.value *= self.convert(value)
+        self.value *= super().convert(value)
         return self
 
-    def hook(self, value: customtypes.NumberStr) -> customtypes.Number:
-        return clamp(self.convert(value), self.min_value, self.max_value)
+    def convert(self, value: customtypes.NumberStr) -> customtypes.Number:
+        return clamp(super().convert(value), self.min_value, self.max_value)
 
 
 class IntSetting(NumberSetting):
@@ -243,8 +239,8 @@ class ThumbnailSizeSetting(Setting):
     typ = int
     ALLOWED_VALUES = 64, 128, 256, 512
 
-    def hook(self, value: customtypes.IntStr) -> int:
-        ivalue = self.convert(value)
+    def convert(self, value: customtypes.IntStr) -> int:
+        ivalue = super().convert(value)
         if ivalue not in self.ALLOWED_VALUES:
             raise ValueError("Thumbnail size must be one of 64, 128, 256, 512")
         return ivalue

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -178,7 +178,7 @@ class BoolSetting(Setting):
         return "Bool"
 
 
-class NumberSetting(Setting):
+class NumberSetting(Setting):  # pylint: disable=abstract-method  # Still abstract class
     """Used as ABC for Int and Float settings.
 
     This allows using isinstance(setting, NumberSetting) for add_to and
@@ -204,13 +204,15 @@ class NumberSetting(Setting):
         self.min_value = min_value
         self.max_value = max_value
 
-    @abstractmethod
     def __iadd__(self, value: customtypes.NumberStr) -> "NumberSetting":
-        """Must be implemented by child."""
+        """Add a value to the currently stored number."""
+        self.value += self.convert(value)
+        return self
 
-    @abstractmethod
     def __imul__(self, value: customtypes.NumberStr) -> "NumberSetting":
-        """Must be implemented by child."""
+        """Multiply the currently stored number with a value."""
+        self.value *= self.convert(value)
+        return self
 
     def hook(self, value: customtypes.NumberStr) -> customtypes.Number:
         return clamp(self.convert(value), self.min_value, self.max_value)
@@ -221,24 +223,6 @@ class IntSetting(NumberSetting):
 
     typ = int
 
-    def __iadd__(self, value: customtypes.NumberStr) -> "IntSetting":
-        """Add a value to the currently stored integer.
-
-        Args:
-            value: The integer value to add as string.
-        """
-        self.value = self.value + self.convert(value)
-        return self
-
-    def __imul__(self, value: customtypes.NumberStr) -> "IntSetting":
-        """Multiply the currently stored integer with a value.
-
-        Args:
-            value: The value to multiply with as string.
-        """
-        self.value = self.value * self.convert(value)
-        return self
-
     def __str__(self) -> str:
         return "Integer"
 
@@ -247,24 +231,6 @@ class FloatSetting(NumberSetting):
     """Stores a float setting."""
 
     typ = float
-
-    def __iadd__(self, value: customtypes.NumberStr) -> "FloatSetting":
-        """Add a value to the currently stored float.
-
-        Args:
-            value: The float value to add as string.
-        """
-        self.value = self.value + self.convert(value)
-        return self
-
-    def __imul__(self, value: customtypes.NumberStr) -> "FloatSetting":
-        """Multiply the currently stored float with a value.
-
-        Args:
-            value: The value to multiply with as string.
-        """
-        self.value = self.value * self.convert(value)
-        return self
 
     def __str__(self) -> str:
         return "Float"

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -163,6 +163,9 @@ class BoolSetting(Setting):
     def __str__(self) -> str:
         return "Bool"
 
+    def __bool__(self) -> bool:
+        return self.value
+
 
 class NumberSetting(Setting):  # pylint: disable=abstract-method  # Still abstract class
     """Used as ABC for Int and Float settings.

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -245,18 +245,10 @@ class ThumbnailSizeSetting(Setting):
             raise ValueError("Thumbnail size must be one of 64, 128, 256, 512")
         return ivalue
 
-    def increase(self) -> None:
-        """Increase thumbnail size."""
-        index = self.ALLOWED_VALUES.index(self.value)
-        index += 1
-        index = min(index, len(self.ALLOWED_VALUES) - 1)
-        self.value = self.ALLOWED_VALUES[index]
-
-    def decrease(self) -> None:
-        """Decrease thumbnail size."""
-        index = self.ALLOWED_VALUES.index(self.value)
-        index -= 1
-        index = max(index, 0)
+    def step(self, up: bool = True) -> None:
+        """Change thumbnail size by one step up if up else down."""
+        index = self.ALLOWED_VALUES.index(self.value) + (1 if up else -1)
+        index = clamp(index, 0, len(self.ALLOWED_VALUES) - 1)
         self.value = self.ALLOWED_VALUES[index]
 
     def suggestions(self) -> List[str]:

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -67,9 +67,11 @@ class Setting(QObject, metaclass=AbstractQObjectMeta):
 
     Attributes:
         name: Name of the setting as string.
+        desc: Description of the setting.
         hidden: True if the setting should not be visible in the :set completion.
 
         _default: Default value of the setting stored in its python type.
+        _suggestions: List of useful values to show in completion widget.
         _value: Value of the setting stored in its python type.
 
     Signals:
@@ -88,19 +90,13 @@ class Setting(QObject, metaclass=AbstractQObjectMeta):
     ):
         """Initialize attributes with default values.
 
-        Args:
-            name: Name of the setting to initialize.
-            default_value: Default value of the setting to start with.
-            desc: Description of the setting.
-            suggestions: List of useful values to show in completion widget.
-            hidden: True if the setting should not be visible in the :set completion.
+        See the class attributes section for a description of the arguments.
         """
         super().__init__()
         self.name = name
-        self._default = default_value
-        self._value = default_value
         self.desc = desc
         self.hidden = hidden
+        self._value = self._default = default_value
         self._suggestions = suggestions if suggestions is not None else []
         _storage[name] = self  # Store setting in storage
 
@@ -134,10 +130,7 @@ class Setting(QObject, metaclass=AbstractQObjectMeta):
         return self._suggestions
 
     def convert(self, value: Any) -> Any:
-        """Convert value to setting type before using it.
-
-        Must be implemented by the child as it knows which type to require.
-        """
+        """Convert value to setting type before using it."""
         with suppress(ValueError):  # We re-raise later with a consistent message
             if isinstance(value, str):
                 return self.convertstr(value)

--- a/vimiv/gui/thumbnail.py
+++ b/vimiv/gui/thumbnail.py
@@ -17,7 +17,7 @@ from PyQt5.QtGui import QColor, QIcon
 from vimiv import api, utils, imutils
 from vimiv.commands import argtypes, search, number_for_command
 from vimiv.config import styles
-from vimiv.utils import create_pixmap, thumbnail_manager, clamp, log
+from vimiv.utils import create_pixmap, thumbnail_manager, log
 from . import eventhandler, synchronize
 
 
@@ -272,10 +272,10 @@ class ThumbnailView(eventhandler.EventHandlerMixin, QListWidget):
         **count:** multiplier
         """
         _logger.debug("Zooming in direction '%s'", direction)
-        size = self.iconSize().width()
-        size = size // 2 if direction == direction.Out else size * 2
-        size = clamp(size, 64, 512)
-        api.settings.thumbnail.size.value = size
+        if direction == direction.In:
+            api.settings.thumbnail.size.increase()
+        else:
+            api.settings.thumbnail.size.decrease()
 
     def rescale_items(self):
         """Reset item hint when item size has changed."""

--- a/vimiv/gui/thumbnail.py
+++ b/vimiv/gui/thumbnail.py
@@ -272,10 +272,7 @@ class ThumbnailView(eventhandler.EventHandlerMixin, QListWidget):
         **count:** multiplier
         """
         _logger.debug("Zooming in direction '%s'", direction)
-        if direction == direction.In:
-            api.settings.thumbnail.size.increase()
-        else:
-            api.settings.thumbnail.size.decrease()
+        api.settings.thumbnail.size.step(up=direction == direction.In)
 
     def rescale_items(self):
         """Reset item hint when item size has changed."""


### PR DESCRIPTION
Refactor `api.settings` to remove some of the unnecessarily difficult parts. Fixed a bug and docstrings on-the-fly.