### PR TITLE
Copy Image to Clipboard

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -36,6 +36,8 @@ Added:
     image in library mode.
 
   Thanks `@BachoSeven`_ for your thoughts!
+* `copy-image` command which copies the selected image to the clipboard. The flags
+  `--width`, `--height` and `--size` allow to scale the copied image.
 
 Changed:
 ^^^^^^^^

--- a/tests/end2end/features/misc/clipboard.feature
+++ b/tests/end2end/features/misc/clipboard.feature
@@ -28,26 +28,26 @@ Feature: Interaction with the system clipboard.
         Then the working directory should be child_01
 
     Scenario: Copy image to clipboard.
-        Given I open the image '.hidden.jpg'
+        Given I open any image
         When I run copy-image
-        Then the clipboard should contain image .hidden.jpg
+        Then the clipboard should contain any image
 
     Scenario: Copy image to primary.
-        Given I open the image '.hidden.jpg'
+        Given I open any image
         When I run copy-image --primary
-        Then the primary selection should contain image .hidden.jpg
+        Then the primary selection should contain any image
 
     Scenario: Copy image to clipboard and scale width.
-        Given I open the image '.hidden.jpg'
+        Given I open any image
         When I run copy-image --width=100
         Then the clipboard should contain an image with width 100
 
     Scenario: Copy image to clipboard and scale height.
-        Given I open the image '.hidden.jpg'
+        Given I open any image
         When I run copy-image --height=100
         Then the clipboard should contain an image with height 100
 
     Scenario: Copy image to clipboard and scale size.
-        Given I open the image '.hidden.jpg'
+        Given I open any image
         When I run copy-image --size=100
         Then the clipboard should contain an image with size 100

--- a/tests/end2end/features/misc/clipboard.feature
+++ b/tests/end2end/features/misc/clipboard.feature
@@ -26,3 +26,28 @@ Feature: Interaction with the system clipboard.
         When I run copy-name
         And I run paste-name
         Then the working directory should be child_01
+
+    Scenario: Copy image to clipboard.
+        Given I open the image '.hidden.jpg'
+        When I run copy-image
+        Then the clipboard should contain image .hidden.jpg
+
+    Scenario: Copy image to primary.
+        Given I open the image '.hidden.jpg'
+        When I run copy-image --primary
+        Then the primary selection should contain image .hidden.jpg
+
+    Scenario: Copy image to clipboard and scale width.
+        Given I open the image '.hidden.jpg'
+        When I run copy-image --width=100
+        Then the clipboard should contain an image with width 100
+
+    Scenario: Copy image to clipboard and scale height.
+        Given I open the image '.hidden.jpg'
+        When I run copy-image --height=100
+        Then the clipboard should contain an image with height 100
+
+    Scenario: Copy image to clipboard and scale size.
+        Given I open the image '.hidden.jpg'
+        When I run copy-image --size=100
+        Then the clipboard should contain an image with size 100

--- a/tests/end2end/features/misc/conftest.py
+++ b/tests/end2end/features/misc/conftest.py
@@ -4,7 +4,7 @@
 # Copyright 2017-2021 Christian Karl (karlch) <karlch at protonmail dot com>
 # License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
 
-from PyQt5.QtGui import QGuiApplication, QClipboard
+from PyQt5.QtGui import QGuiApplication, QClipboard, QImage
 
 import pytest
 import pytest_bdd as bdd
@@ -23,3 +23,33 @@ def check_clipboard(clipboard, text):
 @bdd.then(bdd.parsers.parse("The primary selection should contain {text}"))
 def check_primary(clipboard, text):
     assert text in clipboard.text(mode=QClipboard.Selection)
+
+
+@bdd.then(bdd.parsers.parse("The clipboard should contain image {image}"))
+def check_clipboard_image(clipboard, image):
+    assert clipboard.pixmap(mode=QClipboard.Clipboard).toImage() == QImage(image)
+
+
+@bdd.then(bdd.parsers.parse("The primary selection should contain image {image}"))
+def check_primary_image(clipboard, image):
+    assert clipboard.pixmap(mode=QClipboard.Selection).toImage() == QImage(image)
+
+
+@bdd.then(bdd.parsers.parse("The clipboard should contain an image with width {width}"))
+def check_clipboard_image_width(clipboard, width):
+    assert clipboard.pixmap(mode=QClipboard.Clipboard).size().width() == int(width)
+
+
+@bdd.then(
+    bdd.parsers.parse("The clipboard should contain an image with height {height}")
+)
+def check_clipboard_image_height(clipboard, height):
+    assert clipboard.pixmap(mode=QClipboard.Clipboard).size().height() == int(height)
+
+
+@bdd.then(bdd.parsers.parse("The clipboard should contain an image with size {size}"))
+def check_clipboard_image_size(clipboard, size):
+    assert max(
+        clipboard.pixmap(mode=QClipboard.Clipboard).size().height(),
+        clipboard.pixmap(mode=QClipboard.Clipboard).size().width(),
+    ) == int(size)

--- a/tests/end2end/features/misc/conftest.py
+++ b/tests/end2end/features/misc/conftest.py
@@ -4,7 +4,7 @@
 # Copyright 2017-2021 Christian Karl (karlch) <karlch at protonmail dot com>
 # License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
 
-from PyQt5.QtGui import QGuiApplication, QClipboard, QImage
+from PyQt5.QtGui import QGuiApplication, QClipboard
 
 import pytest
 import pytest_bdd as bdd
@@ -25,14 +25,14 @@ def check_primary(clipboard, text):
     assert text in clipboard.text(mode=QClipboard.Selection)
 
 
-@bdd.then(bdd.parsers.parse("The clipboard should contain image {image}"))
+@bdd.then(bdd.parsers.parse("The clipboard should contain any image"))
 def check_clipboard_image(clipboard, image):
-    assert clipboard.pixmap(mode=QClipboard.Clipboard).toImage() == QImage(image)
+    assert not clipboard.pixmap(mode=QClipboard.Clipboard).toImage().isNull()
 
 
-@bdd.then(bdd.parsers.parse("The primary selection should contain image {image}"))
+@bdd.then(bdd.parsers.parse("The primary selection should contain any image"))
 def check_primary_image(clipboard, image):
-    assert clipboard.pixmap(mode=QClipboard.Selection).toImage() == QImage(image)
+    assert not clipboard.pixmap(mode=QClipboard.Selection).toImage().isNull()
 
 
 @bdd.then(bdd.parsers.parse("The clipboard should contain an image with width {width}"))

--- a/vimiv/api/_modules.py
+++ b/vimiv/api/_modules.py
@@ -17,7 +17,7 @@ from PyQt5.QtCore import QDateTime
 from PyQt5.QtGui import QGuiApplication, QClipboard
 
 from vimiv import api
-from vimiv.utils import files, log
+from vimiv.utils import files, log, imagereader
 
 
 _logger = log.module_logger(__name__)
@@ -87,6 +87,30 @@ def copy_name(abspath: bool = False, primary: bool = False) -> None:
     path = api.current_path()
     name = path if abspath else os.path.basename(path)
     clipboard.setText(name, mode=mode)
+
+
+@api.keybindings.register("yi", "copy-image")
+@api.keybindings.register("yI", "copy-image --primary")
+@api.commands.register()
+def copy_image(primary: bool = False) -> None:
+    """Copy currently selected image to system clipboard.
+
+    **syntax:** ``:copy-image [--primary]``
+
+    optional arguments:
+        * ``--primary``: Copy to primary selection.
+    """
+    clipboard = QGuiApplication.clipboard()
+    mode = QClipboard.Selection if primary else QClipboard.Clipboard
+    path = api.current_path()
+    try:
+        reader = imagereader.get_reader(path)
+        pixmap = reader.get_pixmap()
+    except ValueError as e:
+        log.error(str(e))
+        return
+
+    clipboard.setPixmap(pixmap, mode=mode)
 
 
 @api.commands.register()

--- a/vimiv/api/_modules.py
+++ b/vimiv/api/_modules.py
@@ -93,17 +93,24 @@ def copy_name(abspath: bool = False, primary: bool = False) -> None:
 @api.keybindings.register("yI", "copy-image --primary")
 @api.commands.register()
 def copy_image(
-    primary: bool = False, width: int = None, height: int = None, size: int = None
+    primary: bool = False,
+    width: int = None,
+    height: int = None,
+    size: int = None,
+    count: int = None,
 ) -> None:
     """Copy currently selected image to system clipboard.
 
-    **syntax:** ``:copy-image [--primary] [--width=WIDTH] [--height=HEIGHT] [--size=SIZE]``
+    **syntax:** ``:copy-image [--primary] [--width=WIDTH] [--height=HEIGHT]
+    [--size=SIZE]``
 
     optional arguments:
         * ``--primary``: Copy to primary selection.
         * ``--width``: Scale width to the specified value.
         * ``--height``: Scale height to the specified value.
         * ``--size``: Scale longer side to the specified value.
+
+    **count:** Equivalent to the ``--size`` option
     """
     clipboard = QGuiApplication.clipboard()
     mode = QClipboard.Selection if primary else QClipboard.Clipboard
@@ -116,15 +123,17 @@ def copy_image(
         log.error(str(e))
         return
 
-    if size:
+    if size or count:
         pix_size = pixmap.size()
+
+        size = count if count is not None else size
 
         if pix_size.height() >= pix_size.width():
             _logger.debug(f"Copy image with size {size} restricting height")
-            pixmap = pixmap.scaledToHeight(size)
+            pixmap = pixmap.scaledToHeight(size)  # type: ignore[arg-type]
         else:
             _logger.debug(f"Copy image with size {size} restricting width")
-            pixmap = pixmap.scaledToWidth(size)
+            pixmap = pixmap.scaledToWidth(size)  # type: ignore[arg-type]
 
     elif width:
         _logger.debug(f"Copy image with width {width}")


### PR DESCRIPTION
Adds a new command `copy-image` to copy the whole image pixmap to the system clipboard, allowing easy pasting to other applications. `yi` and `yI` are currently bound to this command (global clipboard and selection clipboard respectively). 

Todo:
- [x] Check if implementation fulfils requirements
- [ ] ~Flag to copy the original image in contrast to the (potentially compressed) QPixmap~
- [x] Unit tests?

Implements: #358

