### PR TITLE
Interface for External Filetype Handler

### DIFF
--- a/vimiv/api/__init__.py
+++ b/vimiv/api/__init__.py
@@ -7,7 +7,8 @@
 """`Utilities to interact with the application`."""
 
 import os
-from typing import List, Iterable
+from typing import List, Iterable, Dict, Callable
+from PyQt5.QtGui import QPixmap
 
 from vimiv.utils import files
 
@@ -27,6 +28,7 @@ from vimiv.api import (
 )
 
 mark = _mark.Mark()
+external_handler: Dict[str, Callable[[str], QPixmap]] = {}
 
 
 def current_path(mode: modes.Mode = None) -> str:

--- a/vimiv/imutils/_file_handler.py
+++ b/vimiv/imutils/_file_handler.py
@@ -120,13 +120,22 @@ class ImageFileHandler(QObject):
             api.signals.movie_loaded.emit(movie, reload_only)
             self._edit_handler.clear()
         # Regular image
-        else:
+        elif file_format in reader.supportedImageFormats():
             pixmap = QPixmap.fromImageReader(reader)
             if reader.error():
                 log.error("Error reading image %s: %s", path, reader.errorString())
                 return
             self._edit_handler.pixmap = pixmap
             api.signals.pixmap_loaded.emit(pixmap, reload_only)
+        # Externally handled image
+        elif file_format in api.external_handler:
+            handler = api.external_handler[file_format]
+            pixmap = handler(path)
+            self._edit_handler.pixmap = pixmap
+            api.signals.pixmap_loaded.emit(pixmap, reload_only)
+        else:
+            log.error("Error reading image %s: fileformat not supported", path)
+            return
         self._path = path
 
     @api.commands.register(mode=api.modes.IMAGE)

--- a/vimiv/utils/files.py
+++ b/vimiv/utils/files.py
@@ -13,6 +13,8 @@ from typing import List, Tuple, Optional, BinaryIO, Iterable, Callable
 
 from PyQt5.QtGui import QImageReader
 
+from vimiv import api
+
 
 def listdir(directory: str, show_hidden: bool = False) -> List[str]:
     """Wrapper around os.listdir.
@@ -150,7 +152,10 @@ def add_image_format(name: str, check: Callable[[bytes, BinaryIO], bool]) -> Non
         if check(h, f):
             if hasattr(test, "checked"):
                 return name
-            if name in QImageReader.supportedImageFormats():
+            if (
+                name in QImageReader.supportedImageFormats()
+                or name in api.external_handler
+            ):
                 setattr(test, "checked", True)
                 return name
             imghdr.tests.remove(test)


### PR DESCRIPTION
Currently, the plugin `imageformats` fails to open cr2 Raw files. Therefore, I have decided to implement another raw filetype plugin ([see here](https://github.com/jeanggi90/RawPrev)). It follows the idea proposed and discussed in #16 and displays the jpge thumbnail extracted from the Raw.

The make such a plugin work, I had to create a suitable interface within vimiv. My idea was to have a list (`api.external_hander`) to which plugins which want to provide support for additional file types, can add a tuple of the following format: The first value is a list of filetypes which this plugin support. The second value is a callable, which returns an instance of `Pixmap`, containing the image to open.

In `imutils/_file_handler` there is a check which determines whether the type of the current image is in handled by the standard `QImageReader` or by an external handler. In case it is handled externally, the appropriate callable is responsible for creating a `Pixmap` instance with the image to display.

Please @karlch let me know that you think about this idea as well as the implementation. There are certainly many things to improve and maybe there is even a better way to implement this functionality.

**Edit**:
I seem to have troubles on getting the typing for `api.external_handler` right :grimacing: 
