### PR TITLE
Adopt mouse scroll behaviour of library mode for thumbnail mode

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -65,8 +65,8 @@ Changed:
 * New set of default metadata key sets numbered from 1 to 5. Thanks `@jcjgraf`_!
 * When toggling ``library.show_hidden`` the selection now stays on the same file, not
   the same index.
-* Using the mouse to scroll in the library now changes the selection instead of just
-  scrolling the view.
+* Using the mouse to scroll in library and thumbnail mode now changes the selection
+  instead of just scrolling the view.
 
 Fixed:
 ^^^^^^

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,6 +34,8 @@ Added:
     image mode.
   * ``<button-forward>`` and ``<button-back>`` to scroll down/up and open any selected
     image in library mode.
+  * ``<button-forward>`` and ``<button-back>`` select the next/previous thumbnail in
+    thumnbail mode.
 
   Thanks `@BachoSeven`_ for your thoughts!
 * The ``:copy-image`` command which copies the selected image to the clipboard. The
@@ -66,7 +68,8 @@ Changed:
 * When toggling ``library.show_hidden`` the selection now stays on the same file, not
   the same index.
 * Using the mouse to scroll in library and thumbnail mode now changes the selection
-  instead of just scrolling the view.
+  instead of just scrolling the view. Horizontal scrolling in thumbnail mode is
+  supported.
 
 Fixed:
 ^^^^^^

--- a/vimiv/gui/library.py
+++ b/vimiv/gui/library.py
@@ -352,12 +352,12 @@ class Library(
         if open_selected_image and not os.path.isdir(current):
             self.open_selected(close=False)
 
-    def _scroll_wheel_callback(self, steps):
+    def _scroll_wheel_callback(self, _steps_x, steps_y):
         """Callback function used by the scroll wheel mixin for mouse scrolling."""
-        if steps < 0:
-            self.scroll(argtypes.DirectionWithPage.Down, count=abs(steps))
-        else:
-            self.scroll(argtypes.DirectionWithPage.Up, count=steps)
+        if steps_y < 0:
+            self.scroll(argtypes.DirectionWithPage.Down, count=abs(steps_y))
+        elif steps_y > 0:
+            self.scroll(argtypes.DirectionWithPage.Up, count=steps_y)
 
 
 class LibraryModel(QStandardItemModel):

--- a/vimiv/gui/library.py
+++ b/vimiv/gui/library.py
@@ -11,7 +11,7 @@ import math
 import os
 from typing import List, Optional, Dict, NamedTuple
 
-from PyQt5.QtCore import Qt, QTimer, pyqtSlot
+from PyQt5.QtCore import Qt, pyqtSlot
 from PyQt5.QtWidgets import QStyledItemDelegate, QSizePolicy, QStyle
 from PyQt5.QtGui import QStandardItemModel, QColor, QTextDocument, QStandardItem
 
@@ -38,15 +38,16 @@ class Position(NamedTuple):
 
 
 class Library(
-    eventhandler.EventHandlerMixin, widgets.GetNumVisibleMixin, widgets.FlatTreeView
+    eventhandler.EventHandlerMixin,
+    widgets.GetNumVisibleMixin,
+    widgets.ScrollWheelCumulativeMixin,
+    widgets.FlatTreeView,
 ):
     """Library widget.
 
     Attributes:
         _last_selected: Name of the path that was selected last.
         _positions: Dictionary that stores positions in directories.
-        _scroll_step: Currently unprocessed scrolling step to support finer devices.
-        _scroll_timer: Timer to reset _scroll_step after scrolling.
     """
 
     STYLESHEET = """
@@ -87,18 +88,11 @@ class Library(
     @api.modes.widget(api.modes.LIBRARY)
     @api.objreg.register
     def __init__(self, mainwindow):
-        super().__init__(parent=mainwindow)
+        widgets.ScrollWheelCumulativeMixin.__init__(self, self._scroll_wheel_callback)
+        widgets.FlatTreeView.__init__(self, parent=mainwindow)
+
         self._last_selected = ""
         self._positions: Dict[str, Position] = {}
-        self._scroll_step = 0
-        self._scroll_timer = QTimer()
-        self._scroll_timer.setInterval(100)
-        self._scroll_timer.setSingleShot(True)
-
-        def reset_scroll_step():
-            self._scroll_step = 0
-
-        self._scroll_timer.timeout.connect(reset_scroll_step)
 
         self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         self.setSizePolicy(QSizePolicy.Maximum, QSizePolicy.Ignored)
@@ -358,23 +352,12 @@ class Library(
         if open_selected_image and not os.path.isdir(current):
             self.open_selected(close=False)
 
-    def wheelEvent(self, event):
-        """Update mouse wheel for proper scrolling.
-
-        We accumulate steps until we have enough to scroll up / down by one row. For
-        regular mice one "roll" should result in a single scroll. Finer grained devices
-        such as touchpads need this cumulative approach.
-
-        See https://doc.qt.io/qt-5/qwheelevent.html#angleDelta for more details.
-        """
-        self._scroll_step += event.angleDelta().y() / 120
-        steps = int(self._scroll_step)
+    def _scroll_wheel_callback(self, steps):
+        """Callback function used by the scroll wheel mixin for mouse scrolling."""
         if steps < 0:
             self.scroll(argtypes.DirectionWithPage.Down, count=abs(steps))
         else:
             self.scroll(argtypes.DirectionWithPage.Up, count=steps)
-        self._scroll_step = self._scroll_step - steps
-        self._scroll_timer.start()
 
 
 class LibraryModel(QStandardItemModel):

--- a/vimiv/gui/thumbnail.py
+++ b/vimiv/gui/thumbnail.py
@@ -248,8 +248,12 @@ class ThumbnailView(
     )
     @api.keybindings.register("k", "scroll up", mode=api.modes.THUMBNAIL)
     @api.keybindings.register("j", "scroll down", mode=api.modes.THUMBNAIL)
-    @api.keybindings.register("h", "scroll left", mode=api.modes.THUMBNAIL)
-    @api.keybindings.register("l", "scroll right", mode=api.modes.THUMBNAIL)
+    @api.keybindings.register(
+        ("h", "<button-back>"), "scroll left", mode=api.modes.THUMBNAIL
+    )
+    @api.keybindings.register(
+        ("l", "<button-forward>"), "scroll right", mode=api.modes.THUMBNAIL
+    )
     @api.commands.register(mode=api.modes.THUMBNAIL)
     def scroll(  # type: ignore[override]
         self, direction: argtypes.DirectionWithPage, count=1

--- a/vimiv/gui/thumbnail.py
+++ b/vimiv/gui/thumbnail.py
@@ -35,6 +35,7 @@ class ThumbnailView(
     eventhandler.EventHandlerMixin,
     widgets.GetNumVisibleMixin,
     widgets.ScrollToCenterMixin,
+    widgets.ScrollWheelCumulativeMixin,
     QListWidget,
 ):
     """Thumbnail widget.
@@ -79,7 +80,9 @@ class ThumbnailView(
     @api.modes.widget(api.modes.THUMBNAIL)
     @api.objreg.register
     def __init__(self):
-        super().__init__()
+        widgets.ScrollWheelCumulativeMixin.__init__(self, self._scroll_wheel_callback)
+        QListWidget.__init__(self)
+
         self._paths: List[str] = []
 
         fail_pixmap = create_pixmap(
@@ -422,6 +425,13 @@ class ThumbnailView(
         """Update resize event to keep selected thumbnail centered."""
         super().resizeEvent(event)
         self.scrollTo(self.currentIndex())
+
+    def _scroll_wheel_callback(self, steps):
+        """Callback function used by the scroll wheel mixin for mouse scrolling."""
+        if steps < 0:
+            self.scroll(argtypes.DirectionWithPage.Down, count=abs(steps))
+        else:
+            self.scroll(argtypes.DirectionWithPage.Up, count=steps)
 
 
 class ThumbnailDelegate(QStyledItemDelegate):

--- a/vimiv/gui/thumbnail.py
+++ b/vimiv/gui/thumbnail.py
@@ -426,12 +426,16 @@ class ThumbnailView(
         super().resizeEvent(event)
         self.scrollTo(self.currentIndex())
 
-    def _scroll_wheel_callback(self, steps):
+    def _scroll_wheel_callback(self, steps_x, steps_y):
         """Callback function used by the scroll wheel mixin for mouse scrolling."""
-        if steps < 0:
-            self.scroll(argtypes.DirectionWithPage.Down, count=abs(steps))
-        else:
-            self.scroll(argtypes.DirectionWithPage.Up, count=steps)
+        if steps_y < 0:
+            self.scroll(argtypes.DirectionWithPage.Down, count=abs(steps_y))
+        elif steps_y > 0:
+            self.scroll(argtypes.DirectionWithPage.Up, count=steps_y)
+        if steps_x < 0:
+            self.scroll(argtypes.DirectionWithPage.Right, count=abs(steps_x))
+        elif steps_x > 0:
+            self.scroll(argtypes.DirectionWithPage.Left, count=steps_x)
 
 
 class ThumbnailDelegate(QStyledItemDelegate):

--- a/vimiv/widgets.py
+++ b/vimiv/widgets.py
@@ -34,13 +34,13 @@ class ScrollWheelCumulativeMixin:
 
     def __init__(self, callback):
         self._callback = callback
-        self._scroll_step = 0
+        self._scroll_step_x = self._scroll_step_y = 0
         self._scroll_timer = QTimer()
         self._scroll_timer.setInterval(100)
         self._scroll_timer.setSingleShot(True)
 
         def reset_scroll_step():
-            self._scroll_step = 0
+            self._scroll_step_x = self._scroll_step_y = 0
 
         self._scroll_timer.timeout.connect(reset_scroll_step)
 
@@ -53,13 +53,17 @@ class ScrollWheelCumulativeMixin:
 
         See https://doc.qt.io/qt-5/qwheelevent.html#angleDelta for more details.
         """
-        self._scroll_step += event.angleDelta().y() / 120
-        steps = int(self._scroll_step)
+        self._scroll_step_x += event.angleDelta().x() / 120
+        self._scroll_step_y += event.angleDelta().y() / 120
 
-        if steps:
-            self._callback(steps)
+        steps_x = int(self._scroll_step_x)
+        steps_y = int(self._scroll_step_y)
 
-        self._scroll_step = self._scroll_step - steps
+        if steps_x or steps_y:
+            self._callback(steps_x, steps_y)
+
+        self._scroll_step_x -= steps_x
+        self._scroll_step_y -= steps_y
         self._scroll_timer.start()
 
 

--- a/vimiv/widgets.py
+++ b/vimiv/widgets.py
@@ -8,7 +8,7 @@
 
 from typing import Optional, Tuple
 
-from PyQt5.QtCore import Qt
+from PyQt5.QtCore import Qt, QTimer
 from PyQt5.QtGui import QPainter, QFontMetrics
 from PyQt5.QtWidgets import QTreeView, QAbstractItemView, QSlider, QDialog
 
@@ -21,6 +21,46 @@ class ScrollToCenterMixin:
 
     def scrollTo(self, index, _hint=None):
         super().scrollTo(index, self.PositionAtCenter)
+
+
+class ScrollWheelCumulativeMixin:
+    """Mixin class for cumulative mouse scrolling.
+
+    Attributes:
+        _callback: Function to call when an integer step is accumulated.
+        _scroll_step: Currently unprocessed scrolling step to support finer devices.
+        _scroll_timer: Timer to reset _scroll_step after scrolling.
+    """
+
+    def __init__(self, callback):
+        self._callback = callback
+        self._scroll_step = 0
+        self._scroll_timer = QTimer()
+        self._scroll_timer.setInterval(100)
+        self._scroll_timer.setSingleShot(True)
+
+        def reset_scroll_step():
+            self._scroll_step = 0
+
+        self._scroll_timer.timeout.connect(reset_scroll_step)
+
+    def wheelEvent(self, event):
+        """Update mouse wheel for proper scrolling.
+
+        We accumulate steps until we have an integer value. For regular mice one "roll"
+        should result in a single step. Finer grained devices such as touchpads need
+        this cumulative approach.
+
+        See https://doc.qt.io/qt-5/qwheelevent.html#angleDelta for more details.
+        """
+        self._scroll_step += event.angleDelta().y() / 120
+        steps = int(self._scroll_step)
+
+        if steps:
+            self._callback(steps)
+
+        self._scroll_step = self._scroll_step - steps
+        self._scroll_timer.start()
 
 
 class GetNumVisibleMixin:


### PR DESCRIPTION
I feel like this is a bit of a no-brainer, but missed this somehow when implementing the new scroll behaviour in the library in #378. Thumbnail mode now reflects these changes as well and also changes the selection when scrolling with the mouse.

Any thoughts or objections @jcjgraf @BachoSeven?