### PR TITLE
Update Metadata Default Keys

### DIFF
--- a/tests/end2end/features/image/conftest.py
+++ b/tests/end2end/features/image/conftest.py
@@ -24,6 +24,7 @@ def exif_content():
             piexif.ImageIFD.Copyright: b"vimiv-AUTHORS-2020",
         },
         "Exif": {piexif.ExifIFD.ExposureTime: (1, 200)},
+        "GPS": {piexif.GPSIFD.GPSAltitude: (1234, 1)},
     }
 
 

--- a/tests/end2end/features/image/metadata.feature
+++ b/tests/end2end/features/image/metadata.feature
@@ -30,8 +30,8 @@ Feature: Metadata widget displaying image exif information
         When I add exif information
         And I run 3metadata
         Then the metadata widget should be visible
-        And the metadata text should contain 'Copyright'
-        And the metadata text should contain 'vimiv-AUTHORS-2020'
+        And the metadata text should contain 'GPSAltitude'
+        And the metadata text should contain '1234'
 
     Scenario: Error message on invalid metadata key set number
         Given I open any image

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -499,6 +499,7 @@ class metadata:  # pylint: disable=invalid-name
         "Exif.Photo.ExposureTime,Exif.Photo.FNumber,Exif.Photo.ISOSpeedRatings,Exif.Photo.ApertureValue,Exif.Photo.ExposureBiasValue,Exif.Photo.FocalLength,Exif.Photo.ExposureProgram",  # pylint: disable=line-too-long,useless-suppression
         "Exif.GPSInfo.GPSLatitudeRef,Exif.GPSInfo.GPSLatitude,Exif.GPSInfo.GPSLongitudeRef,Exif.GPSInfo.GPSLongitude,Exif.GPSInfo.GPSAltitudeRef,Exif.GPSInfo.GPSAltitude",  # pylint: disable=line-too-long,useless-suppression
         "Iptc.Application2.Caption,Iptc.Application2.Keywords,Iptc.Application2.City,Iptc.Application2.SubLocation,Iptc.Application2.ProvinceState,Iptc.Application2.CountryName,Iptc.Application2.Source,Iptc.Application2.Credit,Iptc.Application2.Copyright,Iptc.Application2.Contact",  # pylint: disable=line-too-long,useless-suppression
+        "Exif.Image.ImageWidth,Exif.Image.ImageLength,Exif.Photo.PixelXDimension,Exif.Photo.PixelYDimension,Exif.Image.BitsPerSample,Exif.Image.Compression,Exif.Photo.ColorSpace",  # pylint: disable=line-too-long,useless-suppression
     ]
 
     # Store the keys as a comma separated string

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -495,9 +495,10 @@ class metadata:  # pylint: disable=invalid-name
 
     # Default sets
     defaults = [
-        "Exif.Image.Make, Exif.Image.Model, Exif.Image.DateTime, Exif.Photo.ExposureTime, Exif.Photo.FNumber, Exif.Photo.IsoSpeedRatings, Exif.Photo.FocalLength, Exif.Photo.LensMake, Exif.Photo.LensModel, Exif.Photo.ExposureBiasValue",  # pylint: disable=line-too-long,useless-suppression
-        "Exif.Photo.ExposureTime, Exif.Photo.FNumber, Exif.Photo.IsoSpeedRatings, Exif.Photo.FocalLength",  # pylint: disable=line-too-long,useless-suppression
-        "Exif.Image.Artist, Exif.Image.Copyright",
+        "Exif.Image.Make,Exif.Image.Model,Exif.Photo.LensModel,Exif.Image.DateTime,Exif.Image.Artist,Exif.Image.Copyright",  # pylint: disable=line-too-long,useless-suppression
+        "Exif.Photo.ExposureTime,Exif.Photo.FNumber,Exif.Photo.ISOSpeedRatings,Exif.Photo.ApertureValue,Exif.Photo.ExposureBiasValue,Exif.Photo.FocalLength,Exif.Photo.ExposureProgram",  # pylint: disable=line-too-long,useless-suppression
+        "Exif.GPSInfo.GPSLatitudeRef,Exif.GPSInfo.GPSLatitude,Exif.GPSInfo.GPSLongitudeRef,Exif.GPSInfo.GPSLongitude,Exif.GPSInfo.GPSAltitudeRef,Exif.GPSInfo.GPSAltitude",  # pylint: disable=line-too-long,useless-suppression
+        "Iptc.Application2.Caption,Iptc.Application2.Keywords,Iptc.Application2.City,Iptc.Application2.SubLocation,Iptc.Application2.ProvinceState,Iptc.Application2.CountryName,Iptc.Application2.Source,Iptc.Application2.Credit,Iptc.Application2.Copyright,Iptc.Application2.Contact",  # pylint: disable=line-too-long,useless-suppression
     ]
 
     # Store the keys as a comma separated string


### PR DESCRIPTION
After merging #311 I thought it is a good time to rework the default metadata keys. Now there are a total of 5 sets which contain the following information:
1. General information about the image
2. Exif camera settings
3. GPS information
4. IPTC data
5. Technical details about the image

I am really happy with the capabilities of metadata widget. But in the set 5 I wanted to present information like color space, image resolution, image format, image size etc. But, not all of these information are stored in exif (or some only for uncompressed files). To get these information into the metadata widget, I thought that we may extend the `ExifHandler` to accept some custom keys, which are dealt with by vimiv itself and not my exiv2. Concretely, I have thought about the following keys:
- `vimiv.ImageFormat`: Image extension (JPEG, CR2 etc.)
- `vimiv.XDimension`: Length of image in pixels
- `vimiv.YDimension`: Height of image in pixels
- `vimiv.FileSize`: The filesize in MB

I think these information are sometimes quite crucial. The proposed solution has the advantage that these additional keys are well integrated into the metadata widget. Meaning that for the user it does not make any difference where the data comes from, it is just all presented in the metadata widget.

In addition, I have had the following idea. The raw coordinates presented in 3. are not very meaning full (at least not to me). So I thought it would be awesome to have a little map which show where a certain image is taken. It does not have to be complex, just a map with zoom and tilt functionality and with a red dot indicating where the image was taken. But that should probably rather go into a dedicated plugin :blush: 

Please let me know that you think about the chosen defaults and if would would find it useful too to have some additional metadata keys.
