### PR TITLE
Add --keep-zoom flag for :next and :prev

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,9 @@ Added:
 * A new api interface which enables writing plugins to support new image formats. See
   :ref:`support_new_imageformats` for more details.
   Thanks `@jcjgraf <https://github.com/jcjgraf>`_!
+* New ``--keep-zoom`` flag for ``:next`` and ``:prev`` which preserves zoom level and
+  scroll position of the current image.
+  Thanks `@jcjgraf <https://github.com/jcjgraf>`_ for the idea!
 
 Changed:
 ^^^^^^^^

--- a/tests/end2end/features/image/imagezoom.feature
+++ b/tests/end2end/features/image/imagezoom.feature
@@ -21,3 +21,9 @@ Feature: Zooming the image displayed.
         When I run zoom in
         And I run reload
         Then the zoom level should not be 1.0
+
+    Scenario: Keep zoom level with --keep-zoom flag.
+        Given I open any image of size 200x200
+        When I run zoom in
+        And I run next --keep-zoom
+        Then the zoom level should be 1.25

--- a/vimiv/api/signals.py
+++ b/vimiv/api/signals.py
@@ -19,6 +19,7 @@ class _SignalHandler(QObject):
 
         new_image_opened: Emitted when the filelist loaded a new path.
             arg1: Path of the new image.
+            arg2: True if the zoom level should be kept.
         new_images_opened: Emitted when the filelist loaded new paths.
             arg1: List of new paths.
         all_images_cleared: Emitted when there are no more paths in the filelist.
@@ -40,7 +41,7 @@ class _SignalHandler(QObject):
     load_images = pyqtSignal(list)
 
     # Emitted when new image path(s) were opened
-    new_image_opened = pyqtSignal(str)
+    new_image_opened = pyqtSignal(str, bool)
     new_images_opened = pyqtSignal(list)
     all_images_cleared = pyqtSignal()
 

--- a/vimiv/gui/image.py
+++ b/vimiv/gui/image.py
@@ -109,29 +109,29 @@ class ScrollableImage(eventhandler.EventHandlerMixin, QGraphicsView):
         """The currently visible part of the scene in the image coordinates."""
         return self.mapToScene(self.viewport().rect()).boundingRect() & self.sceneRect()
 
-    def _load_pixmap(self, pixmap: QPixmap, reload_only: bool) -> None:
+    def _load_pixmap(self, pixmap: QPixmap, keep_zoom: bool) -> None:
         """Load new pixmap into the graphics scene."""
         item = QGraphicsPixmapItem()
         item.setPixmap(pixmap)
         item.setTransformationMode(Qt.SmoothTransformation)
-        self._update_scene(item, item.boundingRect(), reload_only)
+        self._update_scene(item, item.boundingRect(), keep_zoom)
 
-    def _load_movie(self, movie: QMovie, reload_only: bool) -> None:
+    def _load_movie(self, movie: QMovie, keep_zoom: bool) -> None:
         """Load new movie into the graphics scene."""
         movie.jumpToFrame(0)
         if api.settings.image.autoplay.value:
             movie.start()
         widget = QLabel()
         widget.setMovie(movie)
-        self._update_scene(widget, QRectF(movie.currentPixmap().rect()), reload_only)
+        self._update_scene(widget, QRectF(movie.currentPixmap().rect()), keep_zoom)
 
-    def _load_svg(self, path: str, reload_only: bool) -> None:
+    def _load_svg(self, path: str, keep_zoom: bool) -> None:
         """Load new vector graphic into the graphics scene."""
         item = QtSvg.QGraphicsSvgItem(path)
-        self._update_scene(item, item.boundingRect(), reload_only)
+        self._update_scene(item, item.boundingRect(), keep_zoom)
 
     def _update_scene(
-        self, item: Union[QGraphicsItem, QLabel], rect: QRectF, reload_only: bool
+        self, item: Union[QGraphicsItem, QLabel], rect: QRectF, keep_zoom: bool
     ) -> None:
         """Update the scene with the newly loaded item."""
         self.scene().clear()
@@ -140,7 +140,7 @@ class ScrollableImage(eventhandler.EventHandlerMixin, QGraphicsView):
         else:
             self.scene().addWidget(item)
         self.scene().setSceneRect(rect)
-        self.scale(self._scale if reload_only else ImageScale.Overzoom)  # type: ignore
+        self.scale(self._scale if keep_zoom else ImageScale.Overzoom)  # type: ignore
         self._update_focalpoint()
 
     def _update_focalpoint(self):

--- a/vimiv/imutils/filelist.py
+++ b/vimiv/imutils/filelist.py
@@ -28,26 +28,38 @@ _logger = log.module_logger(__name__)
 
 
 # We want to use the name next here as it is the best name for the command
+@api.keybindings.register("<ctrl>n", "next --keep-zoom", mode=api.modes.IMAGE)
 @api.keybindings.register(["n", "<page-down>"], "next", mode=api.modes.IMAGE)
 @api.commands.register(name="next")
-def next_path(count: int = 1) -> None:
+def next_path(count: int = 1, keep_zoom: bool = False) -> None:
     """Select next image.
 
+    **syntax:** ``:next [--keep-zoom]``
+
+    optional arguments:
+        * ``--keep-zoom``: Keep zoom level and scroll position of the current image.
+
     **count:** multiplier
     """
     if _paths:
-        _set_index((_index + count) % len(_paths))
+        _set_index((_index + count) % len(_paths), keep_zoom=keep_zoom)
 
 
+@api.keybindings.register("<ctrl>p", "prev --keep-zoom", mode=api.modes.IMAGE)
 @api.keybindings.register(["p", "<page-up>"], "prev", mode=api.modes.IMAGE)
 @api.commands.register(name="prev")
-def prev_path(count: int = 1) -> None:
+def prev_path(count: int = 1, keep_zoom: bool = False) -> None:
     """Select previous image.
+
+    **syntax:** ``:prev [--keep-zoom]``
+
+    optional arguments:
+        * ``--keep-zoom``: Keep zoom level and scroll position of the current image.
 
     **count:** multiplier
     """
     if _paths:
-        _set_index((_index - count) % len(_paths))
+        _set_index((_index - count) % len(_paths), keep_zoom=keep_zoom)
 
 
 @api.keybindings.register(["G", "<end>"], "goto -1", mode=api.modes.IMAGE)
@@ -204,12 +216,12 @@ class SignalHandler(QObject):
             api.status.update("Image filelist changed")
 
 
-def _set_index(index: int, previous: str = None) -> None:
+def _set_index(index: int, previous: str = None, *, keep_zoom: bool = False) -> None:
     """Set the global _index to index."""
     global _index
     _index = index
     if previous != current():
-        api.signals.new_image_opened.emit(current())
+        api.signals.new_image_opened.emit(current(), keep_zoom)
 
 
 def _set_paths(paths: List[str]) -> None:


### PR DESCRIPTION
Adds a `--keep-zoom` flag to the `:next` and `:prev` command which preserves the zoom level and scroll position of the current image.

This was very easy to implement as all of the logic was already there, just hidden in form of a `reload_only` argument.
@jcjgraf would you like to give this a shot before I merge? Hope you don't mind me dashing ahead here, as you can see the code for this was more or less already in-place.