### PR TITLE
Checks for binding conflicts only after reading keys.conf or using :bind

### DIFF
--- a/tests/unit/utils/test_trie.py
+++ b/tests/unit/utils/test_trie.py
@@ -43,6 +43,7 @@ def test_setitem_warns_for_hidden_key(trie, mocklogger):
     key1 = "key"
     key2 = key1 + "1"
     trie[key1] = trie[key2] = "value"
+    trie.check()
     mocklogger.warning.assert_called_once()
 
 
@@ -51,6 +52,7 @@ def test_setitem_raises_for_hiding_key(trie, mocklogger):
     key1 = "key"
     key2 = key1 + "1"
     trie[key2] = trie[key1] = "value"
+    trie.check()
     mocklogger.warning.assert_called_once()
 
 

--- a/vimiv/api/keybindings.py
+++ b/vimiv/api/keybindings.py
@@ -158,6 +158,6 @@ def items() -> Iterator[Tuple[modes.Mode, Iterable[Tuple[str, str]]]]:
             yield mode, sort(get(mode))
 
 def check() -> None:
-    """Checks every mode for keybinding clashes and logs warnings"""
+    """Checks every mode for keybinding clashes and logs warnings."""
     for mode, bindings_trie in _registry.items():
         bindings_trie.check()

--- a/vimiv/api/keybindings.py
+++ b/vimiv/api/keybindings.py
@@ -156,3 +156,8 @@ def items() -> Iterator[Tuple[modes.Mode, Iterable[Tuple[str, str]]]]:
             yield mode, sort(set(get(mode)) - global_bindings)
         else:
             yield mode, sort(get(mode))
+
+def check() -> None:
+    """Checks every mode for keybinding clashes and logs warnings"""
+    for mode, bindings_trie in _registry.items():
+        bindings_trie.check()

--- a/vimiv/api/keybindings.py
+++ b/vimiv/api/keybindings.py
@@ -157,6 +157,7 @@ def items() -> Iterator[Tuple[modes.Mode, Iterable[Tuple[str, str]]]]:
         else:
             yield mode, sort(get(mode))
 
+
 def check() -> None:
     """Checks every mode for keybinding clashes and logs warnings."""
     for mode, bindings_trie in _registry.items():

--- a/vimiv/api/keybindings.py
+++ b/vimiv/api/keybindings.py
@@ -160,5 +160,5 @@ def items() -> Iterator[Tuple[modes.Mode, Iterable[Tuple[str, str]]]]:
 
 def check() -> None:
     """Checks every mode for keybinding clashes and logs warnings."""
-    for mode, bindings_trie in _registry.items():
+    for _, bindings_trie in _registry.items():
         bindings_trie.check()

--- a/vimiv/config/configcommands.py
+++ b/vimiv/config/configcommands.py
@@ -71,6 +71,7 @@ def bind(keybinding: str, command: List[str], mode: str = None):
     """
     modeobj = api.modes.get_by_name(mode) if mode else api.modes.current()
     api.keybindings.bind(keybinding, " ".join(command), modeobj)
+    api.keybindings.check()
 
 
 @api.commands.register()

--- a/vimiv/config/keyfile.py
+++ b/vimiv/config/keyfile.py
@@ -21,6 +21,7 @@ DEL_BINDING_COMMAND = "unbind"
 def parse(cli_path: str):
     """Parse keybindings from the keys.conf into the keybindings registry."""
     config.parse_config(cli_path, "keys.conf", read, dump)
+    api.keybindings.check()
 
 
 def dump(path: str):

--- a/vimiv/utils/trie.py
+++ b/vimiv/utils/trie.py
@@ -125,10 +125,12 @@ class Trie:
             hidden: List[str] = []
             for child in self.children.values():
                 hidden.extend(key for key, _ in child)
-            _logger.warning("%s hides longer keys: %s", self.key,
-                                                        quotedjoin(hidden))
+            _logger.warning(
+                    "%s hides longer keys: %s", self.key, quotedjoin(hidden)
+                    )
         for elem in self.children:
             self.children[elem].check()
+
 
 class TrieMatch(NamedTuple):
     """Helper class as result for Trie.match, see Trie.match for details."""

--- a/vimiv/utils/trie.py
+++ b/vimiv/utils/trie.py
@@ -42,14 +42,8 @@ class Trie:
         node = self
         for elem in key:
             if elem not in node.children:
-                if node.key is not None:
-                    _logger.warning(
-                        "%s is hidden by shorter key %s", "".join(key), node.key
-                    )
                 node.children[elem] = Trie()
             node = node.children[elem]
-        if node.children:
-            _logger.warning("%s hides longer keys", "".join(key))
         node.key = "".join(key)
         node.value = value
 
@@ -125,6 +119,12 @@ class Trie:
                 raise KeyError("".join(key)) from None
         return nodes
 
+    def check(self) -> None:
+        """Checks for possible clashes and logs warnings."""
+        if self.key and self.children:
+            _logger.warning("%s hides longer keys", self.key)
+        for elem in self.children:
+            self.children[elem].check()
 
 class TrieMatch(NamedTuple):
     """Helper class as result for Trie.match, see Trie.match for details."""

--- a/vimiv/utils/trie.py
+++ b/vimiv/utils/trie.py
@@ -122,7 +122,11 @@ class Trie:
     def check(self) -> None:
         """Checks for possible clashes and logs warnings."""
         if self.key and self.children:
-            _logger.warning("%s hides longer keys", self.key)
+            hidden = []
+            for child in self.children.values():
+                hidden.extend(key for key, _ in child)
+            _logger.warning("%s hides longer keys: %s", self.key,
+                                                        quotedjoin(hidden))
         for elem in self.children:
             self.children[elem].check()
 

--- a/vimiv/utils/trie.py
+++ b/vimiv/utils/trie.py
@@ -11,7 +11,7 @@ See e.g. https://en.wikipedia.org/wiki/Trie for more details.
 
 from typing import NamedTuple, Iterable, Optional, Iterator, Tuple, Dict, List, cast
 
-from vimiv.utils import log
+from vimiv.utils import log, quotedjoin
 
 KeyT = Iterable[str]
 IterResultT = Iterator[Tuple[str, str]]
@@ -122,7 +122,7 @@ class Trie:
     def check(self) -> None:
         """Checks for possible clashes and logs warnings."""
         if self.key and self.children:
-            hidden = []
+            hidden: List[str] = []
             for child in self.children.values():
                 hidden.extend(key for key, _ in child)
             _logger.warning("%s hides longer keys: %s", self.key,

--- a/vimiv/utils/trie.py
+++ b/vimiv/utils/trie.py
@@ -37,7 +37,7 @@ class Trie:
         self.value: Optional[str] = None
 
     def __setitem__(self, key: KeyT, value: str) -> None:
-        """Add a key, value pair to the trie logging a warning on possible clashes."""
+        """Add a key, value pair to the trie."""
         key = tuple(key)
         node = self
         for elem in key:

--- a/vimiv/utils/trie.py
+++ b/vimiv/utils/trie.py
@@ -126,8 +126,8 @@ class Trie:
             for child in self.children.values():
                 hidden.extend(key for key, _ in child)
             _logger.warning(
-                    "%s hides longer keys: %s", self.key, quotedjoin(hidden)
-                    )
+                "%s hides longer keys: %s", self.key, quotedjoin(hidden)
+            )
         for elem in self.children:
             self.children[elem].check()
 


### PR DESCRIPTION
Since you said where and what to change, I thought I could as well try to do it.

So I made the `Trie.check` you spoke about and removed warnings from `__setitem__`. I’m not totally satisfied with what I came with since we have now only one type of warning (the “hides longer key” type) and from a user perspective, they’re the least useful (when you want to keep the short key but don’t know what the longer one is). But since Trie object don’t have a `parent` attribute, I guess I can’t help it.

This is my first pull request on Github, and I’ve discovered what a digital tree was with your code. My changes are small, but I hope they do what they are supposed to and fit to the general code design you adopted for your project. Any comments are welcome.

#### Related content
Issue #270 