### PR TITLE
Add :straighten command

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,11 @@ Added:
 * The ``:resize`` and ``:rescale`` commands to change the dimension of the original
   image. These are transformations and can be written to file.
 * The ``:undo-transformations`` command to reset the image to the original.
+* The ``:straighten`` command which displays a grid to straighten the current image.
+  The image can then be straightened clockwise using the ``l``, ``>`` and ``L`` keys and
+  counter-clockwise with ``h``, ``<`` and ``H``. Accept the changes with ``<return>``
+  and reject them with ``<escape>``. It comes ith the ``{transformation-info}`` status
+  module that displays the current straightening angle in degrees.
 
 Changed:
 ^^^^^^^^

--- a/tests/end2end/features/edit/conftest.py
+++ b/tests/end2end/features/edit/conftest.py
@@ -1,0 +1,26 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2020 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+import pytest_bdd as bdd
+
+from vimiv.parser import geometry
+
+
+@bdd.then(bdd.parsers.parse("the image size should be {size}"))
+def ensure_size(size, image):
+    expected = geometry(size)
+    image_rect = image.sceneRect()
+    assert expected.width() == image_rect.width()
+    assert expected.height() == image_rect.height()
+
+
+@bdd.then(bdd.parsers.parse("the image size should not be {size}"))
+def ensure_size_not(size, image):
+    expected = geometry(size)
+    image_rect = image.sceneRect()
+    width_neq = expected.width() != image_rect.width()
+    height_neq = expected.height() != image_rect.height()
+    assert width_neq or height_neq

--- a/tests/end2end/features/edit/straighten.feature
+++ b/tests/end2end/features/edit/straighten.feature
@@ -1,0 +1,28 @@
+Feature: Straighten an image.
+
+    Background: 
+        Given I open any image
+
+    Scenario: Enter straighten widget
+        When I run straighten
+        Then there should be 1 straighten widget
+        And the center status should include angle: +0.0°
+
+    Scenario: Leave straighten widget discarding changes
+        When I run straighten
+        And I straighten by 1 degree
+        And I leave the straighten widget via <escape>
+        Then there should be 0 straighten widgets
+        And the image size should be 300x300
+
+    Scenario: Leave straighten widget accepting changes
+        When I run straighten
+        And I straighten by 1 degree
+        And I leave the straighten widget via <return>
+        Then there should be 0 straighten widgets
+        And the image size should not be 300x300
+
+    Scenario: Straighten image using keybindings
+        When I run straighten
+        And I hit l on the straighten widget
+        Then the straighten angle should be 0.2

--- a/tests/end2end/features/edit/test_straighten_bdd.py
+++ b/tests/end2end/features/edit/test_straighten_bdd.py
@@ -1,0 +1,66 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+from PyQt5.QtCore import Qt
+
+import pytest
+import pytest_bdd as bdd
+
+import vimiv.gui.straighten_widget
+
+
+bdd.scenarios("straighten.feature")
+
+
+def find_straighten_widgets(image):
+    return image.findChildren(vimiv.gui.straighten_widget.StraightenWidget)
+
+
+@pytest.fixture()
+def straighten(image):
+    """Fixture to retrieve the current instance of the straighten widget."""
+    widgets = find_straighten_widgets(image)
+    assert len(widgets) == 1, "Wrong number of straighten wigets found"
+    return widgets[0]
+
+
+@bdd.when(bdd.parsers.parse("I straighten by {angle:g} degrees"))
+@bdd.when(bdd.parsers.parse("I straighten by {angle:g} degree"))
+def straighten_by(qtbot, straighten, angle):
+    def check():
+        assert straighten.transform.angle == pytest.approx(angle)
+
+    straighten.rotate(angle=angle)
+    qtbot.waitUntil(check)
+
+
+@bdd.when(bdd.parsers.parse("I leave the straighten widget via {keyname}"))
+def leave_straighten_via_key(qtbot, straighten, keyname):
+    keyname = keyname.lower()
+    keys = {"<escape>": Qt.Key_Escape, "<return>": Qt.Key_Return}
+    try:
+        key = keys[keyname]
+    except KeyError:
+        raise KeyError(f"Must leave straighten widget with one of: {', '.join(keys)}")
+    qtbot.keyClick(straighten, key)
+
+
+@bdd.when(bdd.parsers.parse("I hit {keys} on the straighten widget"))
+def press_key_straighten(qtbot, straighten, keys):
+    qtbot.keyClick(straighten, keys)
+
+
+@bdd.then(bdd.parsers.parse("there should be {number:d} straighten widgets"))
+@bdd.then(bdd.parsers.parse("there should be {number:d} straighten widget"))
+def check_number_of_straighten_widgets(qtbot, image, number):
+    def check():
+        assert len(find_straighten_widgets(image)) == number
+
+    qtbot.waitUntil(check)
+
+
+@bdd.then(bdd.parsers.parse("the straighten angle should be {angle:.f}"))
+def check_straighten_angle(qtbot, straighten, angle):
+    def check():
+        assert straighten.angle == pytest.approx(angle)
+
+    qtbot.waitUntil(check)

--- a/tests/end2end/features/edit/test_transform_bdd.py
+++ b/tests/end2end/features/edit/test_transform_bdd.py
@@ -6,8 +6,6 @@
 
 import pytest_bdd as bdd
 
-from vimiv.parser import geometry
-
 
 bdd.scenarios("transform.feature")
 
@@ -22,11 +20,3 @@ def ensure_orientation(image, orientation):
         assert scenerect.height() > scenerect.width()
     else:
         raise ValueError(f"Unkown orientation {orientation}")
-
-
-@bdd.then(bdd.parsers.parse("the image size should be {size}"))
-def ensure_size(size, image):
-    expected = geometry(size)
-    image_rect = image.sceneRect()
-    assert expected.width() == image_rect.width()
-    assert expected.height() == image_rect.height()

--- a/tests/unit/imutils/test_imtransform.py
+++ b/tests/unit/imutils/test_imtransform.py
@@ -70,3 +70,9 @@ def test_change_and_reset(action, transform):
     assert transform.changed
     transform.reset()
     assert not transform.changed
+
+
+@pytest.mark.parametrize("angle", range(0, 360, 15))
+def test_rotate_angle(transform, angle):
+    transform.rotate(angle)
+    assert transform.angle == pytest.approx(angle)

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -395,7 +395,10 @@ class statusbar:  # pylint: disable=invalid-name
         "{basename}   {image-size}   Modified: {modified}   {processing}",
     )
     StrSetting("statusbar.center_thumbnail", "{thumbnail-size}")
-    StrSetting("statusbar.center", "{slideshow-indicator} {slideshow-delay}")
+    StrSetting(
+        "statusbar.center",
+        "{slideshow-indicator} {slideshow-delay} {transformation-info}",
+    )
     StrSetting("statusbar.right", "{keys}  {mark-count}  {mode}")
     StrSetting("statusbar.right_image", "{keys}  {mark-indicator} {mark-count}  {mode}")
 

--- a/vimiv/config/_style_options.py
+++ b/vimiv/config/_style_options.py
@@ -77,4 +77,6 @@ DEFAULT_OPTIONS = {
     # Metadata overlay
     "metadata.padding": "{keyhint.padding}",
     "metadata.border_radius": "{keyhint.border_radius}",
+    # Straighten widget
+    "image.straighten.color": "{base0a}",
 }

--- a/vimiv/gui/image.py
+++ b/vimiv/gui/image.py
@@ -26,6 +26,7 @@ from vimiv.config import styles
 from vimiv.utils import lazy
 
 from .eventhandler import EventHandlerMixin
+from .straighten_widget import StraightenWidget
 
 QtSvg = lazy.import_module("PyQt5.QtSvg", optional=True)
 
@@ -296,6 +297,12 @@ class ScrollableImage(EventHandlerMixin, QGraphicsView):
             widget = self.items()[0].widget()
             movie = widget.movie()
             movie.setPaused(not movie.state() == QMovie.Paused)
+
+    @api.commands.register(mode=api.modes.IMAGE)
+    def straighten(self):
+        """Display a widget to straighten the current image."""
+        # TODO extend this docstring explaining the functionality once this has settled
+        StraightenWidget(self)
 
     def resizeEvent(self, event):
         """Rescale the child image and update statusbar on resize event."""

--- a/vimiv/gui/image.py
+++ b/vimiv/gui/image.py
@@ -9,7 +9,7 @@
 from contextlib import suppress
 from typing import List, Union
 
-from PyQt5.QtCore import Qt, QRectF
+from PyQt5.QtCore import Qt, QRectF, pyqtSignal
 from PyQt5.QtWidgets import (
     QGraphicsView,
     QGraphicsScene,
@@ -45,6 +45,9 @@ class ScrollableImage(EventHandlerMixin, QGraphicsView):
 
     Attributes:
         _scale: ImageScale defining how to scale image on resize.
+
+    Signals:
+        resized: Emitted after every resizeEvent.
     """
 
     STYLESHEET = """
@@ -53,6 +56,8 @@ class ScrollableImage(EventHandlerMixin, QGraphicsView):
         border: none;
     }
     """
+
+    resized = pyqtSignal()
 
     MAX_SCALE = 8
     MIN_SCALE = 1 / 8
@@ -298,6 +303,7 @@ class ScrollableImage(EventHandlerMixin, QGraphicsView):
         if self.items():
             self.scale(self._scale)
             api.status.update("image zoom level changed")
+            self.resized.emit()
 
     def mousePressEvent(self, event):
         """Update mouse press event to start panning on left button."""

--- a/vimiv/gui/image.py
+++ b/vimiv/gui/image.py
@@ -26,7 +26,6 @@ from vimiv.config import styles
 from vimiv.utils import lazy
 
 from .eventhandler import EventHandlerMixin
-from .straighten_widget import StraightenWidget
 
 QtSvg = lazy.import_module("PyQt5.QtSvg", optional=True)
 
@@ -302,6 +301,8 @@ class ScrollableImage(EventHandlerMixin, QGraphicsView):
     def straighten(self):
         """Display a widget to straighten the current image."""
         # TODO extend this docstring explaining the functionality once this has settled
+        from .straighten_widget import StraightenWidget
+
         StraightenWidget(self)
 
     def resizeEvent(self, event):

--- a/vimiv/gui/image.py
+++ b/vimiv/gui/image.py
@@ -303,8 +303,12 @@ class ScrollableImage(EventHandlerMixin, QGraphicsView):
 
     @api.commands.register(mode=api.modes.IMAGE)
     def straighten(self):
-        """Display a widget to straighten the current image."""
-        # TODO extend this docstring explaining the functionality once this has settled
+        """Display a grid to straighten the current image.
+
+        The image can then be straightened clockwise using the ``l``, ``>`` and ``L``
+        keys and counter-clockwise with ``h``, ``<`` and ``H``. Accept the changes with
+        ``<return>`` and reject them with ``<escape>``.
+        """
         from .straighten_widget import StraightenWidget
 
         StraightenWidget(self)

--- a/vimiv/gui/image.py
+++ b/vimiv/gui/image.py
@@ -7,7 +7,7 @@
 """QtWidgets for IMAGE mode."""
 
 from contextlib import suppress
-from typing import List, Union
+from typing import List, Union, Optional, Callable
 
 from PyQt5.QtCore import Qt, QRectF, pyqtSignal
 from PyQt5.QtWidgets import (
@@ -44,6 +44,9 @@ class ScrollableImage(EventHandlerMixin, QGraphicsView):
         MAX_SCALE: Maximum scale to scale an image to.
 
     Attributes:
+        transformation_module: Function returning additional information on current
+            more complex transformation such as straighten if any.
+
         _scale: ImageScale defining how to scale image on resize.
 
     Signals:
@@ -69,6 +72,7 @@ class ScrollableImage(EventHandlerMixin, QGraphicsView):
         styles.apply(self)
 
         self._scale = ImageScaleFloat(1.0)
+        self.transformation_module: Optional[Callable[[], str]] = None
 
         self.setResizeAnchor(QGraphicsView.AnchorViewCenter)
         self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
@@ -304,6 +308,13 @@ class ScrollableImage(EventHandlerMixin, QGraphicsView):
         from .straighten_widget import StraightenWidget
 
         StraightenWidget(self)
+
+    @api.status.module("{transformation-info}")
+    def transformation_info(self) -> str:
+        """Additional information on image transformations such as straightening."""
+        if self.transformation_module is None:
+            return ""
+        return self.transformation_module()  # pylint: disable=not-callable
 
     def resizeEvent(self, event):
         """Rescale the child image and update statusbar on resize event."""

--- a/vimiv/gui/straighten_widget.py
+++ b/vimiv/gui/straighten_widget.py
@@ -10,11 +10,12 @@ import enum
 import functools
 
 from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QPainter, QPen
+from PyQt5.QtGui import QPainter, QPen, QColor
 from PyQt5.QtWidgets import QWidget, QStyleOption
 
 from vimiv import api
 from vimiv.imutils import imtransform
+from vimiv.config import styles
 
 
 class Direction(enum.IntEnum):
@@ -55,6 +56,7 @@ class StraightenWidget(QWidget):
                 self.rotate, direction=Direction.CounterClockwise
             ),
         }
+        self.color = QColor(styles.get("image.straighten.color"))
         self.transform = imtransform.Transform.instance
         self.previous_matrix = self.transform.matrix
         self.total_angle = 0
@@ -111,7 +113,7 @@ class StraightenWidget(QWidget):
         opt = QStyleOption()
         opt.initFrom(self)
         painter = QPainter(self)
-        pen = QPen(Qt.black)
+        pen = QPen(self.color)
         for fraction, style, width in self.LINES:
             pen.setStyle(style)
             pen.setWidth(width)

--- a/vimiv/gui/straighten_widget.py
+++ b/vimiv/gui/straighten_widget.py
@@ -91,11 +91,15 @@ class StraightenWidget(QWidget):
     def update_geometry(self):
         """Update geometry of the grid to overlay the image."""
         image_size = self.parent().sceneRect()
-        image_width = int(image_size.width() * self.parent().zoom_level)
-        image_height = int(image_size.height() * self.parent().zoom_level)
-        self.setFixedSize(image_width, image_height)
-        x = (self.parent().width() - image_width) // 2
-        y = (self.parent().height() - image_height) // 2
+        width = min(
+            int(image_size.width() * self.parent().zoom_level), self.parent().width()
+        )
+        height = min(
+            int(image_size.height() * self.parent().zoom_level), self.parent().height()
+        )
+        self.setFixedSize(width, height)
+        x = (self.parent().width() - width) // 2
+        y = (self.parent().height() - height) // 2
         self.move(x, y)
 
     def keyPressEvent(self, event):

--- a/vimiv/gui/straighten_widget.py
+++ b/vimiv/gui/straighten_widget.py
@@ -1,0 +1,90 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2020 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+"""Widget to display a grid for straightening and interact with image and transform."""
+
+import functools
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QPainter, QPen
+from PyQt5.QtWidgets import QWidget, QStyleOption
+
+from vimiv import api
+
+
+class StraightenWidget(QWidget):
+    """Widget to display a grid for straightening and interact with image and transform.
+
+    The grid is a visual helper for the user to straighten the image. An interaction
+    with the imtransform module to apply the transformations and the image widget to
+    display the transformation is performed with this class acting as man-in-the-middle.
+
+    Attributes:
+        bindings: Dictionary of keybindings required for straightening.
+    """
+
+    LINES = (
+        (0.25, Qt.DashLine, 2),
+        (0.5, Qt.SolidLine, 4),
+        (0.75, Qt.DashLine, 2),
+    )
+
+    def __init__(self, image):
+        super().__init__(parent=image)
+        self.setObjectName(self.__class__.__qualname__)
+        self.setWindowFlags(Qt.SubWindow)
+        self.setFixedSize(image.size())
+        self.setFocus()
+
+        self.bindings = {
+            Qt.Key_Escape: self.leave,
+            Qt.Key_Return: functools.partial(self.leave, accept=True),
+        }
+
+        image.resized.connect(self.resize)
+        self.show()
+
+    def leave(self, accept: bool = False):
+        """Leave the straighten widget for image mode.
+
+        Args:
+            accept: If True, keep the straightening as transformation.
+        """
+        if accept:
+            raise NotImplementedError("TODO")
+        self.parent().setFocus()  # type: ignore
+
+    def resize(self):
+        self.setFixedSize(self.parent().size())
+
+    def keyPressEvent(self, event):
+        """Prefer custom bindings, fall back to the parent (image) widget."""
+        binding = self.bindings.get(event.key())
+        if binding is not None:
+            binding()
+            api.status.update("straighten binding")
+        else:
+            self.parent().keyPressEvent(event)
+
+    def paintEvent(self, _event):
+        """Paint a grid of helper lines."""
+        opt = QStyleOption()
+        opt.initFrom(self)
+        painter = QPainter(self)
+        pen = QPen(Qt.black)
+        for fraction, style, width in self.LINES:
+            pen.setStyle(style)
+            pen.setWidth(width)
+            painter.setPen(pen)
+            x_fraction = int(self.width() * fraction)
+            y_fraction = int(self.height() * fraction)
+            painter.drawLine(0, y_fraction, self.width(), y_fraction)
+            painter.drawLine(x_fraction, 0, x_fraction, self.height())
+
+    def focusOutEvent(self, event):
+        """Delete the widget when focusing out."""
+        self.deleteLater()
+        super().focusOutEvent(event)

--- a/vimiv/gui/straighten_widget.py
+++ b/vimiv/gui/straighten_widget.py
@@ -13,7 +13,7 @@ from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QPainter, QPen, QColor
 from PyQt5.QtWidgets import QWidget, QStyleOption
 
-from vimiv import api
+from vimiv import api, utils
 from vimiv.imutils import imtransform
 from vimiv.config import styles
 
@@ -95,8 +95,17 @@ class StraightenWidget(QWidget):
         link to user-interaction and the GUI.
         """
         angle = -angle if counter_clockwise else angle
-        self.transform.setMatrix(*self.previous_matrix)  # Reset any performed changes
         self.total_angle += angle
+        self._perform_rotate()
+
+    @utils.throttled(delay_ms=0)
+    def _perform_rotate(self):
+        """Throttled implementation of the actual rotate.
+
+        The throttling keeps the UI responsive and stops the CPU from going wild when
+        holding down any of the rotate keys.
+        """
+        self.transform.setMatrix(*self.previous_matrix)  # Reset any performed changes
         self.transform.straighten(angle=self.total_angle)
         self.update_geometry()
 

--- a/vimiv/gui/straighten_widget.py
+++ b/vimiv/gui/straighten_widget.py
@@ -97,6 +97,10 @@ class StraightenWidget(TransformWidget):
         y = (self.parent().height() - height) // 2
         self.move(x, y)
 
+    def status_info(self):
+        """Display current rotation angle in the status bar."""
+        return f"angle: {self.angle:+.1f}°"
+
     def paintEvent(self, _event):
         """Paint a grid of helper lines."""
         opt = QStyleOption()

--- a/vimiv/gui/transform_widget.py
+++ b/vimiv/gui/transform_widget.py
@@ -1,0 +1,79 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2020 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+"""Base class for widgets which provide a gui for more complex transformations."""
+
+import abc
+import functools
+from contextlib import suppress
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QWidget
+
+from vimiv.imutils import imtransform
+
+# See https://github.com/PyCQA/pylint/issues/3202
+from vimiv import api, utils  # pylint: disable=unused-import
+
+from .eventhandler import keyevent_to_sequence
+
+
+class TransformWidget(QWidget, metaclass=utils.AbstractQObjectMeta):
+    """Base class for widgets which provide a gui for more complex transformations.
+
+    The child class must implement update_geometry to adapt to a resized image and
+    should provide additional keybindings which implement the actual transformation.
+    """
+
+    def __init__(self, image, **bindings):
+        super().__init__(parent=image)
+        self.setObjectName(self.__class__.__qualname__)
+        self.setWindowFlags(Qt.SubWindow)
+        self.setFocus()
+
+        self.bindings = {
+            ("<escape>",): self.leave,
+            ("<return>",): functools.partial(self.leave, accept=True),
+            **bindings,
+        }
+        self.transform = imtransform.Transform.instance
+        self.previous_matrix = self.transform.matrix
+
+        image.resized.connect(self.update_geometry)
+        self.update_geometry()
+        self.show()
+
+    @abc.abstractmethod
+    def update_geometry(self):
+        """Update geometry of the widget."""
+
+    def leave(self, accept: bool = False):
+        """Leave the transform widget for image mode.
+
+        Args:
+            accept: If True, keep the straightening as transformation.
+        """
+        if not accept:
+            self.reset_transformations()
+            self.transform.apply()
+        self.parent().setFocus()  # type: ignore
+
+    def reset_transformations(self):
+        self.transform.setMatrix(*self.previous_matrix)
+
+    def keyPressEvent(self, event):
+        """Run binding from bindings dictionary."""
+        with suppress(ValueError, KeyError):
+            keysequence = keyevent_to_sequence(event)
+            binding = self.bindings[keysequence]
+            api.status.clear("straighten binding")
+            binding()
+            api.status.update("straighten binding")
+
+    def focusOutEvent(self, event):
+        """Delete the widget when focusing out."""
+        self.deleteLater()
+        super().focusOutEvent(event)

--- a/vimiv/gui/transform_widget.py
+++ b/vimiv/gui/transform_widget.py
@@ -42,6 +42,8 @@ class TransformWidget(QWidget, metaclass=utils.AbstractQObjectMeta):
         self.transform = imtransform.Transform.instance
         self.previous_matrix = self.transform.matrix
 
+        image.transformation_module = self.status_info
+
         image.resized.connect(self.update_geometry)
         self.update_geometry()
         self.show()
@@ -49,6 +51,10 @@ class TransformWidget(QWidget, metaclass=utils.AbstractQObjectMeta):
     @abc.abstractmethod
     def update_geometry(self):
         """Update geometry of the widget."""
+
+    def status_info(self) -> str:
+        """Can be overridden by the child to display information in the status bar."""
+        return ""
 
     def leave(self, accept: bool = False):
         """Leave the transform widget for image mode.
@@ -59,6 +65,7 @@ class TransformWidget(QWidget, metaclass=utils.AbstractQObjectMeta):
         if not accept:
             self.reset_transformations()
             self.transform.apply()
+        self.parent().transformation_module = None  # type: ignore
         self.parent().setFocus()  # type: ignore
         self.deleteLater()
         api.status.update("transform widget left")

--- a/vimiv/gui/transform_widget.py
+++ b/vimiv/gui/transform_widget.py
@@ -60,6 +60,8 @@ class TransformWidget(QWidget, metaclass=utils.AbstractQObjectMeta):
             self.reset_transformations()
             self.transform.apply()
         self.parent().setFocus()  # type: ignore
+        self.deleteLater()
+        api.status.update("transform widget left")
 
     def reset_transformations(self):
         self.transform.setMatrix(*self.previous_matrix)
@@ -69,11 +71,11 @@ class TransformWidget(QWidget, metaclass=utils.AbstractQObjectMeta):
         with suppress(ValueError, KeyError):
             keysequence = keyevent_to_sequence(event)
             binding = self.bindings[keysequence]
-            api.status.clear("straighten binding")
+            api.status.clear("transform binding")
             binding()
-            api.status.update("straighten binding")
+            api.status.update("transform binding")
 
     def focusOutEvent(self, event):
-        """Delete the widget when focusing out."""
-        self.deleteLater()
-        super().focusOutEvent(event)
+        """Leave the widget when focusing another widget."""
+        if event.reason() != Qt.ActiveWindowFocusReason:  # Unfocused the whole window
+            self.leave(accept=False)

--- a/vimiv/imutils/imtransform.py
+++ b/vimiv/imutils/imtransform.py
@@ -199,6 +199,9 @@ class Transform(QTransform):
         Returns:
             Rectangle with the coordinates and size within the rotated rectangle.
         """
+        # Not beautiful, but also not much nicer if we refactor this into multiple
+        # functions
+        # pylint: disable=too-many-locals
         rad = angle / 180 * math.pi
         is_portrait = original.height() > original.width()
         short = original.width() if is_portrait else original.height()

--- a/vimiv/imutils/imtransform.py
+++ b/vimiv/imutils/imtransform.py
@@ -54,10 +54,10 @@ class Transform(QTransform):
         self._handler = weakref.ref(handler)
 
     @property
-    def angle(self) -> int:
+    def angle(self) -> float:
         """Current rotation angle in degrees."""
-        x, y = self.map(0, 1)
-        return int(math.atan2(x, y) / math.pi * 180)
+        x, y = self.map(1.0, 0.0)
+        return (math.atan2(y, x) / math.pi * 180) % 360
 
     @api.keybindings.register("<", "rotate --counter-clockwise", mode=api.modes.IMAGE)
     @api.keybindings.register(">", "rotate", mode=api.modes.IMAGE)

--- a/vimiv/imutils/imtransform.py
+++ b/vimiv/imutils/imtransform.py
@@ -143,7 +143,7 @@ class Transform(QTransform):
         """
         original = self._handler().original
         self.rotate(angle)
-        transformed = original.transformed(self, mode=Qt.FastTransformation)
+        transformed = original.transformed(self, mode=Qt.SmoothTransformation)
         rect = self.largest_rect_in_rotated(
             original=original.size(), rotated=transformed.size(), angle=angle
         )

--- a/vimiv/imutils/imtransform.py
+++ b/vimiv/imutils/imtransform.py
@@ -11,7 +11,7 @@ import math
 import weakref
 from typing import Optional
 
-from PyQt5.QtCore import Qt
+from PyQt5.QtCore import Qt, QRect, QSize
 from PyQt5.QtGui import QTransform
 
 from vimiv import api
@@ -31,7 +31,7 @@ def register_transform_command(**kwargs):
             # pylint: disable=protected-access
             self._ensure_editable()
             func(self, *args, **kwargs)
-            self._apply_transformations()
+            self.apply()
 
         return api.commands.register(mode=api.modes.IMAGE, **kwargs)(inner)
 
@@ -127,11 +127,30 @@ class Transform(QTransform):
         dy = dy if dy is not None else dx
         self.scale(dx, dy)
 
-    def _apply_transformations(self):
+    def apply(self):
         """Apply all transformations to the original pixmap."""
-        transformed = self._handler().original.transformed(
-            self, mode=Qt.SmoothTransformation
+        original = self._handler().original
+        self._apply(original.transformed(self, mode=Qt.SmoothTransformation))
+
+    def straighten(self, *, angle: int):
+        """Straighten the original image.
+
+        This rotates the image by the total angle and crops the valid, axis-aligned
+        rectangle from the rotated image.
+
+        Args:
+            angle: Rotation angle to straighten the original image by.
+        """
+        original = self._handler().original
+        self.rotate(angle)
+        transformed = original.transformed(self, mode=Qt.FastTransformation)
+        rect = self.largest_rect_in_rotated(
+            original=original.size(), rotated=transformed.size(), angle=angle
         )
+        self._apply(transformed.copy(rect))
+
+    def _apply(self, transformed):
+        """Check the transformed pixmap for validity and apply it to the handler."""
         if transformed.isNull():
             raise api.commands.CommandError(
                 "Error transforming image, ignoring transformation.\n"
@@ -148,8 +167,54 @@ class Transform(QTransform):
         """True if transformations have been applied."""
         return not self.isIdentity()
 
+    @property
+    def matrix(self):
+        """Tuple of matrix elements defining the current transformation matrix."""
+        # fmt: off
+        return (
+            self.m11(), self.m12(), self.m13(),
+            self.m21(), self.m22(), self.m23(),
+            self.m31(), self.m32(), self.m33(),
+        )
+        # fmt: on
+
     @api.commands.register(mode=api.modes.IMAGE)
     def undo_transformations(self):
         """Undo any transformation applied to the current image."""
         self.reset()
         self._handler().transformed = self._handler().original
+
+    @classmethod
+    def largest_rect_in_rotated(
+        cls, *, original: QSize, rotated: QSize, angle: float
+    ) -> QRect:
+        """Return largest possible axis-aligned rectangle in rotated rectangle.
+
+        See https://stackoverflow.com/a/16778797 for the implementation details.
+
+        Args:
+            original: Size of the original (unrotated) rectangle.
+            rotated: Size of the rotated and padded rectangle (larger than original).
+            angle: Rotation angle in degrees.
+        Returns:
+            Rectangle with the coordinates and size within the rotated rectangle.
+        """
+        rad = angle / 180 * math.pi
+        is_portrait = original.height() > original.width()
+        short = original.width() if is_portrait else original.height()
+        long = original.height() if is_portrait else original.width()
+        sin_a = abs(math.sin(rad))
+        cos_a = abs(math.cos(rad))
+
+        if short <= 2.0 * sin_a * cos_a * long or abs(sin_a - cos_a) < 1e-10:
+            s = 0.5 * short
+            wr, hr = (s / cos_a, s / sin_a) if is_portrait else (s / sin_a, s / cos_a)
+        else:
+            cos_2a = cos_a ** 2 - sin_a ** 2
+            wr = (original.width() * cos_a - original.height() * sin_a) / cos_2a
+            hr = (original.height() * cos_a - original.width() * sin_a) / cos_2a
+
+        x = (rotated.width() - wr) // 2
+        y = (rotated.height() - hr) // 2
+
+        return QRect(int(x), int(y), int(wr), int(hr))


### PR DESCRIPTION
Implements a new `:straighten` command which displays a grid to straighten images.

The image is rotated clockwise with `l`, `>` or `L` and counter-clockwise with `h`, `<` or `H`. Changes are accepted with `<return>` and discarded with `<escape>`. This comes with the new `{transformation-info}` status module which displays the current angle when straightening.

Here is a picture of the whole implementation in action:
![vimiv-straighten](https://user-images.githubusercontent.com/12006766/72687379-7a3a4f00-3afd-11ea-9210-bdb0028c1952.png)

