### PR TITLE
Refactor trash manager and delete commands

### DIFF
--- a/tests/unit/utils/test_trash_manager.py
+++ b/tests/unit/utils/test_trash_manager.py
@@ -6,6 +6,7 @@
 
 """Tests for vimiv.utils.trash_manager."""
 
+import collections
 import os
 
 import pytest
@@ -13,21 +14,8 @@ import pytest
 from vimiv.utils import trash_manager
 
 
-def create_tmpfile(tmpdir, basename):
-    """Simple function to create a temporary file using the tmpdir fixture."""
-    path = tmpdir.join(basename)
-    path.write("temporary")
-    return str(path)
-
-
-@pytest.fixture()
-def tmpfile(tmpdir):
-    """Create a temporary file as fixture using tmpdir."""
-    yield create_tmpfile(tmpdir, "file")
-
-
 @pytest.fixture(autouse=True)
-def trash(monkeypatch, mocker, tmpdir):
+def trash(monkeypatch, tmpdir):
     """Initialize trash for testing as fixture.
 
     Returns:
@@ -35,44 +23,66 @@ def trash(monkeypatch, mocker, tmpdir):
     """
     xdg_data_home = tmpdir.mkdir("data")
     monkeypatch.setenv("XDG_DATA_HOME", str(xdg_data_home))
-    mocker.patch("vimiv.utils.files.is_image", return_value=True)
     trash_manager.init()
-    yield os.path.join(str(xdg_data_home), "Trash")
+    yield
     trash_manager.trash_info.cache_clear()
 
 
-def test_delete_file(tmpfile):
-    trash_manager.delete([tmpfile])
-    assert not os.path.exists(tmpfile)
+@pytest.fixture()
+def deleted_file(tmpdir):
+    original_filename = create_tmpfile(tmpdir, "file")
+    trash_filename = trash_manager.delete(original_filename)
+    info_filename = trash_manager._get_info_filename(original_filename)
+    paths = collections.namedtuple("DeletedFile", ("original", "trash", "info"))
+    return paths(original_filename, trash_filename, info_filename)
 
 
-def test_delete_multiple_files(tmpdir):
-    files = [create_tmpfile(tmpdir, f"file_{i:d}") for i in range(2)]
-    trash_manager.delete(files)
-    for fname in files:
-        assert not os.path.exists(fname)
+def test_delete_file(deleted_file):
+    assert not os.path.exists(deleted_file.original), "Original file not deleted"
+    assert os.path.exists(deleted_file.trash), "File not moved to trash"
 
 
-def test_delete_and_undelete_file(tmpfile):
-    trash_manager.delete([tmpfile])
-    basename = os.path.basename(tmpfile)
-    trash_manager.undelete([basename])
-    assert os.path.exists(tmpfile)
+def test_undelete_file(deleted_file):
+    trash_basename = os.path.basename(deleted_file.trash)
+    trash_manager.undelete(trash_basename)
+    assert os.path.exists(deleted_file.original), "Original file not restored"
+    assert not os.path.exists(deleted_file.trash), "File not removed from trash"
+    assert not os.path.exists(deleted_file.info), "File info not removed from trash"
 
 
-def test_do_not_override_existing_file_in_trash(trash, tmpdir):
-    for _ in range(2):
-        path = create_tmpfile(tmpdir, "new_file")
-        trash_manager.delete([path])
-    trashdir = os.path.join(trash, "files")
-    assert os.path.exists(os.path.join(trashdir, "new_file"))
-    assert os.path.exists(os.path.join(trashdir, "new_file.2"))
+def test_create_trashinfo(deleted_file):
+    with open(deleted_file.info, "r") as f:
+        content = f.read()
+
+    assert content.startswith("[Trash Info]"), "Trash info header not created"
+    assert f"Path={deleted_file.original}" in content, "Original path not written"
+    assert "DeletionDate=" in content, "Deletion date not written"
 
 
-def test_create_trash_info_file(trash, tmpdir):
-    for _ in range(2):
-        path = create_tmpfile(tmpdir, "new_file")
-        trash_manager.delete([path])
-    infodir = os.path.join(trash, "info")
-    assert os.path.exists(os.path.join(infodir, "new_file.trashinfo"))
-    assert os.path.exists(os.path.join(infodir, "new_file.2.trashinfo"))
+def test_do_not_overwrite_trash_file(deleted_file):
+    with open(deleted_file.original, "w") as f:
+        f.write("temporary")
+    trash_manager.delete(deleted_file.original)
+    assert os.path.exists(deleted_file.trash + ".2")
+    assert os.path.exists(deleted_file.info.replace(".trashinfo", ".2.trashinfo"))
+
+
+def test_fail_undelete_non_existing_file():
+    with pytest.raises(FileNotFoundError, match="File for"):
+        trash_manager.undelete(os.path.join("any", "random", "file"))
+
+
+def test_fail_undelete_non_existing_original_directory(tmpdir):
+    directory = tmpdir.mkdir("directory")
+    original_filename = create_tmpfile(directory, "file")
+    trash_filename = trash_manager.delete(original_filename)
+    os.rmdir(directory)
+    with pytest.raises(FileNotFoundError, match="Original directory"):
+        trash_manager.undelete(os.path.basename(trash_filename))
+
+
+def create_tmpfile(tmpdir, basename):
+    """Simple function to create a temporary file using the tmpdir fixture."""
+    path = tmpdir.join(basename)
+    path.write("temporary")
+    return str(path)

--- a/vimiv/commands/delete_command.py
+++ b/vimiv/commands/delete_command.py
@@ -1,0 +1,58 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2020 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+"""Commands to move files to and restore files from the trash directory."""
+
+import os
+from typing import List
+
+from vimiv import api
+from vimiv.utils import files, log, trash_manager
+
+_last_deleted: List[str] = []
+
+
+@api.keybindings.register("x", "delete %")
+@api.commands.register()
+def delete(paths: List[str]) -> None:
+    """Move one or more images to the trash directory.
+
+    **syntax:** ``:delete path [path ...]``
+
+    positional arguments:
+        * ``paths``: The path(s) to the images to delete.
+
+    .. note:: This only deletes images, not any other path(s).
+    """
+    _last_deleted.clear()
+    images = [path for path in paths if files.is_image(path)]
+    if not images:
+        raise api.commands.CommandError("No images to delete")
+    for filename in images:
+        trash_filename = trash_manager.delete(filename)
+        _last_deleted.append(os.path.basename(trash_filename))
+    n_images = len(images)
+    if n_images > 1:
+        log.info("Deleted %d images", n_images)
+
+
+@api.commands.register()
+def undelete(basenames: List[str]) -> None:
+    """Restore a file from the trash directory.
+
+    **syntax:** ``:undelete [basename ...]``
+
+    If no basename is given, the last deleted images in this session are restored.
+
+    positional arguments:
+        * ``basenames``: The basename(s) of the file in the trash directory.
+    """
+    basenames = basenames if basenames else _last_deleted
+    for basename in basenames:
+        try:
+            trash_manager.undelete(basename)
+        except FileNotFoundError as e:
+            raise api.commands.CommandError(str(e))

--- a/vimiv/startup.py
+++ b/vimiv/startup.py
@@ -27,7 +27,11 @@ from vimiv.gui import mainwindow
 from vimiv.utils import xdg, crash_handler, log, trash_manager, customtypes, migration
 
 # Must be imported to create the commands using the decorators
-from vimiv.commands import misccommands, help_command  # pylint: disable=unused-import
+from vimiv.commands import (  # pylint: disable=unused-import
+    misccommands,
+    delete_command,
+    help_command,
+)
 from vimiv.config import configcommands  # pylint: disable=unused-import
 
 

--- a/vimiv/utils/trash_manager.py
+++ b/vimiv/utils/trash_manager.py
@@ -10,11 +10,9 @@ The functions delete and undeletes images from the user's Trash directory
 in $XDG_DATA_HOME/Trash according to the freedesktop.org trash specification.
 
 Module Attributes:
-    _files_directory: String path to the directory in which trashed files are
+    _files_directory: Path to the directory in which trashed files are stored.
+    _info_directory: Path to the directory in which info files for trashed files are
         stored.
-    _info_directory: String path to the directory in which info files for
-        trashed files are stored.
-    _last_deleted: List of last deleted images to allow undeleting them.
 """
 
 import configparser
@@ -75,48 +73,6 @@ def undelete(basename: str) -> str:
     return original_filename
 
 
-def _get_trash_filename(filename: str) -> str:
-    """Return the name of the file in self.files_directory.
-
-    Args:
-        filename: The original name of the file.
-    """
-    path = os.path.join(_files_directory, os.path.basename(filename))
-    # Ensure that we do not overwrite any files
-    extension = 2
-    original_path = path
-    while os.path.exists(path):
-        path = original_path + "." + str(extension)
-        extension += 1
-    return path
-
-
-def _get_info_filename(filename: str) -> str:
-    basename = os.path.basename(filename)
-    return os.path.join(_info_directory, basename + ".trashinfo")
-
-
-def _create_info_file(trash_filename: str, original_filename: str) -> None:
-    """Create file with information as specified by the standard.
-
-    Args:
-        trash_filename: The name of the file in self.files_directory.
-        original_filename: The original name of the file.
-    """
-    # Write to temporary file and use shutil.move to make sure the
-    # operation is an atomic operation as specified by the standard
-    temp_file = tempfile.NamedTemporaryFile(dir=_info_directory, delete=False, mode="w")
-    info = TrashInfoParser()
-    info["Trash Info"] = {
-        "Path": original_filename,
-        "DeletionDate": time.strftime("%Y%m%dT%H%M%S"),
-    }
-    info.write(temp_file, space_around_delimiters=False)
-    # Move to proper filename
-    info_filename = _get_info_filename(trash_filename)
-    shutil.move(temp_file.name, info_filename)
-
-
 @functools.lru_cache(None)
 def trash_info(filename: str) -> Tuple[str, str]:
     """Get information stored in the .trashinfo file.
@@ -141,6 +97,53 @@ def trash_info(filename: str) -> Tuple[str, str]:
 
 def files_directory() -> str:
     return _files_directory
+
+
+def _get_trash_filename(filename: str) -> str:
+    """Return the name of the file in the trash files directory.
+
+    Args:
+        filename: The original name of the file.
+    """
+    path = os.path.join(_files_directory, os.path.basename(filename))
+    # Ensure that we do not overwrite any files
+    extension = 2
+    original_path = path
+    while os.path.exists(path):
+        path = original_path + "." + str(extension)
+        extension += 1
+    return path
+
+
+def _get_info_filename(trash_filename: str) -> str:
+    """Return the name of the corresponding trashinfo file.
+
+    Args:
+        trash_filename: The name of the corresponding file in the trash files directory.
+    """
+    basename = os.path.basename(trash_filename)
+    return os.path.join(_info_directory, basename + ".trashinfo")
+
+
+def _create_info_file(trash_filename: str, original_filename: str) -> None:
+    """Create file with information as specified by the standard.
+
+    Args:
+        trash_filename: The name of the file in self.files_directory.
+        original_filename: The original name of the file.
+    """
+    # Write to temporary file and use shutil.move to make sure the
+    # operation is an atomic operation as specified by the standard
+    temp_file = tempfile.NamedTemporaryFile(dir=_info_directory, delete=False, mode="w")
+    info = TrashInfoParser()
+    info["Trash Info"] = {
+        "Path": original_filename,
+        "DeletionDate": time.strftime("%Y%m%dT%H%M%S"),
+    }
+    info.write(temp_file, space_around_delimiters=False)
+    # Move to proper filename
+    info_filename = _get_info_filename(trash_filename)
+    shutil.move(temp_file.name, info_filename)
 
 
 class TrashInfoParser(configparser.ConfigParser):

--- a/vimiv/utils/trash_manager.py
+++ b/vimiv/utils/trash_manager.py
@@ -149,9 +149,9 @@ def _create_info_file(trash_filename: str, original_filename: str) -> None:
 class TrashInfoParser(configparser.ConfigParser):
     """Case-sensitive configparser without interpolation."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(interpolation=None)
 
-    def optionxform(self, optionstr):
+    def optionxform(self, optionstr: str) -> str:
         """Override so the parser becomes case sensitive."""
         return optionstr


### PR DESCRIPTION
* Split the command implementation from the trash manager
* Use configparser to read and write trash info files
* Extend and clean up unit tests

fixes #232 