### PR TITLE
Add prompt to ask the user for confirmation

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,11 @@ Added:
   counter-clockwise with ``h``, ``<`` and ``H``. Accept the changes with ``<return>``
   and reject them with ``<escape>``. It comes ith the ``{transformation-info}`` status
   module that displays the current straightening angle in degrees.
+* The option to prompt the user for an answer using ``api.prompt.ask_question``. This
+  comes with a blocking prompt which can be answered using key presses.
+* A new ``PromptSetting`` type which is essentially a boolean setting with the
+  additional ``ask`` value. If the value is ``ask``, the user is prompted everytime the
+  boolean state of this setting is requested.
 
 Changed:
 ^^^^^^^^
@@ -29,6 +34,8 @@ Changed:
   with the python builtin. Using ``api.open`` directly is deprecated and will be removed
   in `v0.7.0`.
 * The slideshow is always stopped when the image is unfocused.
+* The ``image.autowrite`` setting is now ``ask`` by default. This should prevent
+  surprises in case the changes are written to disk or discarded.
 
 Fixed:
 ^^^^^^

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,7 +20,10 @@ Added:
   and reject them with ``<escape>``. It comes ith the ``{transformation-info}`` status
   module that displays the current straightening angle in degrees.
 * The option to prompt the user for an answer using ``api.prompt.ask_question``. This
-  comes with a blocking prompt which can be answered using key presses.
+  comes with a blocking prompt which can be answered using key presses. The prompt can
+  be styled with the ``prompt.font``, ``prompt.fg``, ``prompt.bg``,
+  ``prompt.padding``, ``prompt.border_radius``, ``prompt.border`` and
+  ``prompt.border.color`` styles.
 * A new ``PromptSetting`` type which is essentially a boolean setting with the
   additional ``ask`` value. If the value is ``ask``, the user is prompted everytime the
   boolean state of this setting is requested.

--- a/docs/documentation/hacking.rst
+++ b/docs/documentation/hacking.rst
@@ -194,6 +194,12 @@ Working Directory
 
 .. automodule:: vimiv.api.working_directory
 
+Prompt
+""""""
+.. automodule:: vimiv.api.prompt
+    :members:
+     ask_question
+
 Imutils Module
 ^^^^^^^^^^^^^^
 

--- a/tests/end2end/features/api/prompt.feature
+++ b/tests/end2end/features/api/prompt.feature
@@ -1,0 +1,13 @@
+Feature: Prompt the user for a question
+
+    Scenario Outline: Ask a question and answer it
+        Given I open any directory
+        And I ask a question and press <key>
+        Then I expect <answer> as answer
+
+        Examples:
+            | key        | answer |
+            | y          | true   |
+            | n          | false  |
+            | <return>   | false  |
+            | <escape>   | none   |

--- a/tests/end2end/features/api/test_prompt_bdd.py
+++ b/tests/end2end/features/api/test_prompt_bdd.py
@@ -4,45 +4,17 @@
 # Copyright 2017-2020 Christian Karl (karlch) <karlch at protonmail dot com>
 # License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
 
-from PyQt5.QtCore import QTimer, Qt
-
 import pytest_bdd as bdd
 
-import vimiv.gui.prompt
 from vimiv import api
 
 
 bdd.scenarios("prompt.feature")
 
 
-def get_prompt(mainwindow):
-    """Retrieve the current prompt widget."""
-    widgets = mainwindow.findChildren(vimiv.gui.prompt.Prompt)
-    assert len(widgets) == 1, "Wrong number of prompts found"
-    return widgets[0]
-
-
 @bdd.given(bdd.parsers.parse("I ask a question and press <key>"))
-def answer_question(qtbot, mainwindow, key):
-    # We define ask and answer in one fixture to avoid a blocking prompt
-    keys = {
-        "y": Qt.Key_Y,
-        "n": Qt.Key_N,
-        "<return>": Qt.Key_Return,
-        "<escape>": Qt.Key_Escape,
-    }
-    try:
-        qkey = keys[key]
-    except KeyError:
-        raise KeyError(
-            f"Unexpected prompt key '{key}', expected one of: {', '.join(keys)}"
-        )
-
-    def click_prompt_key():
-        prompt = get_prompt(mainwindow)
-        qtbot.keyClick(prompt, qkey)
-
-    QTimer.singleShot(0, lambda: qtbot.waitUntil(click_prompt_key))
+def answer_question(qtbot, answer_prompt, key):
+    answer_prompt(key)
     yield api.prompt.ask_question(title="end2end-question", body="Hello there?")
 
 

--- a/tests/end2end/features/api/test_prompt_bdd.py
+++ b/tests/end2end/features/api/test_prompt_bdd.py
@@ -1,0 +1,59 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2020 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+from PyQt5.QtCore import QTimer, Qt
+
+import pytest_bdd as bdd
+
+import vimiv.gui.prompt
+from vimiv import api
+
+
+bdd.scenarios("prompt.feature")
+
+
+def get_prompt(mainwindow):
+    """Retrieve the current prompt widget."""
+    widgets = mainwindow.findChildren(vimiv.gui.prompt.Prompt)
+    assert len(widgets) == 1, "Wrong number of prompts found"
+    return widgets[0]
+
+
+@bdd.given(bdd.parsers.parse("I ask a question and press <key>"))
+def answer_question(qtbot, mainwindow, key):
+    # We define ask and answer in one fixture to avoid a blocking prompt
+    keys = {
+        "y": Qt.Key_Y,
+        "n": Qt.Key_N,
+        "<return>": Qt.Key_Return,
+        "<escape>": Qt.Key_Escape,
+    }
+    try:
+        qkey = keys[key]
+    except KeyError:
+        raise KeyError(
+            f"Unexpected prompt key '{key}', expected one of: {', '.join(keys)}"
+        )
+
+    def click_prompt_key():
+        prompt = get_prompt(mainwindow)
+        qtbot.keyClick(prompt, qkey)
+
+    QTimer.singleShot(0, lambda: qtbot.waitUntil(click_prompt_key))
+    yield api.prompt.ask_question(title="end2end-question", body="Hello there?")
+
+
+@bdd.then(bdd.parsers.parse("I expect <answer> as answer"))
+def check_prompt(answer_question, answer):
+    answer = answer.lower()
+    if answer in ("true", "yes", "1"):
+        assert answer_question
+    elif answer in ("false", "no", "0"):
+        assert not answer_question
+    elif answer == "none":
+        assert answer_question is None
+    else:
+        raise ValueError(f"Unexpected prompt answer '{answer}'")

--- a/tests/end2end/features/image/write.feature
+++ b/tests/end2end/features/image/write.feature
@@ -17,3 +17,10 @@ Feature: Write an image to disk
         When I add exif information
         And I write the image to new_path.jpg
         Then the image new_path.jpg should contain exif information
+
+    Scenario: Prompt for writing edited image
+        Given I open any image
+        When I run rotate
+        And I plan to answer the prompt with n
+        And I run next
+        Then no crash should happen

--- a/tests/unit/api/test_prompt.py
+++ b/tests/unit/api/test_prompt.py
@@ -1,0 +1,41 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2020 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+"""Tests for vimiv.api.prompt."""
+
+from PyQt5.QtCore import QObject
+
+import pytest
+
+from vimiv.api import prompt
+
+
+class QuestionAnswerer(QObject):
+    """Stub class answering an asked question with a defined value."""
+
+    def __init__(self, *, title: str, body: str, answer=None):
+        super().__init__()
+        self.title = title
+        self.body = body
+        self.answered = False
+        self.answer = answer
+        prompt.question_asked.connect(self.answer_question)
+
+    def answer_question(self, question: prompt.Question):
+        assert question.title == self.title
+        assert question.body == self.body
+        question.answer = self.answer
+        self.answered = True
+
+
+@pytest.mark.parametrize("answer", (None, 42, "answer"))
+def test_ask_question(answer):
+    title = "Question"
+    body = "Does this test work?"
+    answerer = QuestionAnswerer(title=title, body=body, answer=answer)
+    answer = prompt.ask_question(title=title, body=body)
+    assert answerer.answered
+    assert answer == answer

--- a/vimiv/api/__init__.py
+++ b/vimiv/api/__init__.py
@@ -17,6 +17,7 @@ from . import (
     keybindings,
     modes,
     objreg,
+    prompt,
     settings,
     signals,
     status,

--- a/vimiv/api/prompt.py
+++ b/vimiv/api/prompt.py
@@ -1,0 +1,62 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2020 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+"""Prompt the user for a question."""
+
+import typing
+
+from PyQt5.QtCore import QObject, pyqtSignal
+
+
+class Question:
+    """Storage class for a question to the user.
+
+    Attributes:
+        title: Title of the question.
+        body: Sentence body representing the actual question.
+        answer: Answer given by the user if any.
+    """
+
+    def __init__(self, *, title: str, body: str):
+        self.title = title
+        self.body = body
+        self.answer = None
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__qualname__}(title={self.title}, body={self.body})"
+
+
+class _Bridge(QObject):
+    """Message bridge using the signal-slot infrastructure.
+
+    Signals:
+        question_asked: Emitted when a question to the user was asked.
+            arg1: The Question instance storing all information on the question.
+    """
+
+    question_asked = pyqtSignal(Question)
+
+
+def ask_question(*, title: str, body: str) -> typing.Any:
+    """Prompt the user to answer a question.
+
+    This emits the question_asked signal which leads to a gui prompt being displayed.
+    The UI is blocked until the question was answered or aborted.
+
+    Args:
+        title: Title of the question.
+        body: Sentence body representing the actual question.
+    Returns:
+        answer: Answer given by the user if any.
+    """
+    question = Question(title=title, body=body)
+    question_asked.emit(question)  # Enters a gui prompt widget
+    return question.answer
+
+
+# Expose only signals from the bridge
+_bridge = _Bridge()
+question_asked = _bridge.question_asked

--- a/vimiv/api/prompt.py
+++ b/vimiv/api/prompt.py
@@ -10,6 +10,11 @@ import typing
 
 from PyQt5.QtCore import QObject, pyqtSignal
 
+from vimiv.utils import log
+
+
+_logger = log.module_logger(__name__)
+
 
 class Question:
     """Storage class for a question to the user.
@@ -53,7 +58,9 @@ def ask_question(*, title: str, body: str) -> typing.Any:
         answer: Answer given by the user if any.
     """
     question = Question(title=title, body=body)
+    _logger.debug("Asking question '%s'", question.title)
     question_asked.emit(question)  # Enters a gui prompt widget
+    _logger.debug("Answered '%s' with '%s'", question.title, question.answer)
     return question.answer
 
 

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -374,7 +374,13 @@ class image:  # pylint: disable=invalid-name
     autoplay = BoolSetting(
         "image.autoplay", True, desc="Start playing animations on open"
     )
-    autowrite = BoolSetting("image.autowrite", True, desc="Save images on changes")
+    autowrite = PromptSetting(
+        "image.autowrite",
+        PromptSetting.Options.ask,
+        question_title="Image edited",
+        question_body="Do you want to write your changes to disk?",
+        desc="Save images on changes",
+    )
     overzoom = FloatSetting(
         "image.overzoom",
         1.0,

--- a/vimiv/config/_style_options.py
+++ b/vimiv/config/_style_options.py
@@ -79,4 +79,12 @@ DEFAULT_OPTIONS = {
     "metadata.border_radius": "{keyhint.border_radius}",
     # Straighten widget
     "image.straighten.color": "{base0a}",
+    # Prompt
+    "prompt.font": "{statusbar.font}",
+    "prompt.fg": "{statusbar.fg}",
+    "prompt.bg": "{statusbar.bg}",
+    "prompt.padding": "{keyhint.padding}",
+    "prompt.border_radius": "{keyhint.border_radius}",
+    "prompt.border": "{statusbar.message_border}",
+    "prompt.border.color": "{statusbar.info}",
 }

--- a/vimiv/gui/mainwindow.py
+++ b/vimiv/gui/mainwindow.py
@@ -52,6 +52,7 @@ class MainWindow(QWidget):
         api.modes.COMMAND.left.connect(self._update_overlay_geometry)
         api.settings.statusbar.show.changed.connect(self._update_overlay_geometry)
         api.modes.MANIPULATE.first_entered.connect(self._init_manipulate)
+        api.prompt.question_asked.connect(self._run_prompt)
 
     @utils.slot
     def _init_manipulate(self):
@@ -155,6 +156,15 @@ class MainWindow(QWidget):
         except KeyError:
             title = api.settings.get_value("title.fallback")
         self.setWindowTitle(api.status.evaluate(title))
+
+    @utils.slot
+    def _run_prompt(self, question: api.prompt.Question) -> None:
+        """Display a UI blocking prompt when a question was asked."""
+        from .prompt import Prompt
+
+        prompt = Prompt(question, parent=self)
+        prompt.update_geometry(self.width(), self.bottom)
+        prompt.run()
 
 
 class ImageThumbnailStack(QStackedWidget):

--- a/vimiv/gui/prompt.py
+++ b/vimiv/gui/prompt.py
@@ -13,6 +13,9 @@ from vimiv import api, utils
 from vimiv.config import styles
 
 
+_logger = utils.log.module_logger(__name__)
+
+
 class Prompt(QLabel):
     """Blocking prompt widget asking the user a question.
 
@@ -55,11 +58,15 @@ class Prompt(QLabel):
         styles.apply(self)
         header = f"<h3>{question.title}</h3>{question.body}"
         self.setText(header + self.bindings_table())
+        _logger.debug("Initialized %s", self)
 
         self.setFocus()
         self.adjustSize()
         self.raise_()
         self.show()
+
+    def __str__(self):
+        return f"prompt for '{self.question.title}'"
 
     @classmethod
     def bindings_table(cls):
@@ -75,6 +82,7 @@ class Prompt(QLabel):
 
     def run(self):
         """Run the blocking event loop."""
+        _logger.debug("Running blocking %s", self)
         self.loop.exec_()
 
     def update_geometry(self, _width: int, bottom: int):
@@ -83,6 +91,7 @@ class Prompt(QLabel):
 
     def leave(self, *, answer=None):
         """Leave the prompt by answering the question and quitting the loop."""
+        _logger.debug("Leaving %s with '%s'", self, answer)
         self.question.answer = answer
         self.loop.quit()
         self.loop.deleteLater()

--- a/vimiv/gui/prompt.py
+++ b/vimiv/gui/prompt.py
@@ -33,13 +33,13 @@ class Prompt(QLabel):
 
     STYLESHEET = """
     QLabel {
-        font: {statusbar.font};
-        background-color: {statusbar.bg};
-        padding: {keyhint.padding};
-        color: {statusbar.fg};
-        border-top-right-radius: {keyhint.border_radius};
-        border-top: {statusbar.message_border} {statusbar.info};
-        border-right: {statusbar.message_border} {statusbar.info};
+        font: {prompt.font};
+        color: {prompt.fg};
+        background-color: {prompt.bg};
+        padding: {prompt.padding};
+        border-top-right-radius: {prompt.border_radius};
+        border-top: {prompt.border} {prompt.border.color};
+        border-right: {prompt.border} {prompt.border.color};
     }
     """
 

--- a/vimiv/gui/prompt.py
+++ b/vimiv/gui/prompt.py
@@ -1,0 +1,105 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2020 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+"""Blocking prompt widget asking the user a question."""
+
+from PyQt5.QtCore import Qt, QEventLoop
+from PyQt5.QtWidgets import QLabel
+
+from vimiv import api, utils
+from vimiv.config import styles
+
+
+class Prompt(QLabel):
+    """Blocking prompt widget asking the user a question.
+
+    The prompt is initialized with a question and displays the question, its title and
+    the valid keybindings. Calling ``run`` blocks the UI until a valid keybinding to
+    answer/abort the question was given.
+
+    Class Attributes:
+        BINDINGS: Valid keybindings to answer/abort the question.
+
+    Attributes:
+        question: Question object defining title, question and answer.
+        loop: Event loop used to block the UI.
+    """
+
+    STYLESHEET = """
+    QLabel {
+        font: {statusbar.font};
+        background-color: {statusbar.bg};
+        padding: {keyhint.padding};
+        color: {statusbar.fg};
+        border-top-right-radius: {keyhint.border_radius};
+        border-top: {statusbar.message_border} {statusbar.info};
+        border-right: {statusbar.message_border} {statusbar.info};
+    }
+    """
+
+    BINDINGS = (
+        ("y", "Yes"),
+        ("n", "No"),
+        ("<return>", "No"),
+        ("<escape>", "Abort"),
+    )
+
+    def __init__(self, question: api.prompt.Question, *, parent):
+        super().__init__(parent=parent)
+        self.question = question
+        self.loop = QEventLoop()
+
+        styles.apply(self)
+        header = f"<h3>{question.title}</h3>{question.body}"
+        self.setText(header + self.bindings_table())
+
+        self.setFocus()
+        self.adjustSize()
+        self.raise_()
+        self.show()
+
+    @classmethod
+    def bindings_table(cls):
+        """Return a formatted html table with the valid keybindings."""
+        bindings = "".join(
+            "<tr>"
+            f"<td><b>{utils.escape_html(binding)}</b></td>"
+            f"<td style='padding-left: 2ex'>{command}</td>"
+            "</tr>"
+            for binding, command in cls.BINDINGS
+        )
+        return f"<table>{bindings}</table>"
+
+    def run(self):
+        """Run the blocking event loop."""
+        self.loop.exec_()
+
+    def update_geometry(self, _width: int, bottom: int):
+        y = bottom - self.height()
+        self.setGeometry(0, y, self.width(), self.height())
+
+    def leave(self, *, answer=None):
+        """Leave the prompt by answering the question and quitting the loop."""
+        self.question.answer = answer
+        self.loop.quit()
+        self.loop.deleteLater()
+        self.deleteLater()
+        api.modes.current().widget.setFocus()
+
+    def keyPressEvent(self, event):
+        """Leave the prompt on a valid key binding."""
+        if event.key() == Qt.Key_Y:
+            self.leave(answer=True)
+        elif event.key() in (Qt.Key_N, Qt.Key_Return):
+            self.leave(answer=False)
+        elif event.key() == Qt.Key_Escape:
+            self.leave()
+
+    def focusOutEvent(self, event):
+        """Leave the prompt without answering when unfocused."""
+        if self.loop.isRunning():
+            self.leave()
+        super().focusOutEvent(event)

--- a/vimiv/imutils/_file_handler.py
+++ b/vimiv/imutils/_file_handler.py
@@ -128,6 +128,11 @@ class ImageFileHandler(QObject):
         self._pixmaps.transformed = pixmap
         self.current = pixmap
 
+    @property
+    def changed(self):
+        """True if the current image was edited in any way."""
+        return self.transform.changed or (self.manipulate and self.manipulate.changed)
+
     @utils.slot
     def _on_new_image_opened(self, path: str):
         """Load proper displayable QWidget for a new image path."""
@@ -153,12 +158,12 @@ class ImageFileHandler(QObject):
             path: Path to the image file.
             parallel: Write the image in an additional thread.
         """
-        if not api.settings.image.autowrite:
-            self._reset()
-        elif self.transform.changed or (
-            self.manipulate is not None and self.manipulate.changed
-        ):
+        if not self.changed:
+            return
+        if api.settings.image.autowrite:
             self.write_pixmap(self.current, path, original_path=path, parallel=parallel)
+        else:
+            self._reset()
 
     @utils.slot
     def _on_quit(self):


### PR DESCRIPTION
The prompt is displayed in the bottom-left above the statusbar and asks the user a simple yes/no/abort question. It can be started with the ``api.prompt.ask_question`` function. In addition there is the new ``PromptSetting`` type which is essentially a boolean setting with the additional ``ask`` value. When set to ``ask``, the user is prompted everytime the boolean value of this setting is requested.

This new setting is now used for ``image.autowrite`` defaulting to ``ask``. This should help resolve the issue mentioned by @symbioquine in https://github.com/karlch/vimiv/issues/48.

Here is an image of how this looks in action:
![vimiv-prompt](https://user-images.githubusercontent.com/12006766/73135151-5ddb6c80-403f-11ea-8a26-5e5c3a019867.png)

As I see no further issues with the default settings, fixes #169.