### PR TITLE
Vimiv as pipe

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -55,6 +55,9 @@ Added:
 * The ``:print-stdout`` command which prints a given list of string to the STDOUT.
 * The ``:mark-print`` default alias which prints all marked images to STDOUT using
   ``:print-stdout``.
+* The ``-o TEXT`` flag to print ``TEXT`` to standard output before exit. Wildcards are
+  expanded before printing, allowing to for example print marked files using ``-o %m``.
+* The ``-i`` flag to read paths to open from standard input instead.
 
 Changed:
 ^^^^^^^^

--- a/tests/end2end/features/misc/startup.feature
+++ b/tests/end2end/features/misc/startup.feature
@@ -37,3 +37,9 @@ Feature: Startup vimiv with various flags
     Scenario: Open hidden image upon startup
         Given I open the image '.hidden.jpg'
         Then the filelist should contain 1 images
+
+    Scenario: Pipe paths to vimiv
+        Given I patch stdin for 3 images
+        And I open 5 images with -i
+        # Pipe takes preference over regular filelist with -i
+        Then the filelist should contain 3 images

--- a/tests/end2end/features/misc/teardown.feature
+++ b/tests/end2end/features/misc/teardown.feature
@@ -1,0 +1,21 @@
+Feature: Various features related to teardown
+
+    Scenario: Print text to stdout upon quit
+        Given I start vimiv with -o vimiv
+        And I capture output
+        When I quit the application
+        Then stdout should contain 'vimiv'
+
+    Scenario: Print current path to stdout upon quit
+        Given I open 2 images with -o %
+        And I capture output
+        When I quit the application
+        Then stdout should contain 'image_01.jpg'
+
+    Scenario: Print marked images to stdout upon quit
+        Given I open 2 images with -o %m
+        And I capture output
+        When I run mark *
+        And I quit the application
+        Then stdout should contain 'image_01.jpg'
+        And stdout should contain 'image_02.jpg'

--- a/tests/end2end/features/misc/test_startup_bdd.py
+++ b/tests/end2end/features/misc/test_startup_bdd.py
@@ -4,7 +4,9 @@
 # Copyright 2017-2021 Christian Karl (karlch) <karlch at protonmail dot com>
 # License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
 
+import io
 import logging
+import sys
 
 import pytest_bdd as bdd
 
@@ -13,6 +15,13 @@ from vimiv.utils import log
 
 
 bdd.scenarios("startup.feature")
+
+
+@bdd.given(bdd.parsers.parse("I patch stdin for {n_images:d} images"))
+def patch_stdin(monkeypatch, tmp_path, n_images):
+    paths = [tmp_path / f"image_{i:02d}.jpg\n" for i in range(1, n_images + 1)]
+    stdin = io.StringIO("".join(str(path) for path in paths))
+    monkeypatch.setattr(sys, "stdin", stdin)
 
 
 @bdd.then("the version information should be displayed")

--- a/tests/end2end/features/misc/test_teardown_bdd.py
+++ b/tests/end2end/features/misc/test_teardown_bdd.py
@@ -1,0 +1,15 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2021 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+import pytest_bdd as bdd
+
+
+bdd.scenarios("teardown.feature")
+
+
+@bdd.when("I quit the application")
+def quit_application(qapp):
+    qapp.aboutToQuit.emit()

--- a/vimiv/parser.py
+++ b/vimiv/parser.py
@@ -86,6 +86,13 @@ def get_argparser() -> argparse.ArgumentParser:
         "--output",
         help="Wildcard expanded string to print to standard output upon quit",
     )
+    parser.add_argument(
+        "-i",
+        "--input",
+        action="store_true",
+        help="Read paths to open from standard input",
+        dest="stdinput",
+    )
 
     devel = parser.add_argument_group("development arguments")
     devel.add_argument(

--- a/vimiv/parser.py
+++ b/vimiv/parser.py
@@ -81,6 +81,11 @@ def get_argparser() -> argparse.ArgumentParser:
     parser.add_argument(
         "paths", nargs="*", type=existing_path, metavar="PATH", help="Paths to open"
     )
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Wildcard expanded string to print to standard output upon quit",
+    )
 
     devel = parser.add_argument_group("development arguments")
     devel.add_argument(

--- a/vimiv/startup.py
+++ b/vimiv/startup.py
@@ -15,13 +15,13 @@ import argparse
 import os
 import sys
 import tempfile
-from typing import List
+from typing import cast, List
 
-from PyQt5.QtCore import QSize
+from PyQt5.QtCore import QSize, QCoreApplication
 from PyQt5.QtWidgets import QApplication
 
 from vimiv import app, api, parser, imutils, plugins
-from vimiv.commands import runners, search
+from vimiv.commands import runners, search, wildcards
 from vimiv.config import configfile, keyfile, styles
 from vimiv.gui import mainwindow
 from vimiv.utils import xdg, crash_handler, log, trash_manager, customtypes, migration
@@ -88,6 +88,14 @@ def setup_post_app(args: argparse.Namespace) -> None:
     init_paths(args)
     if args.command:
         run_startup_commands(*args.command)
+    if args.output:
+
+        def print_output() -> None:
+            print(wildcards.expand_internal(args.output, api.modes.current()))
+
+        # We are sure we have an application here
+        qapp = cast(QApplication, QCoreApplication.instance())
+        qapp.aboutToQuit.connect(print_output)
 
 
 def init_directories(args: argparse.Namespace) -> None:

--- a/vimiv/startup.py
+++ b/vimiv/startup.py
@@ -121,8 +121,14 @@ def init_directories(args: argparse.Namespace) -> None:
 def init_paths(args: argparse.Namespace) -> None:
     """Open paths given from commandline or fallback to library if set."""
     _logger.debug("Opening paths")
+    read_stdin = args.stdinput and not sys.stdin.isatty()
+    paths = (
+        [os.path.realpath(line.strip()) for line in sys.stdin]
+        if read_stdin
+        else args.paths
+    )
     try:
-        api.open_paths(args.paths)
+        api.open_paths(paths)
     except api.commands.CommandError:
         _logger.debug("init_paths: No valid paths retrieved")
         if api.settings.startup_library.value:


### PR DESCRIPTION
After better understanding the idea behind #379 I went ahead and added the `-i` and `-o` flags. The described workflow with "vimiv as pipe" to select images should now be possible using:
```bash
SELECTED=$(find images -type f | vimiv -i -o "%m" --command "enter thumbnail")
```

Any feedback would be welcome @jcjgraf and @loiccoyle as I don't really use this type of a workflow myself :blush:

TODO:
- [x] Tests
- [x] Think about paths with special characters, e.g. whitespace. Currently they are quoted as usual, e.g. `'path with space'`