### PR TITLE
Mention new Video plugin in docs

### DIFF
--- a/docs/documentation/configuration/plugins.rst
+++ b/docs/documentation/configuration/plugins.rst
@@ -20,6 +20,8 @@ Currently the following user plugins are available:
 * `Importer <https://github.com/jcjgraf/Importer>`_ to easily import your images from a
   SD card, camera or any directory into your photo storage.
 * `BatchMark <https://github.com/jcjgraf/BatchMark>`_ to easily mark contiguous images.
+* `Video <https://github.com/jcjgraf/Video>`_ for video support. Videos are listed
+  within vimiv and can be played using an external player.
 
 If you would like to write a plugin, some of the information on :ref:`writing_plugins`
 may be helpful to get started.


### PR DESCRIPTION
I have written a little plugin which adds *Video Support* to vimiv. Videos are listed within vimiv (this way i do not miss then when copying images from my SD card using vimiv :blush:) and can be played using an external player like MPV or something.

At the time, only QuickTime Movie (`.mov`) is supported but I intend to add new formats soon.

P.S. is there a particular reason why in the docs the default plugins are listed in a table and the user plugins in a list? I think a table looks much nicer.
