### PR TITLE
Reduce the uses of class.instance for classes in objreg

### DIFF
--- a/tests/end2end/conftest.py
+++ b/tests/end2end/conftest.py
@@ -47,6 +47,7 @@ def cleanup():
     utils.Throttle.stop_all()
     utils.Pool.clear()
     utils.Pool.wait(5000)
+    api.objreg._apply_instance.cache_clear()
     api.settings.reset()
     api.mark.mark_clear()
     runners._last_command.clear()

--- a/tests/end2end/conftest.py
+++ b/tests/end2end/conftest.py
@@ -47,7 +47,6 @@ def cleanup():
     utils.Throttle.stop_all()
     utils.Pool.clear()
     utils.Pool.wait(5000)
-    api.objreg._apply_instance.cache_clear()
     api.settings.reset()
     api.mark.mark_clear()
     runners._last_command.clear()

--- a/tests/end2end/features/image/test_slideshow_bdd.py
+++ b/tests/end2end/features/image/test_slideshow_bdd.py
@@ -16,7 +16,9 @@ bdd.scenarios("slideshow.feature")
 
 @pytest.fixture
 def sshow():
-    return slideshow.Slideshow.instance
+    instance = slideshow.Slideshow.instance
+    yield instance
+    instance.stop()
 
 
 @bdd.given(bdd.parsers.parse("I forcefully set the slideshow delay to {N:d}ms"))

--- a/tests/end2end/features/image/test_slideshow_bdd.py
+++ b/tests/end2end/features/image/test_slideshow_bdd.py
@@ -16,7 +16,7 @@ bdd.scenarios("slideshow.feature")
 
 @pytest.fixture
 def sshow():
-    instance = slideshow.Slideshow.instance
+    instance = slideshow._timer
     yield instance
     instance.stop()
 

--- a/tests/end2end/mockdecorators.py
+++ b/tests/end2end/mockdecorators.py
@@ -33,7 +33,5 @@ def mockregister_cleanup():
 @contextmanager
 def apply():
     """Contextmanager to mock relevant vimiv decorators and restore state."""
-    with mock.patch("vimiv.utils.cached_method", lambda x: x), mock.patch(
-        "vimiv.api.objreg.register", mockregister
-    ):
+    with mock.patch("vimiv.api.objreg.register", mockregister):
         yield

--- a/vimiv/api/commands.py
+++ b/vimiv/api/commands.py
@@ -316,8 +316,7 @@ class _Command:  # pylint: disable=too-many-instance-attributes
         parsed_args = self.argparser.parse_args(args)
         kwargs = vars(parsed_args)
         self._parse_count(count, kwargs)
-        func = objreg._apply_instance(self.func)
-        func(**kwargs)
+        objreg._call_with_instance(self.func, **kwargs)
 
     @property
     def argparser(self) -> _CommandArguments:

--- a/vimiv/api/objreg.py
+++ b/vimiv/api/objreg.py
@@ -6,11 +6,11 @@
 
 """*Storage system for objects*.
 
-The object registry is a storage system for long-lived objects. These objects
-are stored and identified using their type. Therefore every stored object must
-be unique in its type and only one instance of each type can be stored. It is
-mainly used by commands as well as statusbar modules to retrieve the ``self``
-argument for methods that require an instance of the class.
+The object registry is a storage system for long-lived objects. These objects are stored
+and identified using their type. Therefore every stored object must be unique in its
+type and only one instance of each type can be stored. Purpose of this registry is to
+define an interface used by commands as well as statusbar modules to retrieve the
+``self`` argument for methods that require an instance of the class.
 
 To register a new class for this purpose, the
 :func:`register` decorator can be used as following::
@@ -23,10 +23,13 @@ To register a new class for this purpose, the
         def __init__(self):
             ...
 
-The first created instance is then stored in the class itself. To retrieve the instance
-of the class, use::
+This class is now ready to provide commands and statusbar modules using the regular
+decorators. In principle, you can now retrieve the instance of the class via::
 
     my_instance = MyLongLivedClass.instance
+
+This is not recommended though and considered an implementation detail. The preferred
+method is to keep track of the instance otherwise.
 """
 
 import functools

--- a/vimiv/api/status.py
+++ b/vimiv/api/status.py
@@ -60,8 +60,7 @@ class _Module:
         self._func = func
 
     def __call__(self) -> str:
-        func = objreg._apply_instance(self._func)
-        return func()
+        return objreg._call_with_instance(self._func)
 
     def __repr__(self) -> str:
         return f"StatusModule('{self._func.__name__}')"

--- a/vimiv/api/status.py
+++ b/vimiv/api/status.py
@@ -38,7 +38,9 @@ from typing import Callable, TypeVar, Any, Dict
 
 from PyQt5.QtCore import pyqtSignal, QObject
 
-from vimiv.utils import cached_method, is_method, class_that_defined_method, log
+from vimiv.utils import log
+
+from . import objreg
 
 
 Module = Callable[[], str]
@@ -58,28 +60,11 @@ class _Module:
         self._func = func
 
     def __call__(self) -> str:
-        func = self._create_func(self._func)
+        func = objreg._apply_instance(self._func)
         return func()
 
     def __repr__(self) -> str:
         return f"StatusModule('{self._func.__name__}')"
-
-    @cached_method
-    def _create_func(self, func: Callable[..., str]) -> Module:
-        """Create function to call for a status module.
-
-        This retrieves the instance of a class object for methods and sets it
-        as first argument (the 'self' argument) of a lambda. For standard
-        functions nothing is done.
-
-        Returns:
-            A function to be called without arguments.
-        """
-        _logger.debug("Creating function for status module '%s'", func.__name__)
-        if is_method(func):
-            cls = class_that_defined_method(func)
-            return functools.partial(func, cls.instance)
-        return func
 
 
 def module(name: str) -> Callable[[ModuleFunc], ModuleFunc]:

--- a/vimiv/gui/image.py
+++ b/vimiv/gui/image.py
@@ -21,6 +21,7 @@ from PyQt5.QtWidgets import (
 from PyQt5.QtGui import QMovie, QPixmap
 
 from vimiv import api, imutils, utils
+from vimiv.imutils import slideshow
 from vimiv.commands.argtypes import Direction, ImageScale, ImageScaleFloat, Zoom
 from vimiv.config import styles
 from vimiv.utils import lazy
@@ -370,6 +371,4 @@ class ScrollableImage(EventHandlerMixin, QGraphicsView):
     def focusOutEvent(self, event):
         """Stop slideshow when focusing another widget."""
         if event.reason() != Qt.ActiveWindowFocusReason:  # Unfocused the whole window
-            slideshow = imutils.slideshow.Slideshow.instance
-            if slideshow is not None and slideshow.isActive():
-                slideshow.stop()
+            slideshow.stop()

--- a/vimiv/gui/mainwindow.py
+++ b/vimiv/gui/mainwindow.py
@@ -61,11 +61,10 @@ class MainWindow(QWidget):
     @utils.slot
     def _init_manipulate(self):
         """Create UI widgets related to manipulate mode."""
-        from .manipulate import Manipulate, ManipulateImage
+        from .manipulate import Manipulate
 
         manipulate_widget = Manipulate(self)
         self.add_overlay(manipulate_widget)
-        self.add_overlay(ManipulateImage(self, manipulate_widget))
 
     @api.keybindings.register("f", "fullscreen", mode=api.modes.MANIPULATE)
     @api.keybindings.register("f", "fullscreen")

--- a/vimiv/gui/mainwindow.py
+++ b/vimiv/gui/mainwindow.py
@@ -28,8 +28,9 @@ class MainWindow(QWidget):
     """QMainWindow which groups all the other widgets.
 
     Attributes:
-        _statusbar: Statusbar object displayed at the bottom.
+        _library: Library object at the left of the grid.
         _overlays: List of overlay widgets.
+        _statusbar: Statusbar object displayed at the bottom.
     """
 
     @api.objreg.register
@@ -42,7 +43,8 @@ class MainWindow(QWidget):
         grid.setSpacing(0)
         grid.setContentsMargins(0, 0, 0, 0)
         grid.addWidget(ImageThumbnailStack(), 0, 1, 1, 1)
-        grid.addWidget(Library(self), 0, 0, 1, 1)
+        self._library = Library(self)
+        grid.addWidget(self._library, 0, 0, 1, 1)
         grid.addWidget(self._statusbar, 1, 0, 1, 2)
         # Add overlay widgets
         self._overlays.append(KeyhintWidget(self))
@@ -119,7 +121,7 @@ class MainWindow(QWidget):
         """
         super().resizeEvent(event)
         self._update_overlay_geometry()
-        Library.instance.update_width()
+        self._library.update_width()
 
     def show(self):
         """Update show to resize overlays."""

--- a/vimiv/gui/manipulate.py
+++ b/vimiv/gui/manipulate.py
@@ -23,7 +23,7 @@ class Manipulate(EventHandlerMixin, QTabWidget):
     """Manipulate widget displaying progress bars and labels.
 
     Attributes:
-        _error: String containing the current error message.
+        _image: ManipulateImage displayed at the top right of the manipulate widget.
     """
 
     STYLESHEET = """
@@ -131,7 +131,7 @@ class ManipulateImage(QLabel):
     It is shown once manipulate mode is entered and hides afterwards.
 
     Attributes:
-        _manipulate: The manipulate widget to retrieve y-coordinate.
+        _bottom_right: Point describing the expected bottom right of this widget.
         _max_size: Maximum size to use up which corresponds to half the window size.
         _pixmap: The manipulated pixmap to display.
     """

--- a/vimiv/gui/manipulate.py
+++ b/vimiv/gui/manipulate.py
@@ -8,7 +8,7 @@
 
 from typing import List, Optional
 
-from PyQt5.QtCore import Qt, QSize
+from PyQt5.QtCore import Qt, QSize, QPoint
 from PyQt5.QtGui import QPixmap
 from PyQt5.QtWidgets import QWidget, QHBoxLayout, QLabel, QTabWidget
 
@@ -41,8 +41,8 @@ class Manipulate(EventHandlerMixin, QTabWidget):
 
     @api.modes.widget(api.modes.MANIPULATE)
     @api.objreg.register
-    def __init__(self, parent):
-        super().__init__(parent=parent)
+    def __init__(self, mainwindow):
+        super().__init__(parent=mainwindow)
         self.setAttribute(Qt.WA_StyledBackground, True)
 
         styles.apply(self)
@@ -50,10 +50,15 @@ class Manipulate(EventHandlerMixin, QTabWidget):
         manipulator = immanipulate.Manipulator.instance
         for group in manipulator.manipulations.groups:
             self._add_group(group)
+
+        self._image = ManipulateImage(mainwindow, manipulator)
         # Connect signals
         self.currentChanged.connect(manipulator.focus_group_index)
-        # Hide by default
-        self.hide()
+        api.modes.MANIPULATE.closed.connect(self._close)
+
+    @property
+    def _mainwindow(self):
+        return self.parentWidget()
 
     @api.keybindings.register("<tab>", "next-tab", mode=api.modes.MANIPULATE)
     @api.commands.register(mode=api.modes.MANIPULATE)
@@ -98,8 +103,26 @@ class Manipulate(EventHandlerMixin, QTabWidget):
 
     def update_geometry(self, window_width, window_height):
         """Rescale width when main window was resized."""
-        y = window_height - self.sizeHint().height()
-        self.setGeometry(0, y, window_width, self.sizeHint().height())
+        if self.isVisible():
+            y = window_height - self.sizeHint().height()
+            self.setGeometry(0, y, window_width, self.sizeHint().height())
+            size_image = QSize(window_width // 2, window_height // 2)
+            y_image = window_height - self.currentWidget().height()
+            self._image.update_geometry(size_image, QPoint(window_width, y_image))
+
+    def show(self):
+        """Override show to also raise and show the image."""
+        super().show()
+        self._image.show()
+        self.update_geometry(self._mainwindow.width(), self._mainwindow.bottom)
+        self.raise_()
+        self._image.raise_()
+
+    @utils.slot
+    def _close(self):
+        """Hide manipulate widgets when closing manipulate mode."""
+        self.hide()
+        self._image.hide()
 
 
 class ManipulateImage(QLabel):
@@ -120,43 +143,31 @@ class ManipulateImage(QLabel):
     }
     """
 
-    def __init__(self, parent, manipulate):
+    def __init__(self, parent, manipulator: immanipulate.Manipulator):
         super().__init__(parent=parent)
-        self._manipulate = manipulate
         self._max_size = QSize(0, 0)
         self._pixmap: Optional[QPixmap] = None
+        self._bottom_right = QPoint(0, 0)
         styles.apply(self)
 
-        api.modes.MANIPULATE.closed.connect(self._on_left)
-        immanipulate.Manipulator.instance.updated.connect(self._update_pixmap)
+        manipulator.updated.connect(self._update_pixmap)
 
-        self.hide()
-
-    def update_geometry(self, window_width, window_height):
-        """Update position and size according to window size.
+    def update_geometry(self, size: QSize, bottom_right: QPoint):
+        """Update position and size according to size and bottom_right.
 
         The size is adapted to take up the lower right corner. This is then reduced
         accordingly by displayed pixmap if it is not perfectly square.
         """
-        self._max_size = QSize(window_width // 2, window_height // 2)
-        if self._pixmap is not None and self.isVisible():
+        self._max_size = size
+        self._bottom_right = bottom_right
+        if self._pixmap is not None:
             self._rescale()
 
     @slot
     def _update_pixmap(self, pixmap: QPixmap):
         """Update the manipulate pixmap and show manipulate widgets if needed."""
-        if not self.isVisible():
-            self._manipulate.raise_()
-            self.raise_()
-            self.show()
         self._pixmap = pixmap
         self._rescale()
-
-    @utils.slot
-    def _on_left(self):
-        """Hide manipulate widgets when leaving manipulate mode."""
-        self.hide()
-        self._manipulate.hide()
 
     def _rescale(self):
         """Rescale pixmap and geometry to fit."""
@@ -170,10 +181,6 @@ class ManipulateImage(QLabel):
         )
         self.setPixmap(pixmap)
         # Update geometry to only show pixmap
-        x = self._max_size.width() + (self._max_size.width() - pixmap.width())
-        y = (
-            self._max_size.height()
-            + (self._max_size.height() - pixmap.height())
-            - self._manipulate.currentWidget().sizeHint().height()
-        )
+        x = self._bottom_right.x() - pixmap.width()
+        y = self._bottom_right.y() - pixmap.height()
         self.setGeometry(x, y, pixmap.width(), pixmap.height())

--- a/vimiv/imutils/filelist.py
+++ b/vimiv/imutils/filelist.py
@@ -19,7 +19,7 @@ from PyQt5.QtCore import QObject, pyqtSlot
 from vimiv import api, utils, imutils
 from vimiv.commands import search, number_for_command
 from vimiv.utils import files, log
-from .slideshow import Slideshow
+from . import slideshow
 
 
 _paths: List[str] = []
@@ -133,7 +133,7 @@ class SignalHandler(QObject):
         search.search.new_search.connect(self._on_new_search)
         # The slideshow object is created here as it is not required by anything else
         # It stays around as it is part of the global object registry
-        Slideshow().timeout.connect(self._on_slideshow_event)
+        slideshow.event.connect(self._on_slideshow_event)
 
         api.signals.load_images.connect(self._on_load_images)
         api.working_directory.handler.images_changed.connect(self._on_images_changed)

--- a/vimiv/imutils/slideshow.py
+++ b/vimiv/imutils/slideshow.py
@@ -4,7 +4,7 @@
 # Copyright 2017-2020 Christian Karl (karlch) <karlch at protonmail dot com>
 # License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
 
-"""Class to play a slideshow."""
+"""Module to play a slideshow."""
 
 from typing import Optional
 
@@ -13,40 +13,51 @@ from PyQt5.QtCore import QTimer
 from vimiv import api
 
 
-class Slideshow(QTimer):
-    """Slideshow class inheriting from QTimer."""
+class Timer(QTimer):
+    """Slideshow timer with interval according to the current setting."""
 
-    @api.objreg.register
     def __init__(self):
         super().__init__()
-        api.settings.slideshow.delay.changed.connect(self._on_delay_changed)
-        self.setInterval(int(api.settings.slideshow.delay.value * 1000))
+        api.settings.slideshow.delay.changed.connect(self._set_delay)
+        self._set_delay(api.settings.slideshow.delay.value)
 
-    @api.keybindings.register("ss", "slideshow", mode=api.modes.IMAGE)
-    @api.commands.register(mode=api.modes.IMAGE)
-    def slideshow(self, count: Optional[int] = None):
-        """Toggle slideshow.
-
-        **count:** Set slideshow delay to count instead.
-        """
-        if count is not None:
-            api.settings.slideshow.delay.value = count
-            self.setInterval(1000 * count)
-        elif self.isActive():
-            self.stop()
-        else:
-            self.start()
-
-    @api.status.module("{slideshow-delay}")
-    def delay(self) -> str:
-        """Slideshow delay in seconds if the slideshow is running."""
-        interval_seconds = self.interval() / 1000
-        return f"{interval_seconds:.1f}" if self.isActive() else ""
-
-    @api.status.module("{slideshow-indicator}")
-    def running_indicator(self) -> str:
-        """Indicator if slideshow is running."""
-        return api.settings.slideshow.indicator.value if self.isActive() else ""
-
-    def _on_delay_changed(self, value: float):
+    def _set_delay(self, value: float):
         self.setInterval(int(value * 1000))
+
+
+# Create timer and expose a few methods to the public
+_timer = Timer()
+event = _timer.timeout
+stop = _timer.stop
+start = _timer.start
+
+
+@api.keybindings.register("ss", "slideshow", mode=api.modes.IMAGE)
+@api.commands.register(mode=api.modes.IMAGE, name="slideshow")
+def toggle(count: Optional[int] = None):
+    """Toggle slideshow.
+
+    **count:** Set slideshow delay to count instead.
+    """
+    if count is not None:
+        api.settings.slideshow.delay.value = count
+        _timer.setInterval(1000 * count)
+    elif _timer.isActive():
+        _timer.stop()
+    else:
+        _timer.start()
+
+
+@api.status.module("{slideshow-delay}")
+def delay() -> str:
+    """Slideshow delay in seconds if the slideshow is running."""
+    if _timer.isActive():
+        interval_seconds = _timer.interval() / 1000
+        return f"{interval_seconds:.1f}"
+    return ""
+
+
+@api.status.module("{slideshow-indicator}")
+def running_indicator() -> str:
+    """Indicator if slideshow is running."""
+    return api.settings.slideshow.indicator.value if _timer.isActive() else ""


### PR DESCRIPTION
Where possible in a simple way we removed using `class.instance` to get the current instance of a class in the `objreg` in unrelated parts of the code. This makes the dependencies clearer and makes calling `class.instance` an implementation detail of the object registry that is not recommended. This should also make refactoring in the future easier.