### PR TITLE
Command to print to STDOUT

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -52,6 +52,9 @@ Added:
   Thanks `@willemw12`_ for the idea!
 * The ``zh`` keybinding to toggle hidden files.
   Thanks `@Kakupakat`_ for the idea!
+* The ``:print-stdout`` command which prints a given list of string to the STDOUT.
+* The ``:mark-print`` default alias which prints all marked images to STDOUT using
+  ``:print-stdout``.
 
 Changed:
 ^^^^^^^^

--- a/tests/end2end/features/api/print.feature
+++ b/tests/end2end/features/api/print.feature
@@ -1,0 +1,42 @@
+Feature: Print to STDOUT
+
+    Scenario: Print trivial list
+        Given I start vimiv
+        And I capture output
+        When I run print-stdout "test"
+        Then stdout should contain 'test'
+
+    Scenario: Print longer list
+        Given I start vimiv
+        And I capture output
+        When I run print-stdout "test1" "test2"
+        Then stdout should contain 'test1'
+        And stdout should contain 'test2'
+
+    Scenario: Print list using sep
+        Given I start vimiv
+        And I capture output
+        When I run print-stdout "test1" "test2" --sep ','
+        Then stdout should contain 'test1,test2'
+
+    Scenario: Print list using end
+        Given I start vimiv
+        And I capture output
+        When I run print-stdout "test1" "test2" --end 'xxx\n'
+        Then stdout should contain 'test2xxx'
+
+    Scenario: Print marked images
+        Given I open 2 images
+        And I capture output
+        When I run mark image_01.jpg image_02.jpg
+        And I run print-stdout %m
+        Then stdout should contain 'image_01.jpg'
+        And stdout should contain 'image_02.jpg'
+
+    Scenario: Print marked images using alias
+        Given I open 2 images
+        And I capture output
+        When I run mark image_01.jpg image_02.jpg
+        And I run mark-print
+        Then stdout should contain 'image_01.jpg'
+        And stdout should contain 'image_02.jpg'

--- a/tests/end2end/features/api/test_print_bdd.py
+++ b/tests/end2end/features/api/test_print_bdd.py
@@ -1,0 +1,10 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2021 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+import pytest_bdd as bdd
+
+
+bdd.scenarios("print.feature")

--- a/vimiv/api/_modules.py
+++ b/vimiv/api/_modules.py
@@ -243,6 +243,22 @@ def mark_rename(
     )
 
 
+@api.commands.register()
+def print_stdout(text: List[str], sep: str = "\n", end: str = "\n") -> None:
+    """Print text to the terminal.
+
+    **syntax:** ``:print-stdout text [--sep] [--end]``
+
+    positional arguments:
+        * ``text``: List of strings to concatenate and print
+
+    optional arguments:
+        * ``--sep``: String inserted between list element, default is new line.
+        * ``--end``: String appended after last element, default is new line.
+    """
+    print(*text, sep=sep, end=end)
+
+
 ###############################################################################
 #                               Status Modules                                #
 ###############################################################################

--- a/vimiv/commands/aliases.py
+++ b/vimiv/commands/aliases.py
@@ -19,7 +19,7 @@ Aliases = Dict[str, str]
 
 _aliases: Dict[api.modes.Mode, Aliases] = {mode: {} for mode in api.modes.ALL}
 # Add default aliases
-_aliases[api.modes.GLOBAL].update(q="quit")
+_aliases[api.modes.GLOBAL].update({"q": "quit", "mark-print": "print-stdout %m"})
 _aliases[api.modes.IMAGE].update(w="write", wq="write && quit")
 
 


### PR DESCRIPTION
Adds the new command `print-stdout` to print to STDOUT from within vimiv, and an alias to print all marked images.

~Implements #379~