### PR TITLE
Add :metadata-list-keys command

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -31,6 +31,8 @@ Added:
   exif values into a human readable format. Thanks a lot
   `@jcjgraf <https://github.com/jcjgraf>`_ for all your hard work, thoughts and comments
   on this topic!
+* New ``:metadata-list-keys`` command to display all valid exif keys for the current
+  image.
 
 Changed:
 ^^^^^^^^

--- a/docs/documentation/exif.rst
+++ b/docs/documentation/exif.rst
@@ -55,9 +55,8 @@ or IPTC keys. It is considered best-practice to use the full path to any key, e.
 comes after the last ``.`` character. In case you pass the full path, vimiv will remove
 everything up to and including the last ``.`` character and match only the short form.
 
-Once `issue #220 <https://github.com/karlch/vimiv-qt/issues/220>`_ has been implemented,
-you will be able to get a list of valid metadata keys for the current image using
-``:metadata --list-keys``.
+You can get a list of valid metadata keys for the current image using the
+``:metadata-list-keys`` command.
 
 
 .. _exiv2: https://www.exiv2.org/index.html

--- a/tests/end2end/features/image/metadata.feature
+++ b/tests/end2end/features/image/metadata.feature
@@ -49,3 +49,22 @@ Feature: Metadata widget displaying image exif information
         Then the metadata widget should be visible
         # The new image no longer has any exif information
         And the metadata text should contain 'No matching metadata found'
+
+    Scenario: Display list of valid metadata keys
+        Given I open any image
+        When I add exif information
+        And I run metadata-list-keys
+        Then the metadata widget should be visible
+        And the metadata text should contain 'Make'
+        And the metadata text should contain 'Model'
+        And the metadata text should contain 'Copyright'
+
+    Scenario: Print list of valid metadata keys
+        Given I open any image
+        And I capture output
+        When I add exif information
+        And I run metadata-list-keys --to-term
+        Then the metadata widget should not be visible
+        And stdout should contain 'Make'
+        And stdout should contain 'Model'
+        And stdout should contain 'Copyright'

--- a/tests/unit/imutils/test_exif.py
+++ b/tests/unit/imutils/test_exif.py
@@ -38,6 +38,7 @@ def test_check_exif_dependency_noexif(noexif):
         ("copy_exif", ("dest.jpg",)),
         ("exif_date_time", ()),
         ("get_formatted_exif", ([],)),
+        ("get_keys", ()),
     ),
 )
 def test_handler_base_raises(methodname, args):

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -322,3 +322,13 @@ def test_call_throttled_function_once(qtbot, n_calls):
         local_task(i)
 
     qtbot.waitUntil(check_calls)
+
+
+@pytest.mark.parametrize("text", ("0x234", "0xAC7", "0x00", "AB67", "aC9e"))
+def test_is_hex_true(text):
+    assert utils.is_hex(text)
+
+
+@pytest.mark.parametrize("text", ("00x234", "0xGC7", "not-hex", "A-67", "a:9e"))
+def test_is_hex_false(text):
+    assert not utils.is_hex(text)

--- a/vimiv/gui/metadatawidget.py
+++ b/vimiv/gui/metadatawidget.py
@@ -67,7 +67,7 @@ if exif.has_exif_support:
 
         @property
         def handler(self) -> exif.ExifHandler:
-            """ExifHandler for the current path."""
+            """Return the ExifHandler for the current path."""
             if self._handler is None:
                 self._handler = exif.ExifHandler(self._path)
             return self._handler

--- a/vimiv/gui/metadatawidget.py
+++ b/vimiv/gui/metadatawidget.py
@@ -121,12 +121,6 @@ if exif.has_exif_support:
                 * ``--to-term``: Print the keys to the terminal instead.
             """
 
-            def format_row(first, *other):
-                other_elems = "".join(
-                    f"<td style='padding-left: 2ex'>{elem}</td>" for elem in other
-                )
-                return f"<tr><td>{first}</td>{other_elems}</tr>"
-
             keys = sorted(set(self.handler.get_keys()))
             if to_term:
                 print(*keys, sep="\n")
@@ -134,9 +128,8 @@ if exif.has_exif_support:
                 raise api.commands.CommandError("Number of columns must be positive")
             else:
                 columns = list(utils.split(keys, n_cols))
-                rows = map(list, itertools.zip_longest(*columns, fillvalue=""))
-                table = utils.add_html(
-                    "\n".join(format_row(*elems) for elems in rows), "table"
+                table = utils.format_html_table(
+                    itertools.zip_longest(*columns, fillvalue="")
                 )
                 self.setText(table)
                 self._update_geometry()

--- a/vimiv/imutils/exif.py
+++ b/vimiv/imutils/exif.py
@@ -16,7 +16,7 @@ import contextlib
 import itertools
 from typing import Any, Dict, Tuple, NoReturn, Sequence, Iterable
 
-from vimiv.utils import log, lazy
+from vimiv.utils import log, lazy, is_hex
 
 pyexiv2 = lazy.import_module("pyexiv2", optional=True)
 piexif = lazy.import_module("piexif", optional=True)
@@ -237,16 +237,7 @@ class ExifHandler(_ExifHandlerBase):
         return exif
 
     def get_keys(self) -> Iterable[str]:
-        def is_hex(key: str) -> bool:
-            """Return True if the name of key is a hexadecimal digit."""
-            _base, _sep, name = key.rpartition(".")
-            try:
-                int(name, base=16)
-                return True
-            except ValueError:
-                return False
-
-        return (key for key in self._metadata if not is_hex(key))
+        return (key for key in self._metadata if not is_hex(key.rpartition(".")[2]))
 
     def copy_exif(self, dest: str, reset_orientation: bool = True) -> None:
         if reset_orientation:

--- a/vimiv/utils/__init__.py
+++ b/vimiv/utils/__init__.py
@@ -50,18 +50,16 @@ def wrap_style_span(style: str, text: str) -> str:
     return f"<span style='{style};'>{text}</span>"
 
 
-def format_html_table(content: typing.Iterable[typing.Tuple[str, str]]) -> str:
-    """Format a nice html table for content in the form of key, value."""
+def format_html_table(content: typing.Iterable[typing.Sequence[str]]) -> str:
+    """Format a nice html table for content."""
 
-    def format_row(key: str, value: str) -> str:
-        return (
-            "<tr>"
-            f"<td>{key}</td>"
-            f"<td style='padding-left: 2ex'>{value}</td>"
-            "</tr>"
+    def format_row(first: str, *other: str) -> str:
+        other_elems = "".join(
+            f"<td style='padding-left: 2ex'>{elem}</td>" for elem in other
         )
+        return f"<tr><td>{first}</td>{other_elems}</tr>"
 
-    return add_html("\n".join(format_row(k, v) for k, v in content), "table")
+    return add_html("\n".join(format_row(*cells) for cells in content), "table")
 
 
 def strip_html(text: str) -> str:

--- a/vimiv/utils/__init__.py
+++ b/vimiv/utils/__init__.py
@@ -130,6 +130,15 @@ def clamp(
     return value
 
 
+def is_hex(text: str) -> bool:
+    """Return True if text is a hexadecimal digit."""
+    try:
+        int(text, base=16)
+        return True
+    except ValueError:
+        return False
+
+
 def parameter_names(function: typing.Callable) -> typing.Tuple[str, ...]:
     """Fast implementation of getting the parameter names of a function.
 


### PR DESCRIPTION
Introduces a new `:metadata-list-keys` command to display all valid exif keys for the current image.

I decided to implement this as a standalone command instead of an option for `:metadata` as there are two optional arguments for `:metadata-list-keys`:
- `--n-cols` to customize the number of columns used to format the html table
- `--to-term` to print to the terminal instead of displaying the table in case one would like to easily copy / format / pick ...

These would otherwise just clutter the `:metadata` command.

@jcjgraf what do you think? One point where I would like to hear your opinion is that I removed all keys which are plain hex digits, like `Exif.CanonCs.0x0006`, I suppose this makes sense?

fixes #220 