### PR TITLE
Zoom Reset Option

### DIFF
--- a/vimiv/commands/argtypes.py
+++ b/vimiv/commands/argtypes.py
@@ -29,6 +29,7 @@ class Zoom(enum.Enum):
 
     In = "in"
     Out = "out"
+    Reset = "reset"
 
 
 class ImageScale(str, enum.Enum):

--- a/vimiv/gui/image.py
+++ b/vimiv/gui/image.py
@@ -203,6 +203,7 @@ class ScrollableImage(eventhandler.EventHandlerMixin, QGraphicsView):
 
     @api.keybindings.register("-", "zoom out", mode=api.modes.IMAGE)
     @api.keybindings.register("+", "zoom in", mode=api.modes.IMAGE)
+    @api.keybindings.register("=", "zoom reset", mode=api.modes.IMAGE)
     @api.commands.register(mode=api.modes.IMAGE)
     def zoom(self, direction: Zoom, count: int = 1):
         """Zoom the current widget.
@@ -210,13 +211,16 @@ class ScrollableImage(eventhandler.EventHandlerMixin, QGraphicsView):
         **syntax:** ``:zoom direction``
 
         positional arguments:
-            * ``direction``: The direction to zoom in (in/out).
+            * ``direction``: The direction to zoom in (in/out/reset).
 
         **count:** multiplier
         """
-        scale = 1.25 ** count if direction == Zoom.In else 1 / 1.25 ** count
-        self._scale_to_float(self.zoom_level * scale)
-        self._scale = ImageScaleFloat(self.zoom_level)
+        if direction == Zoom.Reset:
+            self.scale(ImageScale.Fit)
+        else:
+            scale = 1.25 ** count if direction == Zoom.In else 1 / 1.25 ** count
+            self._scale_to_float(self.zoom_level * scale)
+            self._scale = ImageScaleFloat(self.zoom_level)
 
     @api.keybindings.register("w", "scale --level=fit", mode=api.modes.IMAGE)
     @api.keybindings.register("W", "scale --level=1", mode=api.modes.IMAGE)

--- a/vimiv/gui/thumbnail.py
+++ b/vimiv/gui/thumbnail.py
@@ -262,6 +262,7 @@ class ThumbnailView(
 
     @api.keybindings.register("-", "zoom out", mode=api.modes.THUMBNAIL)
     @api.keybindings.register("+", "zoom in", mode=api.modes.THUMBNAIL)
+    @api.keybindings.register("=", "zoom reset", mode=api.modes.THUMBNAIL)
     @api.commands.register(mode=api.modes.THUMBNAIL)
     def zoom(self, direction: argtypes.Zoom):
         """Zoom the current widget.
@@ -269,12 +270,17 @@ class ThumbnailView(
         **syntax:** ``:zoom direction``
 
         positional arguments:
-            * ``direction``: The direction to zoom in (in/out).
+            * ``direction``: The direction to zoom in (in/out/reset).
 
         **count:** multiplier
         """
         _logger.debug("Zooming in direction '%s'", direction)
-        api.settings.thumbnail.size.step(up=direction == direction.In)
+        if direction == argtypes.Zoom.Reset:
+            api.settings.thumbnail.size.value = api.settings.thumbnail.size.ALLOWED_VALUES[
+                1
+            ]
+        else:
+            api.settings.thumbnail.size.step(up=direction == direction.In)
 
     def rescale_items(self):
         """Reset item hint when item size has changed."""


### PR DESCRIPTION
I think it is crucial to be able to reset to zoom level back to `fit`, after having to zoom an image e.g. to check the sharpness. Therefore I have added this option, with the default keybinding `=`, for the image and for completeness also the thumbnail view.
