### PR TITLE
Wrong URL to pyexiv2 project

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -56,7 +56,7 @@ Added:
 * New ``--keep-zoom`` flag for ``:next`` and ``:prev`` which preserves zoom level and
   scroll position of the current image.
   Thanks `@jcjgraf`_ for the idea!
-* Exif support using `pyexiv2 <https://pypi.org/project/pyexiv2/>`_. When available,
+* Exif support using `pyexiv2 <https://python3-exiv2.readthedocs.io/>`_. When available,
   vimiv now prefers pyexiv2 over piexif for exif support due to its ability to format
   exif values into a human readable format. Thanks a lot
   `@jcjgraf`_ for all your hard work, thoughts and comments

--- a/docs/documentation/exif.rst
+++ b/docs/documentation/exif.rst
@@ -9,6 +9,7 @@ this is the case:
 #. The ``:metadata`` command and the corresponding ``i``-keybinding is available.
 #. The ``{exif-date-time}`` statusbar module is available.
 
+.. include:: pyexiv2.rst
 
 Advantages of the different exif libraries
 ------------------------------------------
@@ -60,5 +61,5 @@ You can get a list of valid metadata keys for the current image using the
 
 
 .. _exiv2: https://www.exiv2.org/index.html
-.. _pyexiv2: https://pypi.org/project/pyexiv2/
+.. _pyexiv2: https://python3-exiv2.readthedocs.io
 .. _piexif: https://pypi.org/project/piexif/

--- a/docs/documentation/install.rst
+++ b/docs/documentation/install.rst
@@ -132,7 +132,7 @@ Dependencies
 * `pyexiv2 <https://python3-exiv2.readthedocs.io>`_ (optional for exif support)
 * `piexif <https://pypi.org/project/piexif/>`_ (optional alternative for exif support)
 
-.. include:: pyexiv.rst
+.. include:: pyexiv2.rst
 
 Package Names For Distributions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/documentation/install.rst
+++ b/docs/documentation/install.rst
@@ -129,8 +129,10 @@ Dependencies
     - QtSvg (optional for svg support)
 * `PyQt5 <http://www.riverbankcomputing.com/software/pyqt/intro>`_  5.9.2 or newer
 * `setuptools <https://pypi.python.org/pypi/setuptools/>`_ (for installation)
-* `pyexiv2 <https://pypi.org/project/pyexiv2/>`_ (optional for exif support)
+* `pyexiv2 <https://python3-exiv2.readthedocs.io>`_ (optional for exif support)
 * `piexif <https://pypi.org/project/piexif/>`_ (optional alternative for exif support)
+
+.. include:: pyexiv.rst
 
 Package Names For Distributions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/documentation/pyexiv2.rst
+++ b/docs/documentation/pyexiv2.rst
@@ -1,4 +1,3 @@
 .. warning::
 
-    There are multiple packages named `pyexiv2`. Make sure you have installed
-    the right one.
+    There are multiple packages named `pyexiv2`. Make sure you install the right one.

--- a/docs/documentation/pyexiv2.rst
+++ b/docs/documentation/pyexiv2.rst
@@ -1,0 +1,4 @@
+.. warning::
+
+    There are multiple packages named `pyexiv2`. Make sure you have installed
+    the right one.


### PR DESCRIPTION
I have just noted that the link to the pyexiv2 project in the documentation is actually wrong. The reason being is that there are (at least) three projects called pyexiv2 (or very similar). We are using [this](https://python3-exiv2.readthedocs.io). I have fixed the URL and added a note to the docs that one has to take care to install the right package.

~I am not sure how to compile and preview the docs locally. So, I cannot guarantee that I did everything right with the warning.~ **Edit:** I just should looked at you contribution guideline in the first place :see_no_evil: 

@karlch feel free to rewrite and change things you do not like.
