### PR TITLE
Change mouse scroll behaviour in library

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -59,6 +59,8 @@ Changed:
 * New set of default metadata key sets numbered from 1 to 5. Thanks `@jcjgraf`_!
 * When toggling ``library.show_hidden`` the selection now stays on the same file, not
   the same index.
+* Using the mouse to scroll in the library now changes the selection instead of just
+  scrolling the view.
 
 Fixed:
 ^^^^^^

--- a/vimiv/gui/library.py
+++ b/vimiv/gui/library.py
@@ -347,6 +347,14 @@ class Library(
         if open_selected_image and not os.path.isdir(current):
             self.open_selected(close=False)
 
+    def wheelEvent(self, event):
+        """Update mouse wheel for proper scrolling."""
+        steps = int(event.angleDelta().y() / 120)
+        if steps < 0:
+            self.scroll(argtypes.DirectionWithPage.Down, count=abs(steps))
+        else:
+            self.scroll(argtypes.DirectionWithPage.Up, count=steps)
+
 
 class LibraryModel(QStandardItemModel):
     """Model used for the library.

--- a/vimiv/gui/library.py
+++ b/vimiv/gui/library.py
@@ -359,15 +359,21 @@ class Library(
             self.open_selected(close=False)
 
     def wheelEvent(self, event):
-        """Update mouse wheel for proper scrolling."""
+        """Update mouse wheel for proper scrolling.
+
+        We accumulate steps until we have enough to scroll up / down by one row. For
+        regular mice one "roll" should result in a single scroll. Finer grained devices
+        such as touchpads need this cumulative approach.
+
+        See https://doc.qt.io/qt-5/qwheelevent.html#angleDelta for more details.
+        """
         self._scroll_step += event.angleDelta().y() / 120
         steps = int(self._scroll_step)
         if steps < 0:
             self.scroll(argtypes.DirectionWithPage.Down, count=abs(steps))
         else:
             self.scroll(argtypes.DirectionWithPage.Up, count=steps)
-        if steps != 0:
-            self._scroll_step = self._scroll_step - steps
+        self._scroll_step = self._scroll_step - steps
         self._scroll_timer.start()
 
 


### PR DESCRIPTION
As this has come up both in #136 and in the recent youtube video, I went ahead and changed the behaviour of scrolling with the mouse in the library. Instead of just scrolling the view, it now changes the selection. Personally I have no preference, as I almost never use the mouse, and felt one can always click wherever one wants when scrolling the view.

@jcjgraf @BachoSeven any thoughts if this version would be preferable?