### PR TITLE
Add support for detecting .avif files using imageformats plugin

### DIFF
--- a/vimiv/plugins/imageformats.py
+++ b/vimiv/plugins/imageformats.py
@@ -38,7 +38,7 @@ def test_cr2(header: bytes, _f: Optional[BinaryIO]) -> bool:
 
 
 def test_avif(header: bytes, _f: Optional[BinaryIO]) -> bool:
-    return header[4:12] == b"ftypavif"
+    return header[4:12] in (b"ftypavif", b"ftypeavis")
 
 
 FORMATS = {

--- a/vimiv/plugins/imageformats.py
+++ b/vimiv/plugins/imageformats.py
@@ -36,9 +36,13 @@ _logger = log.module_logger(__name__)
 def test_cr2(header: bytes, _f: Optional[BinaryIO]) -> bool:
     return header[:2] in (b"II", b"MM") and header[8:10] == b"CR"
 
+def test_avif(header: bytes, _f: Optional[BinaryIO]) -> bool:
+    return header[4:12] == b"ftypavif"
+
 
 FORMATS = {
     "cr2": test_cr2,
+    "avif": test_avif,
 }
 
 

--- a/vimiv/plugins/imageformats.py
+++ b/vimiv/plugins/imageformats.py
@@ -36,6 +36,7 @@ _logger = log.module_logger(__name__)
 def test_cr2(header: bytes, _f: Optional[BinaryIO]) -> bool:
     return header[:2] in (b"II", b"MM") and header[8:10] == b"CR"
 
+
 def test_avif(header: bytes, _f: Optional[BinaryIO]) -> bool:
     return header[4:12] == b"ftypavif"
 


### PR DESCRIPTION
I have not tested this, nor did I find any documentation regarding the bytes header of an avif file.

What I did was downloading images from https://github.com/AOMediaCodec/av1-avif and testing them with `hexdump -n 16 -C`. All of them, except for two with animated features, have a `ftypavif` in byte range 4-12. The two animated have a `ftypavis` in the same range.

[It would seem](https://stackoverflow.com/a/66239407) that some avif files could have another bytes header, but I could not find any relevant document about this.

## Related Issues
#338 