### PR TITLE
API convenience function for adding filetype support

### DIFF
--- a/vimiv/api/__init__.py
+++ b/vimiv/api/__init__.py
@@ -7,10 +7,10 @@
 """`Utilities to interact with the application`."""
 
 import os
-from typing import List, Iterable, Dict, Callable
+from typing import List, Iterable, Callable, BinaryIO
 from PyQt5.QtGui import QPixmap
 
-from vimiv.utils import files
+from vimiv.utils import files, imagereader
 
 from vimiv.api import (
     commands,
@@ -28,7 +28,6 @@ from vimiv.api import (
 )
 
 mark = _mark.Mark()
-external_handler: Dict[str, Callable[[str], QPixmap]] = {}
 
 
 def current_path(mode: modes.Mode = None) -> str:
@@ -78,3 +77,19 @@ def open_paths(paths: Iterable[str]) -> None:
         modes.LIBRARY.enter()
     else:
         raise commands.CommandError("No valid paths")
+
+
+def add_external_format(
+    file_format: str,
+    test_func: Callable[[bytes, BinaryIO], bool],
+    load_func: Callable[[str], QPixmap],
+) -> None:
+    """Add support for new fileformat.
+
+    Args:
+        file_format: String value of the file type
+        test_func: Function returning a boolean depending on whether load_func supports this type
+        load_func: Function returning the a QPixmap in case the file_format is supported by load_func
+    """
+    files.add_image_format(file_format, test_func)
+    imagereader.external_handler[file_format] = load_func

--- a/vimiv/utils/files.py
+++ b/vimiv/utils/files.py
@@ -14,6 +14,7 @@ from typing import List, Tuple, Optional, BinaryIO, Iterable, Callable
 from PyQt5.QtGui import QImageReader
 
 from vimiv import api
+from vimiv.utils import imagereader
 
 
 def listdir(directory: str, show_hidden: bool = False) -> List[str]:
@@ -154,7 +155,7 @@ def add_image_format(name: str, check: Callable[[bytes, BinaryIO], bool]) -> Non
                 return name
             if (
                 name in QImageReader.supportedImageFormats()
-                or name in api.external_handler
+                or name in imagereader.external_handler
             ):
                 setattr(test, "checked", True)
                 return name

--- a/vimiv/utils/imagereader.py
+++ b/vimiv/utils/imagereader.py
@@ -7,6 +7,7 @@
 """Image reader classes to read images from file to Qt objects."""
 
 import abc
+from typing import Dict, Callable
 
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QImageReader, QPixmap, QImage
@@ -14,6 +15,8 @@ from PyQt5.QtGui import QImageReader, QPixmap, QImage
 from vimiv import api
 
 from .files import imghdr
+
+external_handler: Dict[str, Callable[[str], QPixmap]] = {}
 
 
 class BaseReader(abc.ABC):
@@ -94,10 +97,10 @@ class ExternalReader(BaseReader):
 
     @classmethod
     def supports(cls, file_format: str) -> bool:
-        return file_format in api.external_handler
+        return file_format in external_handler
 
     def get_pixmap(self) -> QPixmap:
-        handler = api.external_handler[self.file_format]
+        handler = external_handler[self.file_format]
         return handler(self.path)
 
 


### PR DESCRIPTION
To finish up #282 and a655a71cd61ffce6d9951640b474833b95562131 I have added a convenience function to the API which allows to add support for new file types using:
```
api.add_external_format(fmt="cr2", test_func=test_cr2, load_func=load_cr2)
```
instead of:
```
files.add_image_format("cr2", test_cr2)
api.external_handler["cr2"] = load_cr2
api.external_handler["CR2"] = load_cr2
```

Further, I have moved the `external_handler` dictionary from `vimiv/api/__init__` to `vimiv/utils/imagereader` since there is no need for it to be exposed via the api. @karlch if you think there is a better place for the `external_handler` dict let me know.
