### PR TITLE
Write metadata key sets to initial config file

### DIFF
--- a/vimiv/config/configfile.py
+++ b/vimiv/config/configfile.py
@@ -44,6 +44,12 @@ def get_default_parser() -> configparser.ConfigParser:
     parser.add_section("PLUGINS")
     parser["PLUGINS"] = plugins.get_plugins()
     parser.add_section("ALIASES")
+    # Only write the individual key sets, not the current keyset as the first of the
+    # individual options is chosen as the current one
+    del parser["METADATA"]["current_keyset"]
+    parser["METADATA"].update(
+        {f"keys{num:d}": value for num, value in api.settings.metadata.keysets.items()}
+    )
     return parser
 
 


### PR DESCRIPTION
This changes the formatting of the `METADATA` section in the default config file which is written upon first start from:
```
[METADATA]
current_keyset = Make, Model, DateTime, ExposureTime, FNumber, IsoSpeedRatings, FocalLength, LensMake, LensModel, ExposureBiasValue
```
to:
```
[METADATA]
keys1 = Make, Model, DateTime, ExposureTime, FNumber, IsoSpeedRatings, FocalLength, LensMake, LensModel, ExposureBiasValue
keys2 = ExposureTime, FNumber, IsoSpeedRatings, FocalLength
keys3 = Artist, Copyright
```

I noticed this when playing around with the recently merged #215 and feel like this change improves self-documentation and makes the intention of how to use these slightly clearer.

What do you think @jeanggi90?