### PR TITLE
Tests: use the tmp_path fixture instead of tmpdir

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,3 +134,9 @@ def _retrieve_file_from_web(url: str, path: str) -> None:
     with open(path, "wb") as f:
         f.write(data)
     print("... success")
+
+
+@pytest.fixture()
+def tmpdir():
+    """Override tmpdir to raise a ValueError."""
+    raise ValueError("Use the 'tmp_path' fixture instead of 'tmpdir'")

--- a/tests/end2end/features/command/test_expand_wildcards_bdd.py
+++ b/tests/end2end/features/command/test_expand_wildcards_bdd.py
@@ -14,9 +14,11 @@ bdd.scenarios("expand_wildcards.feature")
 
 
 @pytest.fixture(autouse=True)
-def home_directory(tmpdir, mocker):
+def home_directory(tmp_path, mocker):
     """Fixture to mock os.path.expanduser to return a different home directory."""
-    new_home = str(tmpdir.mkdir("home"))
+    directory = tmp_path / "home"
+    directory.mkdir()
+    new_home = str(directory)
 
     def expand_user(path):
         return path.replace("~", new_home)

--- a/tests/end2end/features/conftest.py
+++ b/tests/end2end/features/conftest.py
@@ -7,6 +7,7 @@
 """Fixtures and bdd-like steps for usage during end2end testing."""
 
 import os
+import pathlib
 
 from PyQt5.QtCore import Qt, QProcess, QTimer
 from PyQt5.QtGui import QFocusEvent
@@ -253,17 +254,17 @@ def create_directory(name):
 
 @bdd.when(bdd.parsers.parse("I create the file '{name}'"))
 def create_file(name):
-    assert not os.path.exists(name), f"Not overriding existing file '{name}'"
-    with open(name, "w") as f:
-        f.write("")
+    path = pathlib.Path(name)
+    assert not path.exists(), f"Not overriding existing file '{name}'"
+    path.touch()
 
 
 @bdd.when(bdd.parsers.parse("I create the tag file '{name}'"))
 def create_tag_file(name):
-    os.makedirs(api.mark.tagdir, mode=0o700, exist_ok=True)
-    path = os.path.join(api.mark.tagdir, name)
-    with open(path, "w") as f:
-        f.write("")
+    directory = pathlib.Path(api.mark.tagdir)
+    directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+    path = directory / name
+    path.touch()
 
 
 ###############################################################################

--- a/tests/end2end/features/image/test_imageopen_bdd.py
+++ b/tests/end2end/features/image/test_imageopen_bdd.py
@@ -15,18 +15,18 @@ bdd.scenarios("imageopen.feature")
 
 
 @bdd.when("I open broken images")
-def open_broken_images(tmpdir):
-    _open_file(tmpdir, b"\211PNG\r\n\032\n")  # PNG
-    _open_file(tmpdir, b"000000JFIF")  # JPG
-    _open_file(tmpdir, b"GIF89a")  # GIF
-    _open_file(tmpdir, b"II")  # TIFF
-    _open_file(tmpdir, b"BM")  # BMP
+def open_broken_images(tmp_path):
+    _open_file(tmp_path, b"\211PNG\r\n\032\n")  # PNG
+    _open_file(tmp_path, b"000000JFIF")  # JPG
+    _open_file(tmp_path, b"GIF89a")  # GIF
+    _open_file(tmp_path, b"II")  # TIFF
+    _open_file(tmp_path, b"BM")  # BMP
 
 
-def _open_file(tmpdir, data):
+def _open_file(directory, data):
     """Open a file containing the bytes from data."""
-    path = str(tmpdir.join("broken"))
-    with open(path, "wb") as f:
-        f.write(data)
-    assert imghdr.what(path) is not None, "Invalid magic bytes in test setup"
-    api.open_paths([path])
+    path = directory / "broken"
+    path.write_bytes(data)
+    filename = str(path)
+    assert imghdr.what(filename) is not None, "Invalid magic bytes in test setup"
+    api.open_paths([filename])

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -24,12 +24,12 @@ def custom_configparser():
 
 
 @pytest.fixture()
-def custom_configfile(tmpdir, custom_configparser):
+def custom_configfile(tmp_path, custom_configparser):
     """Fixture to create a custom config file from a configparser."""
 
     def create_custom_configfile(basename, read, default_parser, **sections):
         parser = custom_configparser(default_parser, **sections)
-        path = tmpdir.join(basename)
+        path = tmp_path / basename
         with open(path, "w") as f:
             parser.write(f)
         read(str(path))

--- a/tests/integration/test_read_bindings.py
+++ b/tests/integration/test_read_bindings.py
@@ -32,7 +32,7 @@ def reset_to_default(cleanup_helper):
 
 
 @pytest.fixture(scope="function")
-def keyspath(tmpdir, custom_configfile, request):
+def keyspath(custom_configfile, request):
     """Fixture to create a custom keybindings file for reading."""
     yield custom_configfile(
         "keys.conf", keyfile.read, keyfile.get_default_parser, **request.param

--- a/tests/integration/test_read_settings.py
+++ b/tests/integration/test_read_settings.py
@@ -61,7 +61,7 @@ def reset_to_default(cleanup_helper):
 
 
 @pytest.fixture(scope="function")
-def configpath(tmpdir, custom_configfile, request):
+def configpath(custom_configfile, request):
     yield custom_configfile(
         "vimiv.conf", configfile.read, configfile.get_default_parser, **request.param
     )

--- a/tests/unit/api/test_mark.py
+++ b/tests/unit/api/test_mark.py
@@ -28,8 +28,9 @@ def mark(qtbot, mocker, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
-def tagdir(tmpdir, mocker):
-    tmp_tagdir = tmpdir.mkdir("tags")
+def tagdir(tmp_path, mocker):
+    tmp_tagdir = tmp_path / "tags"
+    tmp_tagdir.mkdir()
     mocker.patch.object(Tag, "dirname", return_value=str(tmp_tagdir))
     yield str(tmp_tagdir)
 

--- a/tests/unit/commands/test_history.py
+++ b/tests/unit/commands/test_history.py
@@ -41,10 +41,10 @@ def mixed_history():
 
 
 @pytest.fixture()
-def history_file(tmpdir, mocker):
-    path = str(tmpdir.join("history"))
-    mocker.patch.object(vimiv.commands.history, "filename", return_value=path)
-    yield path
+def history_file(tmp_path, mocker):
+    filename = str(tmp_path / "history")
+    mocker.patch.object(vimiv.commands.history, "filename", return_value=filename)
+    yield filename
 
 
 def test_update_history(history):

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -26,7 +26,7 @@ from vimiv.utils import customtypes
         ("[SECTION]\na=0\na=1\n", "duplicate key"),
     ],
 )
-def test_sysexit_on_broken_config(mocker, tmpdir, content, message):
+def test_sysexit_on_broken_config(mocker, tmp_path, content, message):
     """Ensure SystemExit is correctly raised for various broken config files.
 
     Args:
@@ -36,8 +36,8 @@ def test_sysexit_on_broken_config(mocker, tmpdir, content, message):
     print("Ensuring system exit with", message)
     mock_logger = mocker.Mock()
     parser = configparser.ConfigParser()
-    path = tmpdir.join("configfile")
-    path.write(content)
+    path = tmp_path / "configfile"
+    path.write_text(content)
     with pytest.raises(SystemExit, match=str(customtypes.Exit.err_config)):
         config.read_log_exception(parser, mock_logger, str(path))
     mock_logger.critical.assert_called_once()

--- a/tests/unit/config/test_external_configparser.py
+++ b/tests/unit/config/test_external_configparser.py
@@ -27,11 +27,11 @@ def parser():
 
 
 @pytest.fixture()
-def config(tmpdir):
+def config(tmp_path):
     """Fixture to retrieve a written config file with external references."""
     parser = configparser.ConfigParser()
     parser[SECTION_NAME][OPTION_NAME] = "${env:" + ENV_VARIABLE.name + "}"
-    path = tmpdir.join("config.ini")
+    path = tmp_path / "config.ini"
     with open(path, "w") as f:
         parser.write(f)
     yield str(path)

--- a/tests/unit/config/test_styles.py
+++ b/tests/unit/config/test_styles.py
@@ -20,7 +20,7 @@ def new_style(request):
 
 
 @pytest.fixture
-def style_file(tmpdir):
+def style_file(tmp_path):
     """Fixture to create a style file with different properties."""
 
     def create_style_file(color="#FFF", font=None, n_colors=16, header=True, **options):
@@ -33,9 +33,9 @@ def style_file(tmpdir):
             header. If False, omit the STYLE section header.
             options: Further style options passed.
         """
-        path = str(tmpdir.join("style"))
+        filename = str(tmp_path / "style")
         if not header:
-            return path
+            return filename
         parser = configparser.ConfigParser()
         parser.add_section("STYLE")
         for i in range(n_colors):
@@ -44,9 +44,9 @@ def style_file(tmpdir):
             parser["STYLE"]["font"] = font
         for key, value in options.items():
             parser["STYLE"][key] = value
-        with open(path, "w") as f:
+        with open(filename, "w") as f:
             parser.write(f)
-        return path
+        return filename
 
     return create_style_file
 

--- a/tests/unit/utils/test_migration.py
+++ b/tests/unit/utils/test_migration.py
@@ -17,10 +17,12 @@ TAGFILE_NAME = "tagfile"
 
 
 @pytest.fixture
-def mock_gtk_version(tmpdir, monkeypatch):
+def mock_gtk_version(tmp_path, monkeypatch):
     """Fixture to mock the xdg directories and fill them with gtk-version-like files."""
     for name in ("cache", "config", "data"):
-        monkeypatch.setenv(f"XDG_{name.upper()}_HOME", str(tmpdir.mkdir(name)))
+        directory = tmp_path / name
+        directory.mkdir()
+        monkeypatch.setenv(f"XDG_{name.upper()}_HOME", str(directory))
 
     for directory in (
         xdg.vimiv_config_dir(),

--- a/tests/unit/utils/test_thumbnail_manager.py
+++ b/tests/unit/utils/test_thumbnail_manager.py
@@ -14,22 +14,22 @@ from vimiv.utils import thumbnail_manager
 
 
 @pytest.fixture
-def manager(qtbot, tmpdir, mocker):
+def manager(qtbot, tmp_path, mocker):
     """Fixture to create a thumbnail manager with relevant methods mocked."""
     # Mock directory in which the thumbnails are created
-    tmp_cache_dir = tmpdir.join("cache")
+    tmp_cache_dir = tmp_path / "cache"
     mocker.patch("vimiv.utils.xdg.user_cache_dir", return_value=str(tmp_cache_dir))
     # Create thumbnail manager and yield the instance
     yield thumbnail_manager.ThumbnailManager(None)
 
 
 @pytest.mark.parametrize("n_paths", (1, 5))
-def test_create_n_thumbnails(qtbot, tmpdir, manager, n_paths):
+def test_create_n_thumbnails(qtbot, tmp_path, manager, n_paths):
     # Create images to create thumbnails of
-    paths = [str(tmpdir.join(f"image_{i}.jpg")) for i in range(n_paths)]
-    for path in paths:
-        QPixmap(300, 300).save(path, "jpg")
-    manager.create_thumbnails_async(paths)
+    filenames = [str(tmp_path / f"image_{i}.jpg") for i in range(n_paths)]
+    for filename in filenames:
+        QPixmap(300, 300).save(filename, "jpg")
+    manager.create_thumbnails_async(filenames)
     check_thumbails_created(qtbot, manager, n_paths)
 
 
@@ -38,9 +38,9 @@ def test_create_thumbnails_for_non_existing_path(qtbot, manager):
     check_thumbails_created(qtbot, manager, 0)
 
 
-def test_create_thumbnails_for_non_image_path(qtbot, tmpdir, manager):
-    path = str(tmpdir.join("image.jpg"))
-    manager.create_thumbnails_async([path])
+def test_create_thumbnails_for_non_image_path(qtbot, tmp_path, manager):
+    filename = str(tmp_path / "image.jpg")
+    manager.create_thumbnails_async([filename])
     check_thumbails_created(qtbot, manager, 0)
 
 

--- a/tests/unit/utils/test_trash_manager.py
+++ b/tests/unit/utils/test_trash_manager.py
@@ -15,13 +15,13 @@ from vimiv.utils import trash_manager
 
 
 @pytest.fixture(autouse=True)
-def trash(monkeypatch, tmpdir):
+def trash(monkeypatch, tmp_path):
     """Initialize trash for testing as fixture.
 
     Returns:
         The path to the temporary trash directory.
     """
-    xdg_data_home = tmpdir.mkdir("data")
+    xdg_data_home = tmp_path / "data"
     monkeypatch.setenv("XDG_DATA_HOME", str(xdg_data_home))
     trash_manager.init()
     yield
@@ -29,8 +29,8 @@ def trash(monkeypatch, tmpdir):
 
 
 @pytest.fixture()
-def deleted_file(tmpdir):
-    original_filename = create_tmpfile(tmpdir, "file")
+def deleted_file(tmp_path):
+    original_filename = create_tmpfile(tmp_path, "file")
     trash_filename = trash_manager.delete(original_filename)
     info_filename = trash_manager._get_info_filename(original_filename)
     paths = collections.namedtuple("DeletedFile", ("original", "trash", "info"))
@@ -72,8 +72,9 @@ def test_fail_undelete_non_existing_file():
         trash_manager.undelete(os.path.join("any", "random", "file"))
 
 
-def test_fail_undelete_non_existing_original_directory(tmpdir):
-    directory = tmpdir.mkdir("directory")
+def test_fail_undelete_non_existing_original_directory(tmp_path):
+    directory = tmp_path / "directory"
+    directory.mkdir()
     original_filename = create_tmpfile(directory, "file")
     trash_filename = trash_manager.delete(original_filename)
     os.rmdir(directory)
@@ -81,8 +82,8 @@ def test_fail_undelete_non_existing_original_directory(tmpdir):
         trash_manager.undelete(os.path.basename(trash_filename))
 
 
-def create_tmpfile(tmpdir, basename):
-    """Simple function to create a temporary file using the tmpdir fixture."""
-    path = tmpdir.join(basename)
-    path.write("temporary")
+def create_tmpfile(directory, basename):
+    """Simple function to create a temporary file using pathlib."""
+    path = directory / basename
+    path.touch()
     return str(path)

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -264,9 +264,11 @@ def test_run_qprocess():
     assert utils.run_qprocess("pwd") == os.getcwd()
 
 
-def test_run_qprocess_in_other_dir(tmpdir):
-    directory = str(tmpdir.mkdir("directory"))
-    assert utils.run_qprocess("pwd", cwd=directory) == directory
+def test_run_qprocess_in_other_dir(tmp_path):
+    directory = tmp_path / "directory"
+    directory.mkdir()
+    dirname = str(directory)
+    assert utils.run_qprocess("pwd", cwd=dirname) == dirname
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/utils/test_xdg.py
+++ b/tests/unit/utils/test_xdg.py
@@ -22,9 +22,9 @@ def unset_xdg_env(monkeypatch):
 
 
 @pytest.fixture
-def mock_xdg(tmpdir, monkeypatch):
+def mock_xdg(tmp_path, monkeypatch):
     """Set XDG_* directories to a temporary directory."""
-    dirname = str(tmpdir.join("directory"))
+    dirname = str(tmp_path / "directory")
     monkeypatch.setenv("XDG_CACHE_HOME", dirname)
     monkeypatch.setenv("XDG_CONFIG_HOME", dirname)
     monkeypatch.setenv("XDG_DATA_HOME", dirname)


### PR DESCRIPTION
As we can infer from https://github.com/pytest-dev/pytest/issues/7259 or https://github.com/pytest-dev/pytest/projects/4 the long-term plan for pytest is to replace any use of `py.path` with the now standard-library module `pathlib`. This removes any uses of the `tmpdir` fixture and replaces it with the corresponding calls using `tmp_path` to avoid any surprises in the future.