### PR TITLE
Add read only setting

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -39,6 +39,9 @@ Added:
 * The ``:copy-image`` command which copies the selected image to the clipboard. The
   flags ``--width``, ``--height`` and ``--size`` allow to scale the copied image.
   Thanks `@jcjgraf`_!
+* The ``read_only`` setting. When set to true, all commands that may write changes to
+  disk are disabled.
+  Thanks `@willemw12`_ for the idea!
 
 Changed:
 ^^^^^^^^
@@ -457,3 +460,4 @@ Initial release of the Qt version.
 .. _@OliverLew: https://github.com/OliverLew
 .. _@maximbaz: https://github.com/maximbaz
 .. _@BachoSeven: https://github.com/BachoSeven
+.. _@willemw12: https://github.com/willemw12

--- a/tests/end2end/features/edit/manipulate.feature
+++ b/tests/end2end/features/edit/manipulate.feature
@@ -71,3 +71,11 @@ Feature: Manipulate an image.
         And I apply any manipulation
         And I run accept
         Then there should be 0 stored changes
+
+    Scenario: Do not allow entering manipulate when read_only is active
+        When I run set read_only true
+        And I enter manipulate mode
+        Then the message
+            'Manipulate mode is disabled due to read-only being active'
+            should be displayed
+        And the mode should be image

--- a/tests/end2end/features/edit/transform.feature
+++ b/tests/end2end/features/edit/transform.feature
@@ -46,3 +46,12 @@ Feature: Transform an image.
         When I run resize 150
         And I run undo-transformations
         Then the image size should be 300x200
+
+    Scenario: Do not allow transforming when read_only is active
+        Given I open any image of size 300x200
+        When I run set read_only true
+        And I run rotate
+        Then the message
+            'rotate: Disabled due to read-only being active'
+            should be displayed
+        And the orientation should be landscape

--- a/tests/end2end/features/image/imagedelete.feature
+++ b/tests/end2end/features/image/imagedelete.feature
@@ -117,3 +117,12 @@ Feature: Deleting an image in the current file list
         And I run delete %
         Then no crash should happen
         And the file image.jpg should exist
+
+    Scenario: Do not allow deleting when read_only is active
+        Given I open any image
+        When I run set read_only true
+        And I run delete %
+        Then the message
+            'delete: Disabled due to read-only being active'
+            should be displayed
+        And the file image.jpg should exist

--- a/vimiv/api/_modules.py
+++ b/vimiv/api/_modules.py
@@ -160,7 +160,7 @@ def paste_name(primary: bool = True) -> None:
     api.open_paths([clipboard.text(mode=mode)])
 
 
-@api.commands.register()
+@api.commands.register(edit=True)
 def rename(
     paths: List[str],
     base: str,
@@ -210,7 +210,7 @@ def rename(
     api.mark.mark(marked)
 
 
-@api.commands.register()
+@api.commands.register(edit=True)
 def mark_rename(
     base: str, start: int = 1, overwrite: bool = False, separator: str = "_"
 ) -> None:

--- a/vimiv/api/modes.py
+++ b/vimiv/api/modes.py
@@ -34,6 +34,7 @@ from typing import cast, Any, Callable, List, Tuple
 from PyQt5.QtCore import pyqtSignal, QObject
 from PyQt5.QtWidgets import QWidget
 
+from vimiv.api import settings
 from vimiv.utils import AbstractQObjectMeta, log
 
 
@@ -271,6 +272,17 @@ class _CommandMode(Mode):
             self._last = mode
 
 
+class _ManipulateMode(_MainMode):
+    """Manipulate mode class."""
+
+    def enter(self) -> None:
+        """Override enter to ensure we are not in read-only mode when manipulating."""
+        if settings.read_only:
+            log.error("Manipulate mode is disabled due to read-only being active")
+        else:
+            super().enter()
+
+
 # Create all modes
 GLOBAL = _MainMode("global")
 IMAGE = _MainMode("image")
@@ -278,7 +290,7 @@ Mode.active = IMAGE
 LIBRARY = _MainMode("library", last=IMAGE)
 THUMBNAIL = _MainMode("thumbnail", last=IMAGE)
 COMMAND = _CommandMode("command", last=IMAGE)
-MANIPULATE = _MainMode("manipulate", last=IMAGE)
+MANIPULATE = _ManipulateMode("manipulate", last=IMAGE)
 # This cannot be done in the constructor as the constructor of LIBRARY requires IMAGE
 # and vice-versa
 IMAGE.last = IMAGE.last_fallback = LIBRARY

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -330,6 +330,9 @@ startup_library = BoolSetting(
     hidden=True,
 )
 style = StrSetting("style", "default", hidden=True)
+read_only = BoolSetting(
+    "read_only", False, desc="Disable any commands that are able to edit files on disk"
+)
 
 
 class command:  # pylint: disable=invalid-name

--- a/vimiv/commands/delete_command.py
+++ b/vimiv/commands/delete_command.py
@@ -16,7 +16,7 @@ _last_deleted: List[str] = []
 
 
 @api.keybindings.register("x", "delete %")
-@api.commands.register()
+@api.commands.register(edit=True)
 def delete(paths: List[str]) -> None:
     """Move one or more images to the trash directory.
 
@@ -50,7 +50,7 @@ def delete(paths: List[str]) -> None:
         log.info(succ_msg)
 
 
-@api.commands.register()
+@api.commands.register(edit=True)
 def undelete(basenames: List[str]) -> None:
     """Restore a file from the trash directory.
 

--- a/vimiv/gui/image.py
+++ b/vimiv/gui/image.py
@@ -318,7 +318,7 @@ class ScrollableImage(eventhandler.EventHandlerMixin, QGraphicsView):
             movie = widget.movie()
             movie.setPaused(not movie.state() == QMovie.Paused)
 
-    @api.commands.register(mode=api.modes.IMAGE)
+    @api.commands.register(mode=api.modes.IMAGE, edit=True)
     def straighten(self):
         """Display a grid to straighten the current image.
 

--- a/vimiv/imutils/_file_handler.py
+++ b/vimiv/imutils/_file_handler.py
@@ -124,7 +124,7 @@ class ImageFileHandler(QObject):
             api.signals.pixmap_loaded.emit(pixmap, keep_zoom)
         self._path = path
 
-    @api.commands.register(mode=api.modes.IMAGE)
+    @api.commands.register(mode=api.modes.IMAGE, edit=True)
     def write(self, path: List[str]):
         """Save the current image to disk.
 

--- a/vimiv/imutils/imtransform.py
+++ b/vimiv/imutils/imtransform.py
@@ -32,7 +32,7 @@ def register_transform_command(**kwargs):
             func(self, *args, **kwargs)
             self.apply()
 
-        return api.commands.register(mode=api.modes.IMAGE, **kwargs)(inner)
+        return api.commands.register(mode=api.modes.IMAGE, edit=True, **kwargs)(inner)
 
     return decorator
 
@@ -203,7 +203,7 @@ class Transform(QTransform):
         """Size of the transformed image."""
         return self.current.size()
 
-    @api.commands.register(mode=api.modes.IMAGE)
+    @register_transform_command()
     def undo_transformations(self):
         """Undo any transformation applied to the current image."""
         self.reset()


### PR DESCRIPTION
As described in #368 this adds a new `read_only` setting. When active, all commands that may write changes to disk are disabled.

I decided to implement this as a setting instead of a plain parser flag, as settings are nicely available everywhere using the existing settings api. I have to admit that `vimiv -s read_only true` or `vimiv -s read_only 1` is certainly more typing than a simple `vimiv -R` though. @willemw12, do you think the flag should be added in addition? I usually prefer not to do this, as it becomes difficult to decide which settings should also have parser flags, and which should not.

Another open question is how to deal with shell commands. Currently both `:!` and `:spawn` are available when `read_only` is active. This is somewhat borderline as they can obviously make changes to disk. On the other hand, I don't ever see this happening accidentally, and there are clearly also commands that do not write to disk. Any thoughts?