### PR TITLE
Metadata Handling

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,7 @@
 Christian Karl (karlch) <karlch at protonmail dot com>
 Wolfgang Popp (woefe) <mail at wolfgang-popp dot de>
 Ankur Sinha (sanjayankur31) <ankursinha at fedoraproject dot org>
+Jean-Claude Graf (jeanggi90) <jeanggi90 at gmail dot com>
 
 All contributors of non-trivial code are listed here. Please send an email to
 <karlch at protonmail dot com> or open an issue / pull request if you feel like your

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -488,3 +488,14 @@ class title:  # pylint: disable=invalid-name
         desc="Default window title if no mode specific options exist",
     )
     StrSetting("title.image", "vimiv - {basename}", desc="Window title in image mode")
+
+
+class metadata:  # pylint: disable=invalid-name
+    """Namespace for metadata related settings."""
+
+    # Store the keys as a comma seperated string
+    StrSetting(
+        "metadata.keylist",
+        "Make, Model, DateTime, ExposureTime, FNumber, isospeedratings, FocalLength",
+        desc="Define the metadata keys to display"
+    )

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -497,5 +497,5 @@ class metadata:  # pylint: disable=invalid-name
     StrSetting(
         "metadata.keylist",
         "Make, Model, DateTime, ExposureTime, FNumber, isospeedratings, FocalLength",
-        desc="Define the metadata keys to display"
+        desc="Define the metadata keys to display",
     )

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -494,8 +494,8 @@ class metadata:  # pylint: disable=invalid-name
     """Namespace for metadata related settings."""
 
     # Store the keys as a comma seperated string
-    StrSetting(
-        "metadata.keylist",
+    keys = StrSetting(
+        "metadata.keys",
         "Make, Model, DateTime, ExposureTime, FNumber, isospeedratings, FocalLength",
         desc="Define the metadata keys to display",
     )

--- a/vimiv/imutils/exif.py
+++ b/vimiv/imutils/exif.py
@@ -13,7 +13,7 @@ piexif (https://github.com/hMatoba/Piexif).
 import contextlib
 
 from vimiv.utils import log, lazy
-from vimiv import api, utils
+from vimiv import api
 
 piexif = lazy.import_module("piexif", optional=True)
 
@@ -117,7 +117,7 @@ class ExifInformation(dict):
                 if keyname.lower() not in desiredKeys:
                     _logger.debug(f'{keyname.lower()} not in {desiredKeys}. Ignoring it')
                     continue
-                if keytype in (1, 3, 4, 9) : # integer
+                if keytype in (1, 3, 4, 9): # integer
                     with contextlib.suppress(KeyError):
                         self[keyname] = val
                 elif keytype == 2: # byte encoded ascii

--- a/vimiv/imutils/exif.py
+++ b/vimiv/imutils/exif.py
@@ -100,8 +100,11 @@ class ExifInformation(dict):
         """Load exif information from filename into the dictionary."""
         try:
             self._exif = piexif.load(filename)
-            desiredKeys = [e.lower().strip() for e in api.settings.get_value("metadata.keylist").split(',')]
-            _logger.debug(f'Read metadata.keylist {desiredKeys}')
+            desired_keys = [
+                e.lower().strip()
+                for e in api.settings.get_value("metadata.keylist").split(",")
+            ]
+            _logger.debug(f"Read metadata.keylist {desired_keys}")
         except (piexif.InvalidImageDataError, FileNotFoundError, KeyError):
             return
 
@@ -113,20 +116,24 @@ class ExifInformation(dict):
                 keyname = piexif.TAGS[ifd][tag]["name"]
                 keytype = piexif.TAGS[ifd][tag]["type"]
                 val = self._exif[ifd][tag]
-                _logger.debug(f'name: {keyname} type: {keytype} value: {val} tag: {tag}')
-                if keyname.lower() not in desiredKeys:
-                    _logger.debug(f'{keyname.lower()} not in {desiredKeys}. Ignoring it')
+                _logger.debug(
+                    f"name: {keyname} type: {keytype} value: {val} tag: {tag}"
+                )
+                if keyname.lower() not in desired_keys:
+                    _logger.debug(
+                        f"{keyname.lower()} not in {desired_keys}. Ignoring it"
+                    )
                     continue
-                if keytype in (1, 3, 4, 9): # integer
+                if keytype in (1, 3, 4, 9):  # integer
                     with contextlib.suppress(KeyError):
                         self[keyname] = val
-                elif keytype == 2: # byte encoded ascii
+                elif keytype == 2:  # byte encoded ascii
                     with contextlib.suppress(KeyError):
                         self[keyname] = val.decode()
-                elif keytype in (5, 10): # (int, int) <=> numerator, denominator
+                elif keytype in (5, 10):  # (int, int) <=> numerator, denominator
                     with contextlib.suppress(KeyError):
                         self[keyname] = f"{val[0]}/{val[1]}"
-                elif keytype == 7: # byte
+                elif keytype == 7:  # byte
                     with contextlib.suppress(KeyError):
                         self[keyname] = val.decode()
 


### PR DESCRIPTION
Related to #100. I do not think that there is one set of metadata which suit the need to all users. Neither do I think that all users want to fiddle with the source code in order to get their desired metadata to show. Therefore I have added an option to set the desired metadata as a list in the settings.
Since the data is treated generically, I have not yet figured out the best was to properly format the data, e.g. add units, as `piexif` does not seem to have a notion of the units themselves.

Furthermore, depending on the stage of my photography workflow, different metadata information are relevant. Therefore I have thought about adding 3 to 5 user customizable sets of metadata key, which can be viewed one the metadata widget. Changing the metadata set should be done using a shortcut (e.g. <kbd>CTRL</kbd> + <kbd>1</kbd> through <kbd>CTRL</kbd> + <kbd>5</kbd>).

@karlch tell me what you think about that
