### PR TITLE
Fix metadata test flakiness

### DIFF
--- a/tests/end2end/features/image/conftest.py
+++ b/tests/end2end/features/image/conftest.py
@@ -7,7 +7,7 @@
 import pytest
 import pytest_bdd as bdd
 
-from vimiv import imutils
+from vimiv import imutils, utils
 
 try:
     import piexif
@@ -40,4 +40,7 @@ def add_exif_information(handler, exif_content):
     for ifd, ifd_dict in exif_content.items():
         for key, value in ifd_dict.items():
             exif_dict[ifd][key] = value
+    # Wait for thumbnail creation so we don't interfere with the current reading by
+    # adding more bytes
+    utils.Pool.wait(5000)
     piexif.insert(piexif.dump(exif_dict), path)

--- a/tests/end2end/features/image/metadata.feature
+++ b/tests/end2end/features/image/metadata.feature
@@ -1,4 +1,4 @@
-@ci_skip @optional
+@optional
 Feature: Metadata widget displaying image exif information
 
     Scenario: Show metadata widget


### PR DESCRIPTION
Seems like the issue was writing the exif data while thumbnails are being created. This changes the files byte data and can crash QImageReader.  Let's hope this is really the issue :smile: 

fixes #226 