### PR TITLE
Handle Missing Metadata in Widget

### DIFF
--- a/tests/end2end/features/image/metadata.feature
+++ b/tests/end2end/features/image/metadata.feature
@@ -48,4 +48,4 @@ Feature: Metadata widget displaying image exif information
         And I run next
         Then the metadata widget should be visible
         # The new image no longer has any exif information
-        And the metadata text should not contain 'Make'
+        And the metadata text should contain 'No matching metadata found'

--- a/vimiv/gui/metadatawidget.py
+++ b/vimiv/gui/metadatawidget.py
@@ -122,7 +122,10 @@ if exif.piexif is not None:
                 "%s: reading exif of %s", self.__class__.__qualname__, self._path
             )
             exif_information = exif.ExifInformation(self._path)
-            self.setText(utils.format_html_table(exif_information.items()))
+            if exif_information:
+                self.setText(utils.format_html_table(exif_information.items()))
+            else:
+                self.setText("No matching metadata found")
             self._update_geometry()
             self._current_set = api.settings.metadata.current_keyset.value
 


### PR DESCRIPTION
As discussed in #221 

- [x] Display message when there is not metadata for a given keyset
- [ ] ~~Display `-` for a missing metadata value for a given key (???)~~

I have already implemented the first todo. Concerning the second one (the one I have proposed in #211), I am not sure if this option is really required. Personally, I am fine not showing anything for missing value. But if there is demand for such an option, I can easiliy add it.

implements #221