### PR TITLE
Add tests for animated gifs and vector graphics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ Makefile
 **/.mypy_cache
 **/.dmypy.json
 **/*.rstsrc
+tests/data

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,6 +4,7 @@ addopts = --no-flaky-report
 faulthandler_timeout = 30
 markers =
     current: Mark tests during development
+    imageformats: Require retrieving images from the web to test additional formats
     optional: Require optional dependencies
     no_optional: Require optional dependencies to NOT be installed
     ci: Run test only on ci

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@
 
 import os
 import logging
+import urllib.request
 
 import pytest
 
@@ -85,3 +86,51 @@ def mock_file_handler(monkeypatch):
     statements to file.
     """
     monkeypatch.setattr(logging, "FileHandler", DevNullLogHandler)
+
+
+@pytest.fixture()
+def datadir():
+    """Fixture to retrieve the path to the data directory."""
+    testdir = os.path.dirname(__file__)
+    datadir = os.path.join(testdir, "data")
+    if not os.path.isdir(datadir):
+        os.makedirs(datadir, mode=0o700)
+    return datadir
+
+
+@pytest.fixture()
+def gif(datadir):
+    """Fixture to retrieve the path to a gif file.
+
+    We retrieve the file from the web if it does not exist. This should only happen once
+    per developing environment.
+    """
+    path = os.path.join(datadir, "vimiv.gif")
+    if not os.path.exists(path):
+        url = "https://i.postimg.cc/VkcPgcbR/vimiv.gif"
+        _retrieve_file_from_web(url, path)
+    return path
+
+
+@pytest.fixture()
+def svg(datadir):
+    """Fixture to retrieve the path to a svg file.
+
+    We retrieve the file from the web if it does not exist. This should only happen once
+    per developing environment.
+    """
+    path = os.path.join(datadir, "vimiv.svg")
+    if not os.path.exists(path):
+        url = "https://raw.githubusercontent.com/karlch/vimiv-qt/master/icons/vimiv.svg"
+        _retrieve_file_from_web(url, path)
+    return path
+
+
+def _retrieve_file_from_web(url: str, path: str) -> None:
+    """Helper function to write url byte data to path."""
+    print(f"Retrieving {path} from {url}")
+    with urllib.request.urlopen(url) as f:
+        data = f.read()
+    with open(path, "wb") as f:
+        f.write(data)
+    print("... success")

--- a/tests/end2end/conftest.py
+++ b/tests/end2end/conftest.py
@@ -142,6 +142,11 @@ def start_image_name(tmpdir, basename):
     start([path])
 
 
+@bdd.given("I open an animated gif")
+def start_animated_gif(gif):
+    start([gif])
+
+
 @bdd.given("I capture output")
 def output(capsys):
     yield Output(capsys)

--- a/tests/end2end/conftest.py
+++ b/tests/end2end/conftest.py
@@ -147,6 +147,11 @@ def start_animated_gif(gif):
     start([gif])
 
 
+@bdd.given("I open a vector graphic")
+def start_vector_graphic(svg):
+    start([svg])
+
+
 @bdd.given("I capture output")
 def output(capsys):
     yield Output(capsys)

--- a/tests/end2end/features/image/gif.feature
+++ b/tests/end2end/features/image/gif.feature
@@ -1,3 +1,4 @@
+@imageformats
 Feature: Open and play animated gifs
 
     Background:

--- a/tests/end2end/features/image/gif.feature
+++ b/tests/end2end/features/image/gif.feature
@@ -1,0 +1,11 @@
+Feature: Open and play animated gifs
+
+    Background:
+        Given I open an animated gif
+
+    Scenario: Autoplay animated gif
+        Then the animation should be playing
+
+    Scenario: Pause animated gif
+        When I run play-or-pause
+        Then the animation should be paused

--- a/tests/end2end/features/image/gif.feature
+++ b/tests/end2end/features/image/gif.feature
@@ -10,3 +10,9 @@ Feature: Open and play animated gifs
     Scenario: Pause animated gif
         When I run play-or-pause
         Then the animation should be paused
+
+    Scenario: Do not rotate animated gif
+        When I run rotate
+        Then the message
+            'rotate: File format does not support transform'
+            should be displayed

--- a/tests/end2end/features/image/svg.feature
+++ b/tests/end2end/features/image/svg.feature
@@ -1,3 +1,4 @@
+@imageformats
 Feature: Open vector graphics
 
     Background:

--- a/tests/end2end/features/image/svg.feature
+++ b/tests/end2end/features/image/svg.feature
@@ -1,0 +1,8 @@
+Feature: Open vector graphics
+
+    Background:
+        Given I open a vector graphic
+
+    Scenario: Zoom vector graphic
+        When I run zoom in
+        Then no crash should happen

--- a/tests/end2end/features/image/test_gif_bdd.py
+++ b/tests/end2end/features/image/test_gif_bdd.py
@@ -1,0 +1,28 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2020 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+import pytest
+
+import pytest_bdd as bdd
+
+
+bdd.scenarios("gif.feature")
+
+
+@pytest.fixture()
+def movie(image):
+    widget = image.items()[0].widget()
+    return widget.movie()
+
+
+@bdd.then("the animation should be playing")
+def check_animation_playing(movie):
+    assert movie.state() == movie.Running
+
+
+@bdd.then("the animation should be paused")
+def check_animation_paused(movie):
+    assert movie.state() == movie.Paused

--- a/tests/end2end/features/image/test_svg_bdd.py
+++ b/tests/end2end/features/image/test_svg_bdd.py
@@ -1,0 +1,10 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2020 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+import pytest_bdd as bdd
+
+
+bdd.scenarios("svg.feature")


### PR DESCRIPTION
Implements end2end tests for animated gifs and svg files.The corresponding files are currently retrieved from the web once in case they are not available. This does not increase the repo size with unnecessary binary files, but may turn out not to be stable enough. In this case we will have to commit the test data folder.