### PR TITLE
Add option to delete binding via keys.conf

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,7 +17,8 @@ Added:
   `@jeanggi90 <https://github.com/jeanggi90>`_!
 * ``<equal>`` is now bound to ``:scale --level=fit`` in image mode. Thanks
   `@jeanggi90 <https://github.com/jeanggi90>`_ for pointing this out!
-* Special ``del-binding`` mapping to remove default keybindings via ``keys.conf``.
+* Handle ``unbind`` explicitly when parsing ``keys.conf``. Instead of binding a key to
+  the ``:unbind`` command, any existing keybinding for this key is now removed.
 
 Changed:
 ^^^^^^^^

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,7 @@ Added:
   `@jeanggi90 <https://github.com/jeanggi90>`_!
 * ``<equal>`` is now bound to ``:scale --level=fit`` in image mode. Thanks
   `@jeanggi90 <https://github.com/jeanggi90>`_ for pointing this out!
+* Special ``del-binding`` mapping to remove default keybindings via ``keys.conf``.
 
 Changed:
 ^^^^^^^^

--- a/docs/documentation/configuration/keybindings.rst
+++ b/docs/documentation/configuration/keybindings.rst
@@ -21,10 +21,10 @@ There are two ways to add a new keybinding:
 
 If you wish to replace a default keybinding, add a the new keybinding that
 overrides it. For example to replace the ``f : fullscreen`` binding with flip,
-bind ``f : flip``. To remove a default keybinding via ``keys.conf``, map the key to the
-special ``del-binding``. In case you would like to enforce a keybinding to do nothing,
-for example to remove a default Qt binding, use ``nop`` instead. ``:nop`` is a regular
-vimiv command that does nothing.
+bind ``f : flip``. To remove a default keybinding via ``keys.conf``, map the key to
+``unbind``. In case you would like to enforce a keybinding to do nothing, for example to
+remove a default Qt binding, use ``nop`` instead. ``:nop`` is a regular vimiv command
+that does nothing.
 
 .. note::
 

--- a/docs/documentation/configuration/keybindings.rst
+++ b/docs/documentation/configuration/keybindings.rst
@@ -21,8 +21,10 @@ There are two ways to add a new keybinding:
 
 If you wish to replace a default keybinding, add a the new keybinding that
 overrides it. For example to replace the ``f : fullscreen`` binding with flip,
-bind ``f : flip``. To remove a default keybinding, map the key to the special
-``nop`` command that does nothing.
+bind ``f : flip``. To remove a default keybinding via ``keys.conf``, map the key to the
+special ``del-binding``. In case you would like to enforce a keybinding to do nothing,
+for example to remove a default Qt binding, use ``nop`` instead. ``:nop`` is a regular
+vimiv command that does nothing.
 
 .. note::
 

--- a/tests/integration/test_read_bindings.py
+++ b/tests/integration/test_read_bindings.py
@@ -20,6 +20,8 @@ UPDATED_BINDINGS = {
     "LIBRARY": {"<return>": "open-selected --close"},
 }
 
+REMOVE_J_BINDING = {"IMAGE": {"j": keyfile.DEL_BINDING_COMMAND}}
+
 
 ########################################################################################
 #                                      Fixtures                                        #
@@ -39,6 +41,12 @@ def keyspath(custom_configfile, request):
     )
 
 
+@pytest.fixture()
+def bind_j():
+    """Fixture to ensure j is bound to a command."""
+    api.keybindings.bind("j", "scroll down", api.modes.IMAGE)
+
+
 ########################################################################################
 #                                        Tests                                         #
 ########################################################################################
@@ -51,3 +59,9 @@ def test_read_bindings(keyspath):
             modes = api.modes.GLOBALS if mode == api.modes.GLOBAL else (mode,)
             for mode in modes:
                 assert api.keybindings._registry[mode][binding].value == command
+
+
+@pytest.mark.parametrize("keyspath", [REMOVE_J_BINDING], indirect=["keyspath"])
+def test_delete_binding(bind_j, keyspath):
+    image_bindings = api.keybindings.get(api.modes.IMAGE)
+    assert "j" not in image_bindings

--- a/vimiv/config/configcommands.py
+++ b/vimiv/config/configcommands.py
@@ -95,6 +95,5 @@ def unbind(keybinding: str, mode: str = None):
 def nop():
     """Do nothing.
 
-    This is useful to remove default keybindings by explicitly binding them to
-    nop.
+    This is useful to remove keys bound by Qt by explicitly binding them to nop.
     """

--- a/vimiv/config/keyfile.py
+++ b/vimiv/config/keyfile.py
@@ -15,7 +15,7 @@ from vimiv.utils import log
 
 _logger = log.module_logger(__name__)
 
-DEL_BINDING_COMMAND = "del-binding"
+DEL_BINDING_COMMAND = "unbind"
 
 
 def parse(cli_path: str):


### PR DESCRIPTION
Instead of using `nop` to remove default bindings we can now use `del-binding`. `nop` is a command in itself that does nothing. Keeping this in addition is useful to ensure e.g. some default qt bindings do nothing.

@schyzophrene-asynchrone what do you think about this? Do you have a better name than `del-binding` in mind? If you are fine with this implementation, I would go ahead and update the documentation accordingly and then merge.

EDIT: Renamed `del-binding` to `unbind`.

fixes #249 