### PR TITLE
Extend mark api

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,10 @@ Added:
     the first icon of the current row in thumbnail mode.
 
   Thanks `@jcjgraf <https://github.com/jcjgraf>`_ for the idea!
+* The ``--action`` flag for the ``:mark`` command. ``--action toggle`` is the default
+  and keeps the previous behaviour of the mark command, i.e. inversing the mark status
+  of the passed path(s). In addition one can now use ``--action mark`` and
+  ``--action unmark`` to force (un-) marking the paths.
 
 Changed:
 ^^^^^^^^

--- a/tests/unit/api/test_mark.py
+++ b/tests/unit/api/test_mark.py
@@ -47,14 +47,14 @@ def tagwrite(tagdir):
 
 def test_mark_single_image(mark):
     mark.mark(["image"])
-    assert "image" in mark._marked
+    assert mark.is_marked("image")
     assert mark.marked.called_once_with("image")
 
 
 def test_mark_multiple_images(mark):
     mark.mark(["image1", "image2"])
-    assert "image1" in mark._marked
-    assert "image2" in mark._marked
+    assert mark.is_marked("image1")
+    assert mark.is_marked("image2")
     assert mark.marked.called_with("image1")
     assert mark.marked.called_with("image2")
 
@@ -62,14 +62,14 @@ def test_mark_multiple_images(mark):
 def test_mark_action_toggle(mark):
     mark.mark(["image"])
     mark.mark(["image"])
-    assert "image" not in mark._marked
+    assert not mark.is_marked("image")
     assert mark.unmarked.called_once_with("image")
 
 
 def test_mark_action_mark(mark):
     mark.mark(["image"], action=MarkAction.Mark)
     mark.mark(["image"], action=MarkAction.Mark)
-    assert "image" in mark._marked
+    assert mark.is_marked("image")
     assert mark.marked.called_once_with("image")
 
 
@@ -77,14 +77,14 @@ def test_mark_action_unmark(mark):
     mark.mark(["image"])
     mark.mark(["image"], action=MarkAction.Unmark)
     mark.mark(["image"], action=MarkAction.Unmark)
-    assert "image" not in mark._marked
+    assert not mark.is_marked("image")
     assert mark.unmarked.called_once_with("image")
 
 
 def test_mark_clear(mark):
     mark.mark(["image"])
     mark.mark_clear()
-    assert "image" not in mark._marked
+    assert not mark.is_marked("image")
     assert mark.unmarked.called_once_with("image")
 
 
@@ -92,7 +92,7 @@ def test_mark_restore(mark):
     mark.mark(["image"])
     mark.mark_clear()
     mark.mark_restore()
-    assert "image" in mark._marked
+    assert mark.is_marked("image")
     assert mark.marked.called_with("image")
 
 

--- a/tests/unit/api/test_mark.py
+++ b/tests/unit/api/test_mark.py
@@ -48,29 +48,29 @@ def tagwrite(tagdir):
 def test_mark_single_image(mark):
     mark.mark(["image"])
     assert mark.is_marked("image")
-    assert mark.marked.called_once_with("image")
+    mark.marked.emit.assert_called_once_with("image")
 
 
 def test_mark_multiple_images(mark):
-    mark.mark(["image1", "image2"])
-    assert mark.is_marked("image1")
-    assert mark.is_marked("image2")
-    assert mark.marked.called_with("image1")
-    assert mark.marked.called_with("image2")
+    images = ["image1", "image2"]
+    mark.mark(images)
+    for image in images:
+        assert mark.is_marked(image)
+        mark.marked.emit.assert_any_call(image)
 
 
 def test_mark_action_toggle(mark):
     mark.mark(["image"])
     mark.mark(["image"])
     assert not mark.is_marked("image")
-    assert mark.unmarked.called_once_with("image")
+    mark.unmarked.emit.assert_called_once_with("image")
 
 
 def test_mark_action_mark(mark):
     mark.mark(["image"], action=Mark.Action.Mark)
     mark.mark(["image"], action=Mark.Action.Mark)
     assert mark.is_marked("image")
-    assert mark.marked.called_once_with("image")
+    mark.marked.emit.assert_called_once_with("image")
 
 
 def test_mark_action_unmark(mark):
@@ -78,14 +78,14 @@ def test_mark_action_unmark(mark):
     mark.mark(["image"], action=Mark.Action.Unmark)
     mark.mark(["image"], action=Mark.Action.Unmark)
     assert not mark.is_marked("image")
-    assert mark.unmarked.called_once_with("image")
+    mark.unmarked.emit.assert_called_once_with("image")
 
 
 def test_mark_clear(mark):
     mark.mark(["image"])
     mark.mark_clear()
     assert not mark.is_marked("image")
-    assert mark.unmarked.called_once_with("image")
+    mark.unmarked.emit.assert_called_once_with("image")
 
 
 def test_mark_restore(mark):
@@ -93,7 +93,7 @@ def test_mark_restore(mark):
     mark.mark_clear()
     mark.mark_restore()
     assert mark.is_marked("image")
-    assert mark.marked.called_with("image")
+    mark.marked.emit.assert_called_with("image")
 
 
 def test_tag_write(tagwrite):

--- a/tests/unit/api/test_mark.py
+++ b/tests/unit/api/test_mark.py
@@ -13,7 +13,7 @@ import re
 import pytest
 
 from vimiv import api
-from vimiv.api._mark import Mark, MarkAction, Tag
+from vimiv.api._mark import Mark, Tag
 
 
 @pytest.fixture
@@ -67,16 +67,16 @@ def test_mark_action_toggle(mark):
 
 
 def test_mark_action_mark(mark):
-    mark.mark(["image"], action=MarkAction.Mark)
-    mark.mark(["image"], action=MarkAction.Mark)
+    mark.mark(["image"], action=Mark.Action.Mark)
+    mark.mark(["image"], action=Mark.Action.Mark)
     assert mark.is_marked("image")
     assert mark.marked.called_once_with("image")
 
 
 def test_mark_action_unmark(mark):
     mark.mark(["image"])
-    mark.mark(["image"], action=MarkAction.Unmark)
-    mark.mark(["image"], action=MarkAction.Unmark)
+    mark.mark(["image"], action=Mark.Action.Unmark)
+    mark.mark(["image"], action=Mark.Action.Unmark)
     assert not mark.is_marked("image")
     assert mark.unmarked.called_once_with("image")
 

--- a/tests/unit/api/test_mark.py
+++ b/tests/unit/api/test_mark.py
@@ -13,7 +13,7 @@ import re
 import pytest
 
 from vimiv import api
-from vimiv.api._mark import Mark, Tag
+from vimiv.api._mark import Mark, MarkAction, Tag
 
 
 @pytest.fixture
@@ -59,9 +59,24 @@ def test_mark_multiple_images(mark):
     assert mark.marked.called_with("image2")
 
 
-def test_toggle_mark(mark):
+def test_mark_action_toggle(mark):
     mark.mark(["image"])
     mark.mark(["image"])
+    assert "image" not in mark._marked
+    assert mark.unmarked.called_once_with("image")
+
+
+def test_mark_action_mark(mark):
+    mark.mark(["image"], action=MarkAction.Mark)
+    mark.mark(["image"], action=MarkAction.Mark)
+    assert "image" in mark._marked
+    assert mark.marked.called_once_with("image")
+
+
+def test_mark_action_unmark(mark):
+    mark.mark(["image"])
+    mark.mark(["image"], action=MarkAction.Unmark)
+    mark.mark(["image"], action=MarkAction.Unmark)
     assert "image" not in mark._marked
     assert mark.unmarked.called_once_with("image")
 

--- a/vimiv/api/_mark.py
+++ b/vimiv/api/_mark.py
@@ -22,14 +22,6 @@ from vimiv.utils import files, xdg, remove_prefix, wrap_style_span, slot, log
 _logger = log.module_logger(__name__)
 
 
-class MarkAction(enum.Enum):
-    """Valid action options for the mark command."""
-
-    Toggle = "toggle"
-    Mark = "mark"
-    Unmark = "unmark"
-
-
 class Mark(QObject):
     """Handle marking and tagging of images.
 
@@ -45,6 +37,13 @@ class Mark(QObject):
         _watcher: QFileSystemWatcher to monitor marked paths.
     """
 
+    class Action(enum.Enum):
+        """Valid action options for the mark command."""
+
+        Toggle = "toggle"
+        Mark = "mark"
+        Unmark = "unmark"
+
     marked = pyqtSignal(str)
     unmarked = pyqtSignal(str)
     markdone = pyqtSignal()
@@ -57,9 +56,9 @@ class Mark(QObject):
         self._last_marked: List[str] = []
         self._watcher: Optional[QFileSystemWatcher] = None
         self._actions = {
-            MarkAction.Toggle: self._toggle_mark,
-            MarkAction.Mark: self._mark,
-            MarkAction.Unmark: self._unmark,
+            Mark.Action.Toggle: self._toggle_mark,
+            Mark.Action.Mark: self._mark,
+            Mark.Action.Unmark: self._unmark,
         }
 
     @property
@@ -85,7 +84,7 @@ class Mark(QObject):
 
     @keybindings.register("m", "mark %")
     @commands.register()
-    def mark(self, paths: List[str], action: MarkAction = MarkAction.Toggle) -> None:
+    def mark(self, paths: List[str], action: Action = Action.Toggle) -> None:
         """Mark one or more paths.
 
         **syntax:** ``:mark path [path ...] [--action=ACTION]``
@@ -97,8 +96,8 @@ class Mark(QObject):
 
         optional arguments:
             * ``--action``: One of toggle/mark/unmark. Toggle, the default, inverses the
-               mark status of the path(s). Mark forces marking while unmark forces
-               removing the mark.
+              mark status of the path(s). Mark forces marking while unmark forces
+              removing the mark.
         """
         _logger.debug("Calling %s on %d paths", action.value, len(paths))
         function = self._actions[action]

--- a/vimiv/api/_mark.py
+++ b/vimiv/api/_mark.py
@@ -79,6 +79,10 @@ class Mark(QObject):
             self._watcher.fileChanged.connect(self._on_file_changed)  # type: ignore
         return self._watcher
 
+    def is_marked(self, path: str) -> bool:
+        """Return True if the passed path is marked."""
+        return path in self._marked
+
     @keybindings.register("m", "mark %")
     @commands.register()
     def mark(self, paths: List[str], action: MarkAction = MarkAction.Toggle) -> None:

--- a/vimiv/api/_mark.py
+++ b/vimiv/api/_mark.py
@@ -288,6 +288,8 @@ class Mark(QObject):
 
     def _mark(self, path: str) -> None:
         """Mark the given path."""
+        if self.is_marked(path):
+            raise ValueError(f"Path '{path}' is already marked")
         self._marked.append(path)
         self.marked.emit(path)
         self.watcher.addPath(path)


### PR DESCRIPTION
The mark command has been extended with an optional action argument that allows forcing to (un-) mark the passed paths instead of toggling. When used in plugins, one would do
```python
api.mark.mark(paths, api.mark.Action.Mark)  # Force marking
api.mark.mark(paths, api.mark.Action.Unmark)  # Force unmarking
```
for the respective options. This should hopefully deal with all possible use-cases, and always emits `markdone` once done handling all paths. If only a single path should be marked, one can wrap it into a list, i.e.
```python
api.mark.mark([path])  # Toggle mark status of the single path
```

In addition we expose the simple `mark.is_marked` function as proposed.

@jcjgraf does this fulfill your expectations for the first point in #323? :blush:
As I guess the ideas come from the batchmark plugin, I took a quick look and think the `batchmark_end` part should now be doable  with something like
```python
all_marked = all(api.mark.is_marked(path) for path in selected_paths)
action = api.mark.Action.Unmark if all_marked else api.mark.Action.Mark
api.mark.mark(selected_paths, action)
```

I would wait with the exif related part to see what happens in #325, maybe even a bit later if we are not sure of the structuring yet, as once it is exposed via the api, changing the interface is no longer so easy.