### PR TITLE
Also keep library row when last path was removed

### DIFF
--- a/tests/end2end/features/library/libraryscroll.feature
+++ b/tests/end2end/features/library/libraryscroll.feature
@@ -92,6 +92,18 @@ Feature: Scrolling the library.
         And I wait for the working directory handler
         Then the library row should be 3
 
+    Scenario: Keep correct selection when deleting directories
+        Given I open a directory with 5 paths
+        When I run goto 3
+        And I run !rmdir %
+        Then the library row should be 3
+
+    Scenario: Keep correct selection when deleting last directory
+        Given I open a directory with 5 paths
+        When I run goto 5
+        And I run !rmdir %
+        Then the library row should be 4
+
     Scenario: Crash on goto in empty directory
         Given I start vimiv
         When I run goto 3


### PR DESCRIPTION
This fixes jumping to the first row in case we delete e.g. the current directory or the last image file.