### PR TITLE
Extend end2end tests for the :metadata command

### DIFF
--- a/tests/end2end/features/image/conftest.py
+++ b/tests/end2end/features/image/conftest.py
@@ -1,0 +1,39 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2020 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+import pytest
+import pytest_bdd as bdd
+
+from vimiv import imutils
+
+try:
+    import piexif
+except ImportError:
+    piexif = None
+
+
+@pytest.fixture()
+def exif_content():
+    yield {
+        "0th": {piexif.ImageIFD.Make: b"vimiv-testsuite"},
+        "Exif": {piexif.ExifIFD.Sharpness: 65535},
+    }
+
+
+@pytest.fixture()
+def handler():
+    yield imutils._ImageFileHandler.instance
+
+
+@bdd.when("I add exif information")
+def add_exif_information(handler, exif_content):
+    assert piexif is not None, "piexif required to add exif information"
+    path = handler._path
+    exif_dict = piexif.load(path)
+    for ifd, ifd_dict in exif_content.items():
+        for key, value in ifd_dict.items():
+            exif_dict[ifd][key] = value
+    piexif.insert(piexif.dump(exif_dict), path)

--- a/tests/end2end/features/image/conftest.py
+++ b/tests/end2end/features/image/conftest.py
@@ -18,8 +18,12 @@ except ImportError:
 @pytest.fixture()
 def exif_content():
     yield {
-        "0th": {piexif.ImageIFD.Make: b"vimiv-testsuite"},
-        "Exif": {piexif.ExifIFD.Sharpness: 65535},
+        "0th": {
+            piexif.ImageIFD.Make: b"vimiv-testsuite",
+            piexif.ImageIFD.Model: b"image-viewer",
+            piexif.ImageIFD.Copyright: b"vimiv-AUTHORS-2020",
+        },
+        "Exif": {piexif.ExifIFD.ExposureTime: (1, 200)},
     }
 
 

--- a/tests/end2end/features/image/metadata.feature
+++ b/tests/end2end/features/image/metadata.feature
@@ -3,11 +3,49 @@ Feature: Metadata widget displaying image exif information
 
     Scenario: Show metadata widget
         Given I open any image
-        When I run metadata
+        When I add exif information
+        And I run metadata
         Then the metadata widget should be visible
+        And the metadata text should contain 'Make'
+        And the metadata text should contain 'vimiv-testsuite'
+        And the metadata text should contain 'Model'
+        And the metadata text should contain 'image-viewer'
 
     Scenario: Toggle metadata widget
         Given I open any image
         When I run metadata
         And I run metadata
         Then the metadata widget should not be visible
+
+    Scenario: Switch to second metadata key set
+        Given I open any image
+        When I add exif information
+        And I run 2metadata
+        Then the metadata widget should be visible
+        And the metadata text should contain 'ExposureTime'
+        And the metadata text should contain '1/200'
+
+    Scenario: Switch to third metadata key set
+        Given I open any image
+        When I add exif information
+        And I run 3metadata
+        Then the metadata widget should be visible
+        And the metadata text should contain 'Copyright'
+        And the metadata text should contain 'vimiv-AUTHORS-2020'
+
+    Scenario: Error message on invalid metadata key set number
+        Given I open any image
+        When I run 42metadata
+        Then the metadata widget should not be visible
+        And the message
+            'metadata: Invalid key set option 42'
+            should be displayed
+
+    Scenario: Switch metadata information upon new image
+        Given I open 2 images
+        When I add exif information
+        And I run metadata
+        And I run next
+        Then the metadata widget should be visible
+        # The new image no longer has any exif information
+        And the metadata text should not contain 'Make'

--- a/tests/end2end/features/image/test_metadata_bdd.py
+++ b/tests/end2end/features/image/test_metadata_bdd.py
@@ -26,3 +26,13 @@ def check_metadata_widget_visible(metadata):
 @bdd.then("the metadata widget should not be visible")
 def check_metadata_widget_not_visible(metadata):
     assert not metadata.isVisible()
+
+
+@bdd.then(bdd.parsers.parse("the metadata text should contain '{text}'"))
+def check_text_in_metadata(metadata, text):
+    assert text in metadata.text()
+
+
+@bdd.then(bdd.parsers.parse("the metadata text should not contain '{text}'"))
+def check_text_not_in_metadata(metadata, text):
+    assert text not in metadata.text()

--- a/tests/end2end/features/image/test_write_bdd.py
+++ b/tests/end2end/features/image/test_write_bdd.py
@@ -4,7 +4,6 @@
 # Copyright 2017-2020 Christian Karl (karlch) <karlch at protonmail dot com>
 # License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
 
-import pytest
 import pytest_bdd as bdd
 
 try:
@@ -12,23 +11,8 @@ try:
 except ImportError:
     piexif = None
 
-from vimiv import imutils
-
 
 bdd.scenarios("write.feature")
-
-
-@pytest.fixture()
-def handler():
-    yield imutils._ImageFileHandler.instance
-
-
-@pytest.fixture()
-def exif_content():
-    yield {
-        "0th": {piexif.ImageIFD.Make: b"vimiv-testsuite"},
-        "Exif": {piexif.ExifIFD.Sharpness: 65535},
-    }
 
 
 @bdd.when(bdd.parsers.parse("I write the image to {name}"))
@@ -40,17 +24,6 @@ def write_image(handler, name):
         original_path=handler._path,
         parallel=False,
     )
-
-
-@bdd.when("I add exif information")
-def add_exif_information(handler, exif_content):
-    assert piexif is not None, "piexif required to add exif information"
-    path = handler._path
-    exif_dict = piexif.load(path)
-    for ifd, ifd_dict in exif_content.items():
-        for key, value in ifd_dict.items():
-            exif_dict[ifd][key] = value
-    piexif.insert(piexif.dump(exif_dict), path)
 
 
 @bdd.then(bdd.parsers.parse("the image {name} should contain exif information"))

--- a/vimiv/gui/metadatawidget.py
+++ b/vimiv/gui/metadatawidget.py
@@ -135,5 +135,5 @@ if exif.piexif is not None:
                 self._update_text()
 
 
-else:  # No exif support
+else:  # No exif support  # pragma: no cover  # Covered in another CI
     MetadataWidget = None  # type: ignore


### PR DESCRIPTION
This PR adds a few more end2end tests for the `:metadata` command.

In addition to the simple visibility checks we now ensure:
* the correct exif information is 
* we can switch exif information using the different key sets and `:[count]metadata`
* invalid `[count]`s trigger the appropriate error message
* the metadata widget updates its content when the image is changed

For this we did a few things:
1. Do some pytest fixture magic to make the `I add exif information` `when` step available for all tests in the image directory. We now use it in both `metadata.feature` and `write.feature`.
2. Extend the exif content in this fixture so we have a bit of information for each metadata key set.
3. Add two more `then` steps to check the text of the metadata widget.
4. Profit by extending the `metadata.feature` with all sorts of tests to ensure the above.

@jeanggi90 feel free to take a look and ask any questions here, happy to answer them if I can! The bdd-like tests using [pytest](https://docs.pytest.org/en/latest/) and [pytest-bdd](https://pytest-bdd.readthedocs.io/en/latest/) certainly take some getting used to but very often we can now write tests with little or no additional code. These end2end tests always run a full blown vimiv process and interact with it, useful for things like testing commands and their effect. For simpler function or class tests we use plain pytest in the unit test folder.