### PR TITLE
Mark Speed in Thumbnail Mode

### DIFF
--- a/vimiv/api/_mark.py
+++ b/vimiv/api/_mark.py
@@ -27,6 +27,7 @@ class Mark(QObject):
     Signals:
         marked: Emitted with the image path when an image was marked.
         unmarked: Emitted with the image path when an image was unmarked.
+        markdone: Emitted when all image of a given paths list are (un)marked.
 
     Attributes:
         _indicator: Attribute to cache the evaluated mark indicator string.
@@ -37,6 +38,7 @@ class Mark(QObject):
 
     marked = pyqtSignal(str)
     unmarked = pyqtSignal(str)
+    markdone = pyqtSignal()
 
     @objreg.register
     def __init__(self) -> None:
@@ -81,6 +83,7 @@ class Mark(QObject):
         for path in paths:
             if files.is_image(path):
                 self._toggle_mark(path)
+        self.markdone.emit()
 
     @commands.register()
     def mark_clear(self) -> None:
@@ -98,6 +101,7 @@ class Mark(QObject):
         for path in self._last_marked:
             self.unmarked.emit(path)
             _logger.debug("Unmarked '%s'", path)
+        self.markdone.emit()
 
     @commands.register()
     def mark_restore(self) -> None:
@@ -108,6 +112,7 @@ class Mark(QObject):
         for path in self._marked:
             self.marked.emit(path)
             _logger.debug("Marked '%s'", path)
+        self.markdone.emit()
 
     @commands.register()
     def tag_write(self, name: str) -> None:
@@ -179,6 +184,7 @@ class Mark(QObject):
         for path in paths:
             self.marked.emit(path)
             _logger.debug("Marked '%s'", path)
+        self.markdone.emit()
 
     @commands.register()
     def tag_open(self, name: str) -> None:

--- a/vimiv/gui/thumbnail.py
+++ b/vimiv/gui/thumbnail.py
@@ -99,6 +99,7 @@ class ThumbnailView(
         self.doubleClicked.connect(self.open_selected)
         api.mark.marked.connect(self._mark_highlight)
         api.mark.unmarked.connect(lambda path: self._mark_highlight(path, marked=False))
+        api.mark.markdone.connect(self.repaint)
         synchronize.signals.new_library_path_selected.connect(self._select_path)
 
         styles.apply(self)
@@ -194,7 +195,6 @@ class ThumbnailView(
             return
         item = self.item(index)
         item.marked = marked
-        self.repaint()
 
     @api.commands.register(mode=api.modes.THUMBNAIL)
     def open_selected(self):


### PR DESCRIPTION
When an image is marked in thumbnail mode, the view is repainted right after each mark. This makes marking of many images (e.g. `:mark *` in thumbnail view painfully slow (~55s for ~1350 images). During that time the GUI is also blocked and unresponsive.

To improve that, we add an additional signal which is broadcast from mark methods in `api._mark` once they are done marking all images. This way clients can prolong the expensive repainting.

This change improves the speed a lot (fraction of a second for ~1350 images).

@karlch if you belief that his is the wrong way to fix this problem and you have got a better idea let me know.

**EDIT**
Argh, this pipeline again :unamused: 