### PR TITLE
Fix logging for lazy-loaded modules

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@
 """Fixtures for pytest."""
 
 import os
+import logging
 
 import pytest
 
@@ -57,3 +58,30 @@ def cleanup_helper():
                     del init_dict[key][elem]
 
     return cleanup
+
+
+class StubStream:
+    """Dummy stream class that does nothing on write and friends."""
+
+    def stub(self, *args, **kwargs):
+        """Method that accepts anything and does nothing."""
+
+    write = writelines = close = stub
+
+
+class DevNullLogHandler(logging.StreamHandler):
+    """Stub log handler that redirects everything to the black hole."""
+
+    def __init__(self, *args, **kwargs):
+        self.devnull = StubStream()
+        super().__init__(self.devnull)
+
+
+@pytest.fixture(autouse=True)
+def mock_file_handler(monkeypatch):
+    """Fixture to monkeypatch the logging file handler.
+
+    It is not required in any testing here and we do not want to write the test log
+    statements to file.
+    """
+    monkeypatch.setattr(logging, "FileHandler", DevNullLogHandler)

--- a/tests/unit/utils/test_log.py
+++ b/tests/unit/utils/test_log.py
@@ -1,0 +1,60 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2020 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+"""Tests for vimiv.utils.log."""
+
+import pytest
+
+from vimiv.utils import log
+
+
+@pytest.fixture(autouse=True)
+def clean_module_loggers():
+    """Fixture to remove any created module loggers."""
+    init_loggers = dict(log._module_loggers)
+    yield
+    for logger in dict(log._module_loggers):
+        if logger not in init_loggers:
+            del log._module_loggers[logger]
+
+
+@pytest.fixture
+def lazy_logger():
+    """Fixture to retrieve a clean lazy logger instance."""
+    return log.LazyLogger("test.logger")
+
+
+@pytest.fixture
+def setup_logging():
+    """Fixture to setup logging appropriately."""
+    log.setup_logging(logging.WARNING)
+
+
+@pytest.mark.parametrize("name", ("vimiv.module", "other.module"))
+def test_module_logger_name(name):
+    expected = name.replace("vimiv.", "")
+    logger = log.module_logger(name)
+    assert logger._name == expected
+
+
+def test_lazy_logger_is_lazy(setup_logging, lazy_logger):
+    """Ensure lazy logger is only created when a message above its level is logged."""
+    message = "Random log statement"
+    lazy_logger.debug(message)
+    assert lazy_logger._logger is None  # Not created for debug message
+    lazy_logger.warning(message)
+    assert lazy_logger._logger is not None  # Created by warning message
+
+
+def test_lazy_logger_logs(capsys, setup_logging, lazy_logger):
+    """Ensure lazy logger logs messages as expected."""
+    message = "Random log statement"
+    lazy_logger.debug(message)
+    captured = capsys.readouterr()
+    assert message not in captured.err
+    lazy_logger.warning(message)
+    captured = capsys.readouterr()
+    assert message in captured.err

--- a/vimiv/utils/log.py
+++ b/vimiv/utils/log.py
@@ -49,7 +49,7 @@ import vimiv
 from . import xdg
 
 
-_module_loggers: Dict[str, logging.Logger] = {}
+_module_loggers: Dict[str, "LazyLogger"] = {}
 formatter = logging.Formatter(
     "[{asctime}] {levelname:8} {name:20} {message}", datefmt="%H:%M:%S", style="{"
 )

--- a/vimiv/utils/log.py
+++ b/vimiv/utils/log.py
@@ -53,6 +53,7 @@ _module_loggers: Dict[str, logging.Logger] = {}
 formatter = logging.Formatter(
     "[{asctime}] {levelname:8} {name:20} {message}", datefmt="%H:%M:%S", style="{"
 )
+_debug_loggers: List[str] = []
 
 
 def debug(msg: str, *args, **kwargs):
@@ -106,6 +107,7 @@ def setup_logging(level: int, *debug_modules: str) -> None:
     _app_logger.handlers = [file_handler, console_handler, statusbar_loghandler]
     LazyLogger.handlers = [console_handler, file_handler]
     # Setup debug logging for specific module loggers
+    _debug_loggers.extend(debug_modules)
     for name, logger in _module_loggers.items():
         logger.level = logging.DEBUG if name in debug_modules else level
 
@@ -123,7 +125,8 @@ def module_logger(name: str) -> "LazyLogger":
         The created logger object.
     """
     name = name.replace("vimiv.", "")
-    logger = LazyLogger(name)
+    level = logging.DEBUG if name in _debug_loggers else _app_logger.level
+    logger = LazyLogger(name, level=level)
     _module_loggers[name] = logger
     return logger
 
@@ -138,8 +141,8 @@ class LazyLogger:
 
     handlers: List[logging.Handler] = []
 
-    def __init__(self, name):
-        self.level = logging.WARNING
+    def __init__(self, name, level=logging.WARNING):
+        self.level = level
         self._logger = None
         self._name = name
 

--- a/vimiv/utils/log.py
+++ b/vimiv/utils/log.py
@@ -122,7 +122,10 @@ def module_logger(name: str) -> "LazyLogger":
     Returns:
         The created logger object.
     """
-    return LazyLogger(name, is_module_logger=True)
+    name = name.replace("vimiv.", "")
+    logger = LazyLogger(name)
+    _module_loggers[name] = logger
+    return logger
 
 
 class LazyLogger:
@@ -135,12 +138,10 @@ class LazyLogger:
 
     handlers: List[logging.Handler] = []
 
-    def __init__(self, name, is_module_logger=False):
+    def __init__(self, name):
         self.level = logging.WARNING
         self._logger = None
-        self._name = name.replace("vimiv.", "") if is_module_logger else name
-        if is_module_logger:
-            _module_loggers[self._name] = self
+        self._name = name
 
     def log(self, level: int, msg: str, *args, **kwargs) -> None:
         """Log a message creating the logger instance if needed."""


### PR DESCRIPTION
As the log level for module-based loggers was only configured in `setup_logging` which is called upon startup, the log level of module-loggers for modules loaded later was always the default `logging.WARNING`. This is fixed by also setting the correct level when creating a new logger. The actual changes in the `utils.log` module are small, but quite some unit tests were added to check this behaviour.

Fixes #172.