### PR TITLE
Refactor class hierarchy of the (status-) bar

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -31,6 +31,10 @@ Changed:
   the html-equivalent ``&nbsp;`` if there are multiple subsequent spaces. This keeps
   wanted additional spacing while allowing to use html code such as
   ``<span style='color: #8FBCBB; font-weight: bold;'>colored and bold</span>``.
+* Both the command line and the widget to display status messages are now overlay
+  widgets instead of being integrated with the bar. This decouples them from the main
+  grid layout and better reflects their role as they are being shown temporarily over
+  the current widget/image.
 
 Fixed:
 ^^^^^^
@@ -42,6 +46,7 @@ Fixed:
 * Crash when scrolling thumbnail mode with empty thumbnail list.
 * Crash when running ``:goto`` without valid paths/images/thumbnails.
 * Switching mode when toggling an inactive mode.
+* Displaying status messages larger than one line in manipulate mode.
 
 
 v0.6.1 (2020-03-07)

--- a/tests/end2end/features/commandline/test_commandline_bdd.py
+++ b/tests/end2end/features/commandline/test_commandline_bdd.py
@@ -11,7 +11,6 @@ import pytest_bdd as bdd
 import vimiv
 from vimiv import api
 from vimiv.commands import runners
-from vimiv.gui import statusbar
 
 
 bdd.scenarios("commandline.feature")
@@ -29,20 +28,20 @@ def check_commandline_closed():
 
 @bdd.then(bdd.parsers.parse("the help for '{topic}' should be displayed"))
 @bdd.then("the help for '<topic>' should be displayed")
-def check_help(topic):
+def check_help(message_widget, topic):
     if topic == "vimiv":
-        assert vimiv.__description__ in statusbar.statusbar.message.text()
+        assert vimiv.__description__ in message_widget.text()
         return
     if topic == "wildcards":
-        assert "wildcards" in statusbar.statusbar.message.text().lower()
+        assert "wildcards" in message_widget.text().lower()
         return
     topic = topic.lower().lstrip(":")
     with suppress(api.commands.CommandNotFound):
         command = api.commands.get(topic, mode=api.modes.current())
-        assert command.description in statusbar.statusbar.message.text()
+        assert command.description in message_widget.text()
         return
     with suppress(KeyError):
         setting = api.settings.get(topic)
-        assert setting.desc in statusbar.statusbar.message.text()
+        assert setting.desc in message_widget.text()
         return
     raise AssertionError(f"Topic '{topic}' not found")

--- a/tests/end2end/features/conftest.py
+++ b/tests/end2end/features/conftest.py
@@ -67,6 +67,11 @@ def message_widget(mainwindow):
     return get_overlay(mainwindow, vimiv.gui.message.Message)
 
 
+@pytest.fixture()
+def overlay(mainwindow):
+    return lambda typ: get_overlay(mainwindow, typ)
+
+
 def get_overlay(mainwindow, typ):
     for overlay in mainwindow._overlays:
         if isinstance(overlay, typ):

--- a/tests/end2end/features/conftest.py
+++ b/tests/end2end/features/conftest.py
@@ -18,6 +18,7 @@ import pytest_bdd as bdd
 import vimiv.gui.library
 import vimiv.gui.thumbnail
 import vimiv.gui.mainwindow
+import vimiv.gui.message
 import vimiv.gui.commandline
 import vimiv.gui.bar
 import vimiv.gui.image
@@ -59,6 +60,14 @@ def bar():
 @pytest.fixture()
 def image():
     yield vimiv.gui.image.ScrollableImage.instance
+
+
+@pytest.fixture()
+def message_widget(mainwindow):
+    for overlay in mainwindow._overlays:
+        if isinstance(overlay, vimiv.gui.message.Message):
+            return overlay
+    raise ValueError("Message widget not found")
 
 
 class Counter:
@@ -260,49 +269,43 @@ def no_crash(qtbot):
     qtbot.wait(1)
 
 
-@bdd.then(bdd.parsers.parse("the message\n'{message}'\nshould be displayed"))
-def check_statusbar_message(qtbot, message):
-    bar = statusbar.statusbar
-
-    def check_status():
-        assert message == bar.message.text(), "Message expected: '{message}'"
-
-    qtbot.waitUntil(check_status, timeout=100)
-    assert bar.stack.currentWidget() == bar.message
-
-
 @bdd.then(bdd.parsers.parse("the {position} status should include {text}"))
-def check_left_status(qtbot, position, text):
+def check_status_text(qtbot, position, text):
     bar = statusbar.statusbar
     message = f"statusbar {position} should include {text}"
 
     def check_status():
-        assert text in getattr(bar.status, position).text(), message
+        assert text in getattr(bar, position).text(), message
 
     qtbot.waitUntil(check_status, timeout=100)
-    assert bar.stack.currentWidget() == bar.status
+    assert bar.isVisible()
+
+
+@bdd.then(bdd.parsers.parse("the message\n'{message}'\nshould be displayed"))
+def check_message(qtbot, message_widget, message):
+    def check():
+        assert message == message_widget.text(), "Message expected: '{message}'"
+
+    qtbot.waitUntil(check, timeout=100)
+    assert message_widget.isVisible()
 
 
 @bdd.then("a message should be displayed")
-def check_a_statusbar_message(qtbot):
-    bar = statusbar.statusbar
+def check_any_message(qtbot, message_widget):
+    def check():
+        assert message_widget.text(), "Any message expected"
 
-    def check_status():
-        assert bar.message.text(), "Any message expected"
-
-    qtbot.waitUntil(check_status, timeout=100)
-    assert bar.stack.currentWidget() == bar.message
+    qtbot.waitUntil(check, timeout=100)
+    assert message_widget.isVisible()
 
 
 @bdd.then("no message should be displayed")
-def check_no_statusbar_message(qtbot):
-    bar = statusbar.statusbar
+def check_no_message(qtbot, message_widget):
+    def check():
+        assert not message_widget.text(), "No message expected"
 
-    def check_status():
-        assert not bar.message.text(), "No message expected"
-
-    qtbot.waitUntil(check_status, timeout=100)
-    assert bar.stack.currentWidget() == bar.status
+    qtbot.waitUntil(check, timeout=100)
+    assert not message_widget.isVisible()
 
 
 @bdd.then(bdd.parsers.parse("the working directory should be {basename}"))

--- a/tests/end2end/features/conftest.py
+++ b/tests/end2end/features/conftest.py
@@ -20,12 +20,12 @@ import vimiv.gui.thumbnail
 import vimiv.gui.mainwindow
 import vimiv.gui.message
 import vimiv.gui.commandline
-import vimiv.gui.bar
+import vimiv.gui.command_widget
 import vimiv.gui.image
 import vimiv.gui.prompt
+import vimiv.gui.statusbar
 from vimiv import api
 from vimiv.commands import runners
-from vimiv.gui import statusbar
 from vimiv.imutils import filelist
 
 
@@ -53,8 +53,8 @@ def commandline():
 
 
 @pytest.fixture()
-def bar():
-    yield vimiv.gui.bar.Bar.instance
+def statusbar(mainwindow):
+    yield mainwindow._statusbar
 
 
 @pytest.fixture()
@@ -64,10 +64,14 @@ def image():
 
 @pytest.fixture()
 def message_widget(mainwindow):
+    return get_overlay(mainwindow, vimiv.gui.message.Message)
+
+
+def get_overlay(mainwindow, typ):
     for overlay in mainwindow._overlays:
-        if isinstance(overlay, vimiv.gui.message.Message):
+        if isinstance(overlay, typ):
             return overlay
-    raise ValueError("Message widget not found")
+    raise ValueError(f"{typ} not found")
 
 
 class Counter:
@@ -270,15 +274,14 @@ def no_crash(qtbot):
 
 
 @bdd.then(bdd.parsers.parse("the {position} status should include {text}"))
-def check_status_text(qtbot, position, text):
-    bar = statusbar.statusbar
+def check_status_text(qtbot, statusbar, position, text):
     message = f"statusbar {position} should include {text}"
 
     def check_status():
-        assert text in getattr(bar, position).text(), message
+        assert text in getattr(statusbar, position).text(), message
 
     qtbot.waitUntil(check_status, timeout=100)
-    assert bar.isVisible()
+    assert statusbar.isVisible()
 
 
 @bdd.then(bdd.parsers.parse("the message\n'{message}'\nshould be displayed"))

--- a/tests/end2end/features/misc/test_keyhint_bdd.py
+++ b/tests/end2end/features/misc/test_keyhint_bdd.py
@@ -73,9 +73,9 @@ def keyhint_widget_contains(keyhint, command):
 
 
 @bdd.then("the keyhint widget should be above the statusbar")
-def keyhint_widget_above_bar(keyhint, bar):
+def keyhint_widget_above_bar(keyhint, statusbar):
     keyhint_bottom = keyhint.y() + keyhint.height()
-    bar_top = bar.y()
+    bar_top = statusbar.y()
     assert keyhint_bottom == bar_top
 
 

--- a/tests/end2end/features/misc/test_keyhint_bdd.py
+++ b/tests/end2end/features/misc/test_keyhint_bdd.py
@@ -13,8 +13,8 @@ from vimiv.gui import keyhint_widget, eventhandler
 
 
 @pytest.fixture()
-def keyhint():
-    return keyhint_widget.KeyhintWidget.instance
+def keyhint(overlay):
+    return overlay(keyhint_widget.KeyhintWidget)
 
 
 bdd.scenarios("keyhint.feature")

--- a/tests/end2end/features/statusbar/message.feature
+++ b/tests/end2end/features/statusbar/message.feature
@@ -9,19 +9,10 @@ Feature: Push messages to the statusbar.
             'this is a warning'
             should be displayed
 
-    Scenario: Display message when bar is hidden
-        When I run set statusbar.show false
-        And I log the warning 'this is a warning'
-        Then the message
-            'this is a warning'
-            should be displayed
-        And the bar should be visible
-
-    Scenario: Hide statusbar after message
-        When I run set statusbar.show false
-        And I log the warning 'this is a warning'
+    Scenario: Hide message widget when clearing status
+        When I log the warning 'this is a warning'
         And I clear the status
-        Then the bar should not be visible
+        Then no message should be displayed
 
     Scenario: Clear message after key press
         When I log the warning 'this is a warning'

--- a/tests/end2end/features/statusbar/test_message_bdd.py
+++ b/tests/end2end/features/statusbar/test_message_bdd.py
@@ -21,13 +21,3 @@ def log_warning(message, qtbot):
 @bdd.when("I clear the status")
 def clear_status():
     api.status.clear("clear in bdd step")
-
-
-@bdd.then("the bar should be visible")
-def check_bar_visible(bar):
-    assert bar.isVisible()
-
-
-@bdd.then("the bar should not be visible")
-def check_bar_not_visible(bar):
-    assert not bar.isVisible()

--- a/vimiv/completion/completer.py
+++ b/vimiv/completion/completer.py
@@ -23,7 +23,6 @@ class Completer(QObject):
         _completion: CompletionWidget object.
     """
 
-    @api.objreg.register
     def __init__(self, commandline, completion):
         super().__init__()
 

--- a/vimiv/completion/completer.py
+++ b/vimiv/completion/completer.py
@@ -32,7 +32,6 @@ class Completer(QObject):
         self._completion.activated.connect(self._complete)
         api.modes.COMMAND.first_entered.connect(self._init_models)
         self._cmd.textEdited.connect(self._on_text_changed)
-        self._cmd.editingFinished.connect(self._on_editing_finished)
 
     @property
     def proxy_model(self) -> api.completion.FilterProxyModel:
@@ -45,6 +44,11 @@ class Completer(QObject):
     @property
     def has_completions(self) -> bool:
         return self.proxy_model.rowCount() > 0
+
+    def reset(self):
+        """Reset completion and models."""
+        self._completion.clearSelection()
+        self.proxy_model.reset()
 
     @utils.slot
     def _init_models(self):
@@ -68,13 +72,6 @@ class Completer(QObject):
         self._update_proxy_model(text)
         self.model.on_text_changed(text)
         self._show_unless_empty()
-
-    @utils.slot
-    def _on_editing_finished(self):
-        """Reset filter and hide completion widget."""
-        self._completion.clearSelection()
-        self.proxy_model.reset()
-        self._completion.hide()
 
     def _update_proxy_model(self, text: str):
         """Update completion proxy model depending on text.

--- a/vimiv/gui/bar.py
+++ b/vimiv/gui/bar.py
@@ -41,10 +41,7 @@ class Bar(QWidget):
         self._stack.setCurrentWidget(statusbar.statusbar)
 
         self._commandline.editingFinished.connect(self._on_editing_finished)
-        statusbar.statusbar.timer.timeout.connect(self._maybe_hide)
         api.settings.statusbar.show.changed.connect(self._on_show_changed)
-        api.status.signals.clear.connect(self._maybe_hide)
-        utils.log.statusbar_loghandler.message.connect(self.show)
 
         if not api.settings.statusbar.show.value:
             self.hide()

--- a/vimiv/gui/command_widget.py
+++ b/vimiv/gui/command_widget.py
@@ -80,7 +80,7 @@ class CommandWidget(QWidget):
     def _enter_command_mode(self, text):
         """Enter command mode setting the text to text."""
         api.modes.COMMAND.enter()
-        self._commandline.setText(text)
+        self._commandline.enter(text)
         self._completer.initialize(text)
         self.raise_()
         self.show()

--- a/vimiv/gui/command_widget.py
+++ b/vimiv/gui/command_widget.py
@@ -9,7 +9,7 @@
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QWidget, QSizePolicy, QVBoxLayout
 
-from vimiv import api, utils
+from vimiv import api
 from vimiv.completion import completer
 
 from . import commandline, completionwidget
@@ -43,7 +43,7 @@ class CommandWidget(QWidget):
         layout.addWidget(self._commandline)
         layout.setAlignment(Qt.AlignBottom)
 
-        self._commandline.editingFinished.connect(self._on_editing_finished)
+        self._commandline.editingFinished.connect(self.leave_commandline)
 
         self.hide()
 
@@ -90,12 +90,8 @@ class CommandWidget(QWidget):
     @api.commands.register(mode=api.modes.COMMAND)
     def leave_commandline(self):
         """Leave command mode."""
-        self._commandline.editingFinished.emit()
-
-    @utils.slot
-    def _on_editing_finished(self):
-        """Close command line on the editingFinished signal."""
-        self._commandline.setText("")
+        self._commandline.leave()
+        self._completer.reset()
         self.hide()
         api.modes.COMMAND.close()
 

--- a/vimiv/gui/command_widget.py
+++ b/vimiv/gui/command_widget.py
@@ -6,6 +6,7 @@
 
 """Command widget at the bottom including commandline and completion widget."""
 
+from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QWidget, QSizePolicy, QVBoxLayout
 
 from vimiv import api, utils
@@ -40,6 +41,7 @@ class CommandWidget(QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(self._completion_widget)
         layout.addWidget(self._commandline)
+        layout.setAlignment(Qt.AlignBottom)
 
         self._commandline.editingFinished.connect(self._on_editing_finished)
 

--- a/vimiv/gui/commandline.py
+++ b/vimiv/gui/commandline.py
@@ -55,7 +55,6 @@ class CommandLine(EventHandlerMixin, QLineEdit):
         self.mode: api.modes.Mode = api.modes.IMAGE
 
         self.returnPressed.connect(self._on_return_pressed)
-        self.editingFinished.connect(self._history.reset)
         self.textEdited.connect(self._on_text_edited)
         self.textChanged.connect(self._incremental_search)
         self.cursorPositionChanged.connect(self._on_cursor_position_changed)
@@ -74,6 +73,10 @@ class CommandLine(EventHandlerMixin, QLineEdit):
     def enter(self, text: str):
         self.setText(text)
         self.mode = api.modes.COMMAND.last
+
+    def leave(self):
+        self.clear()
+        self._history.reset()
 
     @utils.slot
     def _on_return_pressed(self) -> None:

--- a/vimiv/gui/commandline.py
+++ b/vimiv/gui/commandline.py
@@ -52,7 +52,7 @@ class CommandLine(EventHandlerMixin, QLineEdit):
             history.read(),
             max_items=api.settings.command.history_limit.value,
         )
-        self.mode = api.modes.IMAGE
+        self.mode: api.modes.Mode = api.modes.IMAGE
 
         self.returnPressed.connect(self._on_return_pressed)
         self.editingFinished.connect(self._history.reset)
@@ -62,7 +62,6 @@ class CommandLine(EventHandlerMixin, QLineEdit):
         QCoreApplication.instance().aboutToQuit.connect(  # type: ignore
             self._on_app_quit
         )
-        api.modes.COMMAND.entered.connect(self._on_entered)
 
         styles.apply(self)
 
@@ -71,6 +70,10 @@ class CommandLine(EventHandlerMixin, QLineEdit):
 
     def current(self):
         return api.modes.COMMAND.last.widget.current()
+
+    def enter(self, text: str):
+        self.setText(text)
+        self.mode = api.modes.COMMAND.last
 
     @utils.slot
     def _on_return_pressed(self) -> None:
@@ -162,8 +165,3 @@ class CommandLine(EventHandlerMixin, QLineEdit):
 
     def focusOutEvent(self, event):
         """Override focus out event to not emit editingFinished."""
-
-    @utils.slot
-    def _on_entered(self):
-        """Store mode from which the command line was entered."""
-        self.mode = api.modes.COMMAND.last

--- a/vimiv/gui/completionwidget.py
+++ b/vimiv/gui/completionwidget.py
@@ -7,7 +7,6 @@
 """Completion widget in the bar."""
 
 from PyQt5.QtCore import pyqtSignal, Qt
-from PyQt5.QtWidgets import QSizePolicy
 
 from vimiv import api, widgets
 from vimiv.config import styles
@@ -45,19 +44,11 @@ class CompletionView(widgets.FlatTreeView):
     def __init__(self, parent):
         super().__init__(parent=parent)
 
-        self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         self.setEditTriggers(self.NoEditTriggers)
         self.setModel(api.completion.FilterProxyModel())
 
-        self.hide()
-
         styles.apply(self)
-
-    def update_geometry(self, window_width, window_height):
-        """Rescale width when main window was resized."""
-        y = window_height - self.height()
-        self.setGeometry(0, y, window_width, self.height())
 
     @api.keybindings.register(
         "<shift><tab>", "complete --inverse", mode=api.modes.COMMAND

--- a/vimiv/gui/keyhint_widget.py
+++ b/vimiv/gui/keyhint_widget.py
@@ -38,7 +38,6 @@ class KeyhintWidget(QLabel):
     }
     """
 
-    @api.objreg.register
     def __init__(self, parent):
         super().__init__(parent=parent)
         self._show_timer = QTimer(self)

--- a/vimiv/gui/mainwindow.py
+++ b/vimiv/gui/mainwindow.py
@@ -14,20 +14,21 @@ from vimiv import api, utils
 from vimiv.utils import migration
 
 # Import all GUI widgets used to create the full main window
-from .bar import Bar
+from .command_widget import CommandWidget
 from .image import ScrollableImage
 from .keyhint_widget import KeyhintWidget
 from .library import Library
 from .thumbnail import ThumbnailView
 from .message import Message
 from .metadata_widget import MetadataWidget
+from .statusbar import StatusBar
 
 
 class MainWindow(QWidget):
     """QMainWindow which groups all the other widgets.
 
     Attributes:
-        _bar: bar.Bar object containing statusbar and command line.
+        _statusbar: Statusbar object displayed at the bottom.
         _overlays: List of overlay widgets.
     """
 
@@ -36,16 +37,17 @@ class MainWindow(QWidget):
         super().__init__()
         self._overlays: List[QWidget] = []
         # Create main widgets and add them to the grid layout
-        self._bar = Bar(self)
+        self._statusbar = StatusBar()
         grid = QGridLayout(self)
         grid.setSpacing(0)
         grid.setContentsMargins(0, 0, 0, 0)
         grid.addWidget(ImageThumbnailStack(), 0, 1, 1, 1)
         grid.addWidget(Library(self), 0, 0, 1, 1)
-        grid.addWidget(self._bar, 1, 0, 1, 2)
+        grid.addWidget(self._statusbar, 1, 0, 1, 2)
         # Add overlay widgets
         self._overlays.append(KeyhintWidget(self))
         self._overlays.append(Message(self))
+        self._overlays.append(CommandWidget(self))
         if MetadataWidget is not None:  # Not defined if there is no exif support
             self._overlays.append(MetadataWidget(self))
         # Connect signals
@@ -129,8 +131,8 @@ class MainWindow(QWidget):
     @property
     def bottom(self):
         """Bottom of the main window respecting the status bar height."""
-        if self._bar.isVisible():
-            return self.height() - self._bar.height()
+        if self._statusbar.isVisible():
+            return self.height() - self._statusbar.height()
         return self.height()
 
     def add_overlay(self, widget, resize=True):

--- a/vimiv/gui/mainwindow.py
+++ b/vimiv/gui/mainwindow.py
@@ -19,6 +19,7 @@ from .image import ScrollableImage
 from .keyhint_widget import KeyhintWidget
 from .library import Library
 from .thumbnail import ThumbnailView
+from .message import Message
 from .metadata_widget import MetadataWidget
 
 
@@ -44,6 +45,7 @@ class MainWindow(QWidget):
         grid.addWidget(self._bar, 1, 0, 1, 2)
         # Add overlay widgets
         self._overlays.append(KeyhintWidget(self))
+        self._overlays.append(Message(self))
         if MetadataWidget is not None:  # Not defined if there is no exif support
             self._overlays.append(MetadataWidget(self))
         # Connect signals

--- a/vimiv/gui/mainwindow.py
+++ b/vimiv/gui/mainwindow.py
@@ -52,8 +52,6 @@ class MainWindow(QWidget):
             self._overlays.append(MetadataWidget(self))
         # Connect signals
         api.status.signals.update.connect(self._set_title)
-        api.modes.COMMAND.entered.connect(self._update_overlay_geometry)
-        api.modes.COMMAND.closed.connect(self._update_overlay_geometry)
         api.settings.statusbar.show.changed.connect(self._update_overlay_geometry)
         api.modes.MANIPULATE.first_entered.connect(self._init_manipulate)
         api.prompt.question_asked.connect(self._run_prompt)

--- a/vimiv/gui/message.py
+++ b/vimiv/gui/message.py
@@ -1,0 +1,93 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2020 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+"""Message widget to display temporary information to the user."""
+
+from PyQt5.QtCore import Qt, QTimer
+from PyQt5.QtWidgets import QLabel, QSizePolicy
+
+from vimiv import api, utils
+from vimiv.config import styles
+
+from .statusbar import StatusBar
+
+
+class Message(QLabel):
+    """Message widget to display temporary information to the user.
+
+    Messages are pushed using the logging mechanism. The styling is adopted according to
+    the severity of the message. The widget is displayed at the bottom of the window
+    using the full window width.
+
+    Attributes:
+        _timer: QTimer used to hide the widget upon timeout.
+    """
+
+    STYLESHEET = StatusBar.STYLESHEET
+
+    def __init__(self, mainwindow):
+        super().__init__(parent=mainwindow)
+
+        self._timer = QTimer()
+        self._timer.setInterval(api.settings.statusbar.message_timeout.value)
+        self._timer.setSingleShot(True)
+
+        self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Minimum)
+        self.setTextFormat(Qt.RichText)
+        self.setWordWrap(True)
+
+        styles.apply(self)
+        self.hide()
+
+        self._timer.timeout.connect(self._clear_message)
+        api.status.signals.clear.connect(self._clear_message)
+        api.settings.statusbar.message_timeout.changed.connect(self._timer.setInterval)
+        utils.log.statusbar_loghandler.message.connect(self._on_message)
+
+    def update_geometry(self, window_width, _window_height):
+        """Update size according to the window width and the current content."""
+        self.setFixedWidth(window_width)  # Ensure full width is used
+        self.adjustSize()  # Ensure all text is visible, essentially updates height
+        self.move(0, self.parentWidget().height() - self.height())
+
+    @utils.slot
+    def _on_message(self, severity: str, message: str):
+        """Display log message when logging was called.
+
+        Args:
+            severity: levelname of the log record.
+            message: message of the log record.
+        """
+        self._set_severity_style(severity)
+        self.setText(message)
+        self._timer.start()
+        self.raise_()
+        self.update_geometry(self.parentWidget().width(), self.parentWidget().height())
+        self.show()
+
+    @utils.slot
+    def _clear_message(self):
+        """Remove a temporary message from the statusbar."""
+        if self._timer.isActive():
+            self._timer.stop()
+        self.clear()
+        self.hide()
+
+    def _set_severity_style(self, severity):
+        """Set the style of the statusbar for a temporary message.
+
+        Adds a colored border to the top of the statusbar. The border color
+        depends on the severity.
+
+        Args:
+            severity: One of "debug", "info", "warning", "error"
+        """
+        append = f"""
+        QLabel {{
+            border-top: {{statusbar.message_border}} {{statusbar.{severity}}};
+        }}
+        """
+        styles.apply(self, append)

--- a/vimiv/gui/statusbar.py
+++ b/vimiv/gui/statusbar.py
@@ -15,16 +15,12 @@ Module Attributes:
 """
 
 import re
-from typing import cast
 
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QLabel, QWidget, QHBoxLayout
 
 from vimiv import api, utils
 from vimiv.config import styles
-
-
-statusbar = cast("StatusBar", None)
 
 
 class StatusBar(QWidget):
@@ -59,6 +55,10 @@ class StatusBar(QWidget):
 
         styles.apply(self)
         api.status.signals.update.connect(self._update_status)
+        api.settings.statusbar.show.changed.connect(self._on_show_changed)
+
+        if not api.settings.statusbar.show.value:
+            self.hide()
 
     def __iter__(self):
         yield from zip(
@@ -99,7 +99,5 @@ class StatusBar(QWidget):
     def _escape_subsequent_space_for_html(cls, text):
         return re.sub(r" {2,}", lambda m: m.group().replace(" ", "&nbsp;"), text)
 
-
-def init():
-    global statusbar
-    statusbar = StatusBar()
+    def _on_show_changed(self, value: bool):
+        self.setVisible(value)

--- a/vimiv/gui/statusbar.py
+++ b/vimiv/gui/statusbar.py
@@ -17,8 +17,8 @@ Module Attributes:
 import re
 from typing import cast
 
-from PyQt5.QtCore import Qt, QTimer
-from PyQt5.QtWidgets import QLabel, QWidget, QStackedLayout, QHBoxLayout
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QLabel, QWidget, QHBoxLayout
 
 from vimiv import api, utils
 from vimiv.config import styles
@@ -28,18 +28,13 @@ statusbar = cast("StatusBar", None)
 
 
 class StatusBar(QWidget):
-    """Statusbar widget to display permanent and temporary messages.
+    """Statusbar widget to display permanent information to the user.
 
-    Packs three labels for permanent messages ("left", "center", "right") and
-    one for temporary ones ("message"). The three labels are grouped into one
-    hbox. The hbox and the message label are both in a QStackedLayout to toggle
-    between them.
+    Packs three labels for permanent inforormation ("left", "center", "right") grouped
+    into one hbox.
 
     Attributes:
-        timer: QTimer object to remove temporary messages after timeout.
-        status: Widget grouping the labels for status messages.
-        message: Label to display messages.
-        stack: Stacked layout to switch between status and message.
+        left, center, right: The different labels corresponding to their positions.
     """
 
     STYLESHEET = """
@@ -55,59 +50,37 @@ class StatusBar(QWidget):
 
     def __init__(self):
         super().__init__()
-        self.timer = QTimer()
-        self.timer.setInterval(api.settings.statusbar.message_timeout.value)
-        self.timer.setSingleShot(True)
-
-        self.status = StatusLabels()
-        self.message = QLabel()
-        self.message.setWordWrap(True)
-
-        self.stack = QStackedLayout(self)
-        self.stack.addWidget(self.status)
-        self.stack.addWidget(self.message)
-        self.stack.setCurrentWidget(self.status)
+        layout = QHBoxLayout(self)
+        layout.setSpacing(0)
+        layout.setContentsMargins(0, 0, 0, 0)
+        self.left = self.create_label(layout, Qt.AlignLeft)
+        self.center = self.create_label(layout, Qt.AlignCenter)
+        self.right = self.create_label(layout, Qt.AlignRight)
 
         styles.apply(self)
+        api.status.signals.update.connect(self._update_status)
 
-        self.timer.timeout.connect(self.clear_message)
-        api.status.signals.clear.connect(self.clear_message)
-        utils.log.statusbar_loghandler.message.connect(self._on_message)
-        api.status.signals.update.connect(self._on_update_status)
-        api.settings.statusbar.message_timeout.changed.connect(self._on_timeout_changed)
+    def __iter__(self):
+        yield from zip(
+            ("left", "center", "right"), (self.left, self.center, self.right)
+        )
 
-    @utils.slot
-    def _on_message(self, severity: str, message: str):
-        """Display log message when logging was called.
-
-        Args:
-            severity: levelname of the log record.
-            message: message of the log record.
-        """
-        self._set_severity_style(severity)
-        self.message.setText(message)
-        self.stack.setCurrentWidget(self.message)
-        self.timer.start()
+    @classmethod
+    def create_label(cls, layout, alignment):
+        """Create a label with this alignment and add it to the layout."""
+        label = QLabel()
+        label.setAlignment(alignment)
+        label.setTextFormat(Qt.RichText)
+        layout.addWidget(label)
+        return label
 
     @utils.slot
-    def _on_update_status(self):
+    def _update_status(self):
         """Update the statusbar."""
         mode = api.modes.current().name.lower()
-        for position, label in self.status:
+        for position, label in self:
             text = self._get_text(position, mode)
             label.setText(text)
-
-    @utils.slot
-    def clear_message(self):
-        """Remove a temporary message from the statusbar."""
-        if self.timer.isActive():
-            self.timer.stop()
-        self._clear_severity_style()
-        self.message.clear()
-        self.stack.setCurrentWidget(self.status)
-
-    def _on_timeout_changed(self, value: int):
-        self.timer.setInterval(value)
 
     def _get_text(self, position, mode):
         """Get the text to put into one label depending on the current mode.
@@ -125,55 +98,6 @@ class StatusBar(QWidget):
     @classmethod
     def _escape_subsequent_space_for_html(cls, text):
         return re.sub(r" {2,}", lambda m: m.group().replace(" ", "&nbsp;"), text)
-
-    def _set_severity_style(self, severity):
-        """Set the style of the statusbar for a temporary message.
-
-        Adds a colored border to the top of the statusbar. The border color
-        depends on the severity.
-
-        Args:
-            severity: One of "debug", "info", "warning", "error"
-        """
-        append = f"""
-        QLabel {{
-            border-top: {{statusbar.message_border}} {{statusbar.{severity}}};
-        }}
-        """
-        styles.apply(self, append)
-
-    def _clear_severity_style(self):
-        styles.apply(self)
-
-
-class StatusLabels(QWidget):
-    """Widget to group the different status labels in the statusbar.
-
-    Attributes:
-        left, center, right: The different labels corresponding to their positions.
-    """
-
-    def __init__(self):
-        super().__init__()
-        layout = QHBoxLayout(self)
-        layout.setSpacing(0)
-        layout.setContentsMargins(0, 0, 0, 0)
-        self.left = self.label(layout, Qt.AlignLeft)
-        self.center = self.label(layout, Qt.AlignCenter)
-        self.right = self.label(layout, Qt.AlignRight)
-
-    def __iter__(self):
-        yield from zip(
-            ("left", "center", "right"), (self.left, self.center, self.right)
-        )
-
-    def label(self, layout, alignment):
-        """Create a label with this alignment and add it to the layout."""
-        label = QLabel()
-        label.setAlignment(alignment)
-        label.setTextFormat(Qt.RichText)
-        layout.addWidget(label)
-        return label
 
 
 def init():


### PR DESCRIPTION
The bar is now only the statusbar, decoupled from messages and the commandline. This allows treating hide/show separately for the `statusbar.show` setting, displaying a message and entering the command line. In addition the image does not move whenever we show a message / command mode, independent of the statusbar visibility and messages properly overlay the widgets in manipulate mode.