### PR TITLE
FIX: Piexif unsupported filetype

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -53,6 +53,7 @@ Fixed:
 * Expanding tilde to home directory when using the ``:write`` command. Thanks
   `@jcjgraf`_ for pointing this out!
 * Completion for aliases.
+* Crash when extracting metadata using piexif from a non JPEG or TIFF image. Thanks `@BachoSeven`_ for pointing this out!
 
 
 v0.8.0 (2021-01-18)

--- a/docs/documentation/exif.rst
+++ b/docs/documentation/exif.rst
@@ -14,8 +14,9 @@ this is the case:
 Advantages of the different exif libraries
 ------------------------------------------
 
-`Pyexiv2`_ is the more powerful of the two options. One large advantage is that with
-pyexiv2 ``:metadata`` formats exif data into human readable format, for example
+`Pyexiv2`_ is the more powerful of the two options. One large advantage is that it
+supports not only JPEG and TIFF images, but most common file types. In addition,
+with pyexiv2 ``:metadata`` formats exif data into human readable format, for example
 ``FocalLength: 5.0 mm`` where `piexif`_ would only give ``FocalLength: 5.0``. However,
 given it is written as python bindings to the c++ api of `exiv2`_, the installation is
 more involved compared to the pure python `piexif`_ module.


### PR DESCRIPTION
Upon loading metadata information of a image with a type not supported by `piexif` a not caught exception was raised.

Fixes #370 
Thanks @BachoSeven for pointing this out!

@karlch  If you find the warning too verbose we can also get rid of it.