### PR TITLE
Make history mode based

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,12 @@ Changed:
 
 * The ``=`` key can now be bound using ``<equal>``. Using the raw ``=`` character is not
   possible in ``keys.conf`` as it is treated as separator much like ``:``.
+* History is now mode based. The plain-text history file is replaced by a json file
+  which stores the history of each mode. Any existing history is migrated by adding it
+  to every mode and keeping a backup of the plain-text history file at ``history.bak``.
+  The script ``scripts/vimiv_history.py`` is provided to print the history of a mode
+  line-by-line as aid in case user-scripts relied on the plain-text nature of the
+  history file.
 
 Fixed:
 ^^^^^^

--- a/scripts/vimiv_history.py
+++ b/scripts/vimiv_history.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2020 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+"""Script to print the vimiv history of a given mode.
+
+Reads the history from vimiv's json history file and prints the elements
+line-by-line.  The default mode is image. To change the mode, pass it using its
+name.
+
+In case you use a custom data directory or are not using linux, please pass the
+filename as argument.
+"""
+
+import argparse
+import json
+import os
+from typing import List
+
+
+def main():
+    parser = get_parser()
+    args = parser.parse_args()
+    history = read_history(mode=args.mode, filename=args.filename)
+    print(*history, sep="\n")
+
+
+def get_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "mode",
+        choices=("image", "thumbnail", "library", "manipulate"),
+        default="image",
+        nargs="?",
+        help="The mode for which history is printed",
+    )
+    parser.add_argument(
+        "-f",
+        "--filename",
+        default=os.path.expanduser("~/.local/share/vimiv/history.json"),
+        help="Path to the history file to read",
+    )
+    return parser
+
+
+def read_history(*, mode: str, filename: str) -> List[str]:
+    with open(filename, "r") as f:
+        content = json.load(f)
+    return content[mode]
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/end2end/features/commandline/commandline.feature
+++ b/tests/end2end/features/commandline/commandline.feature
@@ -58,6 +58,14 @@ Feature: Use the command line.
         And I run history next
         Then the text in the command line should be /
 
+    Scenario: Do not share history between modes
+        When I run command --text=next
+        And I press '<return>'
+        And I enter image mode
+        And I run command
+        And I run history next
+        Then the text in the command line should be :
+
     Scenario: Close command line when prefix is deleted
         When I run command
         And I press '<backspace>'

--- a/tests/unit/commands/test_history.py
+++ b/tests/unit/commands/test_history.py
@@ -4,127 +4,59 @@
 # Copyright 2017-2020 Christian Karl (karlch) <karlch at protonmail dot com>
 # License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
 
-"""Tests for commands.history."""
+"""Tests for commands.history.History."""
 
 import os
 
 import pytest
 
-import vimiv.commands.history
-from vimiv.commands.argtypes import HistoryDirection
+from vimiv import api
+from vimiv.commands.history import History
 
 
-PREFIXES = ":?/"
-CYCLE_HISTORY = [":first", ":second", ":third"]
-SUBSTR_HISTORY = [":first", ":final", ":useless"]
-MIXED_HISTORY = [prefix + text for text in ("first", "second") for prefix in PREFIXES]
+MODES = (*api.modes.GLOBALS, api.modes.MANIPULATE)
+MAX_ITEMS = 20
+MODE_HISTORY = {
+    mode: [f":{mode.name.lower()}-{i:01d}" for i in range(MAX_ITEMS)] for mode in MODES
+}
+LEGACY_HISTORY = [f":command-{i:01d}" for i in range(MAX_ITEMS)]
+
+
+@pytest.fixture()
+def mode_based_history_files(tmpdir, mocker):
+    """Fixture to create mode-based history files to initialize History."""
+    directory = tmpdir.mkdir("history")
+    mocker.patch.object(History, "dirname", return_value=str(directory))
+    for mode, commands in MODE_HISTORY.items():
+        History._write(History.filename(mode), commands)
+
+
+@pytest.fixture()
+def legacy_history_file(tmpdir, mocker):
+    """Fixture to create legacy file to initialize History."""
+    path = tmpdir.join("history")
+    path.write("\n".join(LEGACY_HISTORY) + "\n")
+    mocker.patch.object(History, "dirname", return_value=str(path))
 
 
 @pytest.fixture()
 def history():
-    yield vimiv.commands.history.History(PREFIXES, [], max_items=20)
+    """Fixture to create a clean history object to test."""
+    yield History(":", MAX_ITEMS)
 
 
-@pytest.fixture()
-def cycle_history():
-    yield vimiv.commands.history.History(PREFIXES, CYCLE_HISTORY, max_items=20)
+def test_read_history(mode_based_history_files, history):
+    for mode, history_deque in history.items():
+        assert list(history_deque) == MODE_HISTORY[mode]
 
 
-@pytest.fixture()
-def substr_history():
-    yield vimiv.commands.history.History(PREFIXES, SUBSTR_HISTORY, max_items=20)
-
-
-@pytest.fixture()
-def mixed_history():
-    yield vimiv.commands.history.History(PREFIXES, MIXED_HISTORY, max_items=20)
-
-
-@pytest.fixture()
-def history_file(tmpdir, mocker):
-    path = str(tmpdir.join("history"))
-    mocker.patch.object(vimiv.commands.history, "filename", return_value=path)
-    yield path
-
-
-def test_update_history(history):
-    history.update(":test")
-    assert ":test" in history
-
-
-def test_fail_update_history_invalid_prefix(history):
-    with pytest.raises(ValueError):
-        history.update("test")
-
-
-def test_fail_update_history_empty_command(history):
-    with pytest.raises(ValueError):
-        history.update("")
-
-
-def test_update_history_with_duplicates(history):
-    for _ in range(3):
-        history.update(":test")
-    assert len(history) == 1
-
-
-def test_never_exceed_history_max_elements(history):
-    for i in range(history.maxlen + 5):
-        history.update(":test-%d" % (i))
-    assert len(history) == history.maxlen
-
-
-def test_do_not_fail_cycle_on_empty_history(history):
-    expected = ":temporary"
-    result = history.cycle(HistoryDirection.Next, expected)
-    assert result == expected
-
-
-def test_do_not_store_temporary_history_element(history):
-    history.cycle(HistoryDirection.Next, ":temporary")
-    assert ":temporary" not in history
-
-
-def test_cycle_through_history(cycle_history):
-    start = ":start"
-    for expected in CYCLE_HISTORY:
-        assert cycle_history.cycle(HistoryDirection.Next, start) == expected
-    assert cycle_history.cycle(HistoryDirection.Next, start) == start
-
-
-def test_cycle_reverse_through_history(cycle_history):
-    start = ":start"
-    for expected in CYCLE_HISTORY[::-1]:
-        assert cycle_history.cycle(HistoryDirection.Prev, start) == expected
-    assert cycle_history.cycle(HistoryDirection.Prev, start) == start
-
-
-def test_substr_search_history(substr_history):
-    start = SUBSTR_HISTORY[0][:2]
-    matches = [elem for elem in SUBSTR_HISTORY if elem.startswith(start)]
-    for expected in matches:
-        assert substr_history.substr_cycle(HistoryDirection.Next, start) == expected
-    assert substr_history.substr_cycle(HistoryDirection.Next, start) == start
-
-
-@pytest.mark.parametrize("prefix", PREFIXES)
-def test_do_not_mix_prefixes(mixed_history, prefix):
-    start = prefix + "start"
-    matches = [elem for elem in MIXED_HISTORY if elem.startswith(prefix)]
-    for expected in matches:
-        assert mixed_history.cycle(HistoryDirection.Next, start) == expected
-    assert mixed_history.substr_cycle(HistoryDirection.Next, start) == start
-
-
-def test_reset_when_cycle_mode_changed(substr_history):
-    start = SUBSTR_HISTORY[0][:2]
-    for expected in SUBSTR_HISTORY[:2]:
-        assert substr_history.substr_cycle(HistoryDirection.Next, start) == expected
-    assert substr_history.cycle(HistoryDirection.Prev, start) == SUBSTR_HISTORY[-1]
-
-
-def test_write_read_history(history_file):
-    expected = [":first", ":second", ":third"]
-    vimiv.commands.history.write(expected)
-    assert os.path.isfile(history_file), "History file not created"
-    assert vimiv.commands.history.read() == expected
+def test_migrate_history(legacy_history_file, history):
+    # Correctly read into new mode - deque - structure
+    for mode, history_deque in history.items():
+        assert list(history_deque) == LEGACY_HISTORY
+    # Backup created
+    assert os.path.isfile(history.dirname() + ".bak")
+    # New structure saved
+    history.write()
+    for mode in MODE_HISTORY:
+        assert os.path.isfile(history.filename(mode))

--- a/tests/unit/commands/test_history_deque.py
+++ b/tests/unit/commands/test_history_deque.py
@@ -1,0 +1,117 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2020 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+"""Tests for commands.history.HistoryDeque."""
+
+import pytest
+
+import vimiv.commands.history
+from vimiv.commands.argtypes import HistoryDirection
+
+
+PREFIXES = ":?/"
+CYCLE_HISTORY = [":first", ":second", ":third"]
+SUBSTR_HISTORY = [":first", ":final", ":useless"]
+MIXED_HISTORY = [prefix + text for text in ("first", "second") for prefix in PREFIXES]
+
+
+@pytest.fixture()
+def history_deque():
+    yield vimiv.commands.history.HistoryDeque(PREFIXES, [], max_items=20)
+
+
+@pytest.fixture()
+def cycle_history_deque():
+    yield vimiv.commands.history.HistoryDeque(PREFIXES, CYCLE_HISTORY, max_items=20)
+
+
+@pytest.fixture()
+def substr_history_deque():
+    yield vimiv.commands.history.HistoryDeque(PREFIXES, SUBSTR_HISTORY, max_items=20)
+
+
+@pytest.fixture()
+def mixed_history_deque():
+    yield vimiv.commands.history.HistoryDeque(PREFIXES, MIXED_HISTORY, max_items=20)
+
+
+def test_update_history_deque(history_deque):
+    history_deque.update(":test")
+    assert ":test" in history_deque
+
+
+def test_fail_update_history_invalid_prefix(history_deque):
+    with pytest.raises(ValueError):
+        history_deque.update("test")
+
+
+def test_fail_update_history_empty_command(history_deque):
+    with pytest.raises(ValueError):
+        history_deque.update("")
+
+
+def test_update_history_with_duplicates(history_deque):
+    for _ in range(3):
+        history_deque.update(":test")
+    assert len(history_deque) == 1
+
+
+def test_never_exceed_history_max_elements(history_deque):
+    for i in range(history_deque.maxlen + 5):
+        history_deque.update(":test-%d" % (i))
+    assert len(history_deque) == history_deque.maxlen
+
+
+def test_do_not_fail_cycle_on_empty_history(history_deque):
+    expected = ":temporary"
+    result = history_deque.cycle(HistoryDirection.Next, expected)
+    assert result == expected
+
+
+def test_do_not_store_temporary_history_element(history_deque):
+    history_deque.cycle(HistoryDirection.Next, ":temporary")
+    assert ":temporary" not in history_deque
+
+
+def test_cycle_through_history(cycle_history_deque):
+    start = ":start"
+    for expected in CYCLE_HISTORY:
+        assert cycle_history_deque.cycle(HistoryDirection.Next, start) == expected
+    assert cycle_history_deque.cycle(HistoryDirection.Next, start) == start
+
+
+def test_cycle_reverse_through_history(cycle_history_deque):
+    start = ":start"
+    for expected in CYCLE_HISTORY[::-1]:
+        assert cycle_history_deque.cycle(HistoryDirection.Prev, start) == expected
+    assert cycle_history_deque.cycle(HistoryDirection.Prev, start) == start
+
+
+def test_substr_search_history(substr_history_deque):
+    start = SUBSTR_HISTORY[0][:2]
+    matches = [elem for elem in SUBSTR_HISTORY if elem.startswith(start)]
+    for expected in matches:
+        match = substr_history_deque.substr_cycle(HistoryDirection.Next, start)
+        assert match == expected
+    assert substr_history_deque.substr_cycle(HistoryDirection.Next, start) == start
+
+
+@pytest.mark.parametrize("prefix", PREFIXES)
+def test_do_not_mix_prefixes(mixed_history_deque, prefix):
+    start = prefix + "start"
+    matches = [elem for elem in MIXED_HISTORY if elem.startswith(prefix)]
+    for expected in matches:
+        assert mixed_history_deque.cycle(HistoryDirection.Next, start) == expected
+    assert mixed_history_deque.substr_cycle(HistoryDirection.Next, start) == start
+
+
+def test_reset_when_cycle_mode_changed(substr_history_deque):
+    start = SUBSTR_HISTORY[0][:2]
+    for expected in SUBSTR_HISTORY[:2]:
+        match = substr_history_deque.substr_cycle(HistoryDirection.Next, start)
+        assert match == expected
+    expected = SUBSTR_HISTORY[-1]
+    assert substr_history_deque.cycle(HistoryDirection.Prev, start) == expected

--- a/vimiv/gui/commandline.py
+++ b/vimiv/gui/commandline.py
@@ -48,9 +48,7 @@ class CommandLine(eventhandler.EventHandlerMixin, QLineEdit):
     def __init__(self) -> None:
         super().__init__()
         self._history = history.History(
-            self.PREFIXES,
-            history.read(),
-            max_items=api.settings.command.history_limit.value,
+            self.PREFIXES, max_items=api.settings.command.history_limit.value,
         )
         self.mode: api.modes.Mode = api.modes.IMAGE
 
@@ -84,7 +82,7 @@ class CommandLine(eventhandler.EventHandlerMixin, QLineEdit):
         prefix, command = self._split_prefix(self.text())
         if not command:  # Only prefix entered
             return
-        self._history.update(prefix + command)
+        self._history[self.mode].update(prefix + command)
         # Run commands in QTimer so the command line has been left when the
         # command runs
         if prefix == ":":
@@ -142,7 +140,7 @@ class CommandLine(eventhandler.EventHandlerMixin, QLineEdit):
         positional arguments:
             * ``direction``: The direction to cycle in (next/prev).
         """
-        self.setText(self._history.cycle(direction, self.text()))
+        self.setText(self._history[self.mode].cycle(direction, self.text()))
 
     @api.keybindings.register(
         "<up>", "history-substr-search next", mode=api.modes.COMMAND
@@ -159,12 +157,12 @@ class CommandLine(eventhandler.EventHandlerMixin, QLineEdit):
         positional arguments:
             * ``direction``: The direction to cycle in (next/prev).
         """
-        self.setText(self._history.substr_cycle(direction, self.text()))
+        self.setText(self._history[self.mode].substr_cycle(direction, self.text()))
 
     @utils.slot
     def _on_app_quit(self):
         """Write command history to file on quit."""
-        history.write(self._history)
+        self._history.write()
 
     def focusOutEvent(self, event):
         """Override focus out event to not emit editingFinished."""


### PR DESCRIPTION
Implements mode based history.

* History is now saved in a json file instead of plain-text.
* History-related commands (`:history` and `:history-substr-search`) now take into account the mode from which we entered the command-line.
* Parts of the command-line, especially history, are now only initialized upon first entry. Therefore the slightly more expensive history reading does not slow down the startup.
* `scripts/vimiv_history.py` is provided to print history of a single mode to stdout. This can be used as a script/reference in case the plain-text nature of the history file was used in any user-scripts.

I will leave this open for a few days for further thinking as we should fix the history format before releasing `1.0` and having it tested in a release before this would be nice.

fixes #140 