### PR TITLE
Mutiple Sets of Metadata

### DIFF
--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -508,4 +508,4 @@ class metadata:  # pylint: disable=invalid-name
         suggestions=defaults,
     )
 
-    keysets: List[str] = defaults
+    keysets: Dict[int, str] = dict(enumerate(defaults, start=1))

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -493,12 +493,19 @@ class title:  # pylint: disable=invalid-name
 class metadata:  # pylint: disable=invalid-name
     """Namespace for metadata related settings."""
 
+    # Default sets
+    defaults = [
+        "Make, Model, DateTime, ExposureTime, FNumber, IsoSpeedRatings, FocalLength, LensMake, LensModel, PixelXDimension', 'PixelYDimension, ExposureBiasValue",
+        "ExposureTime, FNumber, IsoSpeedRatings, FocalLength",
+        "Artist, Copyright",
+    ]
+
     # Store the keys as a comma seperated string
     current_keyset = StrSetting(
         "metadata.current_keyset",
-        "",
-        desc="Define the metadata keys to display",
-        hidden=True,
+        defaults[0],
+        desc="Currently displayed metadata keyset",
+        suggestions=defaults,
     )
 
-    keysets: List[str] = None
+    keysets: List[str] = defaults

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -495,7 +495,7 @@ class metadata:  # pylint: disable=invalid-name
 
     # Default sets
     defaults = [
-        "Make, Model, DateTime, ExposureTime, FNumber, IsoSpeedRatings, FocalLength, LensMake, LensModel, PixelXDimension', 'PixelYDimension, ExposureBiasValue",  # pylint: disable=line-too-long,useless-suppression
+        "Make, Model, DateTime, ExposureTime, FNumber, IsoSpeedRatings, FocalLength, LensMake, LensModel, ExposureBiasValue",  # pylint: disable=line-too-long,useless-suppression
         "ExposureTime, FNumber, IsoSpeedRatings, FocalLength",
         "Artist, Copyright",
     ]

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -499,3 +499,5 @@ class metadata:  # pylint: disable=invalid-name
         "Make, Model, DateTime, ExposureTime, FNumber, isospeedratings, FocalLength",
         desc="Define the metadata keys to display",
     )
+
+    keysets = {}

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -495,7 +495,7 @@ class metadata:  # pylint: disable=invalid-name
 
     # Default sets
     defaults = [
-        "Make, Model, DateTime, ExposureTime, FNumber, IsoSpeedRatings, FocalLength, LensMake, LensModel, PixelXDimension', 'PixelYDimension, ExposureBiasValue",
+        "Make, Model, DateTime, ExposureTime, FNumber, IsoSpeedRatings, FocalLength, LensMake, LensModel, PixelXDimension', 'PixelYDimension, ExposureBiasValue",  # pylint: disable=line-too-long,useless-suppression
         "ExposureTime, FNumber, IsoSpeedRatings, FocalLength",
         "Artist, Copyright",
     ]

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -494,10 +494,11 @@ class metadata:  # pylint: disable=invalid-name
     """Namespace for metadata related settings."""
 
     # Store the keys as a comma seperated string
-    keys = StrSetting(
-        "metadata.keys",
-        "Make, Model, DateTime, ExposureTime, FNumber, isospeedratings, FocalLength",
+    current_keyset = StrSetting(
+        "metadata.current_keyset",
+        "",
         desc="Define the metadata keys to display",
+        hidden=True,
     )
 
-    keysets = {}
+    keysets: List[str] = None

--- a/vimiv/config/configfile.py
+++ b/vimiv/config/configfile.py
@@ -147,14 +147,14 @@ def _read_plugins(pluginsection):
     plugins.add_plugins(**pluginsection)
 
 
-def _add_metadata(configsetion):
+def _add_metadata(configsection):
     """Set available metadata sets from config file.
 
     Args:
-        configparser: METADATA section in the config file.
+        configsection: METADATA section in the config file.
     """
     temp = {}
-    for name, value in configsetion.items():
+    for name, value in configsection.items():
         match = re.search(r"keys(\d+)", name)
         if match:
             temp[match.group(1)] = value

--- a/vimiv/config/configfile.py
+++ b/vimiv/config/configfile.py
@@ -6,6 +6,8 @@
 
 """Functions to read configurations from config file and update settings."""
 
+import re
+
 import configparser
 
 from vimiv import api, plugins
@@ -153,12 +155,10 @@ def _add_metadata(configsetion):
     """
     temp = {}
     for name, value in configsetion.items():
-        try:
-            # If keyname is int, is a metadata set
-            temp[int(name)] = value
+        match = re.search("keys(\d+)", name)
+        if match:
+            temp[match.group(1)] = value
             _logger.debug("Keyset '%s' found", value)
-        except ValueError:
-            pass
     api.settings.metadata.keysets = [v for _, v in temp.items()]
     if len(api.settings.metadata.keysets) > 0:
         api.settings.metadata.current_keyset.value = api.settings.metadata.keysets[0]

--- a/vimiv/config/configfile.py
+++ b/vimiv/config/configfile.py
@@ -151,10 +151,14 @@ def _add_metadata(configsetion):
     Args:
         configparser: METADATA section in the config file.
     """
+    temp = {}
     for name, value in configsetion.items():
         try:
             # If keyname is int, is a metadata set
-            api.settings.metadata.keysets[int(name)] = value
-            _logger.debug("Updating keyset '%s' to '%s'", name, value)
+            temp[int(name)] = value
+            _logger.debug("Keyset '%s' found", value)
         except ValueError:
             pass
+    api.settings.metadata.keysets = [v for _, v in temp.items()]
+    if len(api.settings.metadata.keysets) > 0:
+        api.settings.metadata.current_keyset.value = api.settings.metadata.keysets[0]

--- a/vimiv/config/configfile.py
+++ b/vimiv/config/configfile.py
@@ -62,6 +62,9 @@ def read(path: str) -> None:
     # Read plugins
     if "PLUGINS" in parser:
         _read_plugins(parser["PLUGINS"])
+    # Read metadata sets
+    if "METADATA" in parser:
+        _add_metadata(parser["METADATA"])
     _logger.debug("Read configuration from '%s'", path)
 
 
@@ -140,3 +143,18 @@ def _read_plugins(pluginsection):
     """
     _logger.debug("Plugins in config: %s", quotedjoin(pluginsection))
     plugins.add_plugins(**pluginsection)
+
+
+def _add_metadata(configsetion):
+    """Set available metadata sets from config file.
+
+    Args:
+        configparser: METADATA section in the config file.
+    """
+    for name, value in configsetion.items():
+        try:
+            # If keyname is int, is a metadata set
+            api.settings.metadata.keysets[int(name)] = value
+            _logger.debug("Updating keyset '%s' to '%s'", name, value)
+        except ValueError:
+            pass

--- a/vimiv/config/configfile.py
+++ b/vimiv/config/configfile.py
@@ -155,7 +155,7 @@ def _add_metadata(configsetion):
     """
     temp = {}
     for name, value in configsetion.items():
-        match = re.search("keys(\d+)", name)
+        match = re.search(r"keys(\d+)", name)
         if match:
             temp[match.group(1)] = value
             _logger.debug("Keyset '%s' found", value)

--- a/vimiv/config/configfile.py
+++ b/vimiv/config/configfile.py
@@ -6,9 +6,8 @@
 
 """Functions to read configurations from config file and update settings."""
 
-import re
-
 import configparser
+import re
 
 from vimiv import api, plugins
 from vimiv.commands import aliases

--- a/vimiv/config/configfile.py
+++ b/vimiv/config/configfile.py
@@ -152,12 +152,13 @@ def _add_metadata(configsection):
     Args:
         configsection: METADATA section in the config file.
     """
-    temp = {}
     for name, value in configsection.items():
         match = re.search(r"keys(\d+)", name)
         if match:
-            temp[match.group(1)] = value
-            _logger.debug("Keyset '%s' found", value)
-    api.settings.metadata.keysets = [v for _, v in temp.items()]
+            number = int(match.group(1))
+            api.settings.metadata.keysets[number] = value
+            _logger.debug("Keyset %d: '%s' found", number, value)
     if len(api.settings.metadata.keysets) > 0:
-        api.settings.metadata.current_keyset.value = api.settings.metadata.keysets[0]
+        api.settings.metadata.current_keyset.value = api.settings.metadata.keysets[
+            min(api.settings.metadata.keysets.keys())
+        ]

--- a/vimiv/gui/metadatawidget.py
+++ b/vimiv/gui/metadatawidget.py
@@ -55,7 +55,7 @@ if exif.piexif is not None:
             self._mainwindow_bottom = 0
             self._mainwindow_width = 0
             self._path = ""
-            self._currentSet = ""
+            self._current_set = ""
 
             api.signals.new_image_opened.connect(self._on_image_opened)
             api.settings.metadata.current_keyset.changed.connect(self._update_text)
@@ -112,7 +112,7 @@ if exif.piexif is not None:
 
         def _update_text(self):
             """Update the metadata text if the current image has not been loaded."""
-            if self._currentSet == api.settings.metadata.current_keyset.value:
+            if self._current_set == api.settings.metadata.current_keyset.value:
                 return
             _logger.debug(
                 "%s: reading exif of %s", self.__class__.__qualname__, self._path
@@ -127,18 +127,18 @@ if exif.piexif is not None:
                 )
             self.setText(f"<table>{text}</table>")
             self._update_geometry()
-            self._currentSet = api.settings.metadata.current_keyset.value
+            self._current_set = api.settings.metadata.current_keyset.value
 
         @utils.slot
         def _on_image_opened(self, path: str):
             """Load new image and update text if the widget is currently visible."""
             self._path = path
-            self._currentSet = ""
+            self._current_set = ""
             if self.isVisible():
                 self._update_text()
 
         def _count_is_valid(self, count: int) -> bool:
-            """Check if the provided count is in a valid range"""
+            """Check if the provided count is in a valid range."""
             return count >= 1 and count - 1 < len(api.settings.metadata.keysets)
 
 

--- a/vimiv/gui/metadatawidget.py
+++ b/vimiv/gui/metadatawidget.py
@@ -68,6 +68,16 @@ if exif.piexif is not None:
             """Toggle display of exif metadata of current image.
 
             **count:** Select the key set to display instead.
+
+            .. hint::
+                3 default key sets are provided and mapped to the counts 1-3. To
+                override them or add your own, extend the METADATA section in your
+                configfile like this::
+
+                    keys2 = Override,Second,Set
+                    keys4 = New,Fourth,Set
+
+                where the values must be a comma-separated list of valid metadata keys.
             """
 
             if count is not None:

--- a/vimiv/gui/metadatawidget.py
+++ b/vimiv/gui/metadatawidget.py
@@ -6,14 +6,14 @@
 
 """Overlay widget to display image metadata."""
 
+from typing import Optional
+
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QLabel, QSizePolicy
 
 from vimiv import api, utils
 from vimiv.imutils import exif
 from vimiv.config import styles
-
-from typing import Optional
 
 _logger = utils.log.module_logger(__name__)
 
@@ -31,7 +31,7 @@ if exif.piexif is not None:
             _mainwindow_bottom: y-coordinate of the bottom of the mainwindow.
             _mainwindow_width: width of the mainwindow.
             _path: Absolute path of the current image to load exif metadata of.
-            _loaded: True if metadata has been loaded for the current image.
+            _current_set: Holds a string of the currently selected keyset.
         """
 
         STYLESHEET = """
@@ -65,9 +65,9 @@ if exif.piexif is not None:
         @api.keybindings.register("i", "metadata", mode=api.modes.IMAGE)
         @api.commands.register(mode=api.modes.IMAGE)
         def metadata(self, count: Optional[int] = None):
-            """Toggle display of exif metadata of current image and handle switching of metadata keysets.
+            """Toggle display of exif metadata of current image.
 
-            **count:** Select the key set to display.
+            **count:** Select the key set to display instead.
             """
 
             if self.isVisible():

--- a/vimiv/gui/metadatawidget.py
+++ b/vimiv/gui/metadatawidget.py
@@ -70,27 +70,22 @@ if exif.piexif is not None:
             **count:** Select the key set to display instead.
             """
 
-            if self.isVisible():
-                if count is not None:
-                    if self._count_is_valid(count):
-                        _logger.debug("Switch keyset in open widget")
-                        api.settings.metadata.current_keyset.value = api.settings.metadata.keysets[
-                            count - 1
-                        ]
-                        self._update_text()
-                else:
-                    _logger.debug("Hiding widget")
-                    self.hide()
+            if count is not None:
+                try:
+                    _logger.debug("Switch keyset")
+                    api.settings.metadata.current_keyset.value = api.settings.metadata.keysets[
+                        count
+                    ]
+                    if not self.isVisible():
+                        _logger.debug("Showing widget")
+                        self.raise_()
+                        self.show()
+                except KeyError:
+                    raise api.commands.CommandError(f"Invalid key set option {count}")
+            elif self.isVisible():
+                _logger.debug("Hiding widget")
+                self.hide()
             else:
-                if count is not None:
-                    if self._count_is_valid(count):
-                        api.settings.metadata.current_keyset.value = api.settings.metadata.keysets[
-                            count - 1
-                        ]
-                    else:
-                        api.settings.metadata.current_keyset.value = api.settings.metadata.keysets[
-                            0
-                        ]
                 _logger.debug("Showing widget")
                 self._update_text()
                 self.raise_()
@@ -136,10 +131,6 @@ if exif.piexif is not None:
             self._current_set = ""
             if self.isVisible():
                 self._update_text()
-
-        def _count_is_valid(self, count: int) -> bool:
-            """Check if the provided count is in a valid range."""
-            return count >= 1 and count - 1 < len(api.settings.metadata.keysets)
 
 
 else:  # No exif support

--- a/vimiv/gui/metadatawidget.py
+++ b/vimiv/gui/metadatawidget.py
@@ -73,9 +73,8 @@ if exif.piexif is not None:
             if count is not None:
                 try:
                     _logger.debug("Switch keyset")
-                    api.settings.metadata.current_keyset.value = api.settings.metadata.keysets[
-                        count
-                    ]
+                    new_keyset = api.settings.metadata.keysets[count]
+                    api.settings.metadata.current_keyset.value = new_keyset
                     if not self.isVisible():
                         _logger.debug("Showing widget")
                         self.raise_()

--- a/vimiv/imutils/exif.py
+++ b/vimiv/imutils/exif.py
@@ -101,9 +101,10 @@ class ExifInformation(dict):
         try:
             self._exif = piexif.load(filename)
             desired_keys = [
-                e.lower().strip() for e in api.settings.metadata.keys.value.split(",")
+                e.lower().strip()
+                for e in api.settings.metadata.current_keyset.value.split(",")
             ]
-            _logger.debug(f"Read metadata.keys {desired_keys}")
+            _logger.debug(f"Read metadata.current_keys {desired_keys}")
         except (piexif.InvalidImageDataError, FileNotFoundError, KeyError):
             return
 


### PR DESCRIPTION
As described in #213, this PR implements several customizable sets of metadata keys which are displayed in the `gui.metadatawidget`. The different sets can be accessed and switched by pressing `[count]i`.

- [x] read keysets from the config
- [x] provide a default keyset(s)
- [ ] ~~allow editing via `:set` (???)~~
- [x] react on shurtcut with count and switch set
- [x] better way to define sets in the config. Maye something like `set3 = ...` instead of `3 = ...`
- [ ] ~~*flag* (e.g. `__ALL__`) to display all metadata found, in a certain list~~
- [ ] unit tests (???)
- [x] documentation

The implementation is very similar to how you suggested to implement it in #213. So far, the basic mechanism for reading the keysets from the config, displaying the appropriate metadata in the `gui.metadatawidget` as well as switching the sets using `[count]i` is implemented.  Does it suit your imagination @karlch ?

An open question I have is, how and what default should be provided? Is a single set sufficient (similarly to how it is currently on master)? If yes, I guess we can simply assign that default to `metadata.current_keyset`, since this value should not we changed if `metadata.keysets` is nothing assigned. Further, I am unsure how these sets can be edited during runtime using `:set` and if there should even be this possible. What so you think @karlch ?

P.S. You need to populate you config with some sets in order to test it. Currently it may crash if you do not do so because of the missin default.
