### PR TITLE
Correctly set image focal-point

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,13 @@ Changed:
 * Manipulations are no longer directly written to file when running ``:accept``.
   Instead, they behave according to the ``image.autowrite`` setting just like
   transformations.
+* Zooming now always uses the center of the currently visible area as focal-point.
+
+Fixed:
+^^^^^^
+
+* Centering the image on any type of resize, even when the user explicitly changed the
+  scroll position.
 
 
 v0.6.1 (2020-03-07)

--- a/tests/end2end/features/image/imagescroll.feature
+++ b/tests/end2end/features/image/imagescroll.feature
@@ -1,0 +1,20 @@
+Feature: Scroll the current image
+
+    Background:
+        Given I open any image
+
+    Scenario: Scroll to left edge
+        When I run 10zoom in
+        And I run scroll-edge left
+        Then the image left-edge should be 0
+
+    Scenario: Scroll to right edge
+        When I run 10zoom in
+        And I run scroll-edge right
+        Then the image right-edge should be 300
+
+    Scenario: Keep scroll position when size changes
+        When I run 10zoom in
+        And I run scroll-edge left
+        And I resize the image
+        Then the image left-edge should be 0

--- a/tests/end2end/features/image/test_imagescroll_bdd.py
+++ b/tests/end2end/features/image/test_imagescroll_bdd.py
@@ -1,0 +1,32 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2020 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+from PyQt5.QtGui import QResizeEvent
+
+import pytest_bdd as bdd
+
+
+bdd.scenarios("imagescroll.feature")
+
+
+@bdd.when("I resize the image")
+def resize_image(image):
+    image.resizeEvent(QResizeEvent(image.size(), image.size()))
+
+
+@bdd.then(bdd.parsers.parse("the image {position} should be {value:d}"))
+def check_image_coordinate(image, position, value):
+    rect = image.visible_rect
+    assert position_to_value(position, rect) == value
+
+
+def position_to_value(position, rect):
+    position = position.lower()
+    if position == "left-edge":
+        return rect.x()
+    if position == "right-edge":
+        return rect.x() + rect.width()
+    raise ValueError(f"Unknown position '{position}'")

--- a/vimiv/gui/image.py
+++ b/vimiv/gui/image.py
@@ -141,6 +141,10 @@ class ScrollableImage(EventHandlerMixin, QGraphicsView):
             self.scene().addWidget(item)
         self.scene().setSceneRect(rect)
         self.scale(self._scale if reload_only else ImageScale.Overzoom)  # type: ignore
+        self._update_focalpoint()
+
+    def _update_focalpoint(self):
+        self.centerOn(self.focalpoint)
 
     def _on_images_cleared(self) -> None:
         self.scene().clear()
@@ -175,8 +179,7 @@ class ScrollableImage(EventHandlerMixin, QGraphicsView):
     @api.commands.register(mode=api.modes.IMAGE)
     def center(self):
         """Center the image in the viewport."""
-        rect = self.scene().sceneRect()
-        self.centerOn(rect.width() / 2, rect.height() / 2)
+        self.centerOn(self.sceneRect().center())
 
     @api.keybindings.register("K", "scroll-edge up", mode=api.modes.IMAGE)
     @api.keybindings.register("J", "scroll-edge down", mode=api.modes.IMAGE)
@@ -255,7 +258,6 @@ class ScrollableImage(EventHandlerMixin, QGraphicsView):
             level *= count  # type: ignore  # Required so it is stored correctly later
             self._scale_to_float(level)
         self._scale = level
-        self.center()
 
     def _scale_to_fit(
         self, width: float = None, height: float = None, limit: float = INF
@@ -284,7 +286,10 @@ class ScrollableImage(EventHandlerMixin, QGraphicsView):
             level: Size to scale to. 1 is the original image size.
         """
         level = utils.clamp(level, self.MIN_SCALE, self.MAX_SCALE)
-        super().scale(level / self.zoom_level, level / self.zoom_level)
+        factor = level / self.zoom_level
+        super().scale(factor, factor)
+        if factor < 1:
+            self._update_focalpoint()
 
     @property
     def zoom_level(self) -> float:

--- a/vimiv/gui/image.py
+++ b/vimiv/gui/image.py
@@ -99,6 +99,16 @@ class ScrollableImage(EventHandlerMixin, QGraphicsView):
         """List of current paths for image mode."""
         return imutils.pathlist()
 
+    @property
+    def focalpoint(self):
+        """The center of the currently visible part of the scene."""
+        return self.visible_rect.center()
+
+    @property
+    def visible_rect(self):
+        """The currently visible part of the scene in the image coordinates."""
+        return self.mapToScene(self.viewport().rect()).boundingRect() & self.sceneRect()
+
     def _load_pixmap(self, pixmap: QPixmap, reload_only: bool) -> None:
         """Load new pixmap into the graphics scene."""
         item = QGraphicsPixmapItem()


### PR DESCRIPTION
* Zoom now always uses the center of the displayed area as focal-point.
* The image is no longer centered on resize, irrespective of the current scroll position.