### PR TITLE
Undelete Failed to Restore Symlinks

### DIFF
--- a/vimiv/utils/trash_manager.py
+++ b/vimiv/utils/trash_manager.py
@@ -63,7 +63,9 @@ def undelete(basename: str) -> str:
     """
     trash_filename = os.path.join(_files_directory, basename)
     info_filename = _get_info_filename(basename)
-    if not os.path.exists(info_filename) or not os.path.exists(trash_filename):
+    if not os.path.exists(info_filename) or (
+        not os.path.exists(trash_filename) and not os.path.islink(trash_filename)
+    ):
         raise FileNotFoundError(f"File for '{basename}' does not exist")
     original_filename, _ = trash_info(basename)
     if not os.path.isdir(os.path.dirname(original_filename)):


### PR DESCRIPTION
The check `os.path.exists(trash_filename)` fails for broken symlinks (returns false). Therefore, vimiv was unable to undelete symlinks to images. An additional call to `os.path.islink(trash_filename)` fixes that issue.