### PR TITLE
Add commandline flag to pass arguments directly to qt

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -58,6 +58,9 @@ Added:
 * The ``-o TEXT`` flag to print ``TEXT`` to standard output before exit. Wildcards are
   expanded before printing, allowing to for example print marked files using ``-o %m``.
 * The ``-i`` flag to read paths to open from standard input instead.
+* The ``--qt-args`` flag to pass arguments directly to qt. When passing multiple
+  arguments, they must be quoted accordingly, e.g.
+  ``vimiv --qt-args '--name floating'``.
 
 Changed:
 ^^^^^^^^

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -95,3 +95,17 @@ def test_parse_settings(argparser):
         arglist.extend(("-s", name, value))
     args = argparser.parse_args(arglist)
     assert args.cmd_settings == settings
+
+
+@pytest.mark.parametrize(
+    "qtargs, expected",
+    [
+        ("--name floating", ["--name", "floating"]),
+        ("--name floating --reverse", ["--name", "floating", "--reverse"]),
+        ("--name 'has space'", ["--name", "has space"]),
+    ],
+)
+def test_parse_qt_args(argparser, qtargs, expected):
+    arglist = ["--qt-args", qtargs]
+    args = argparser.parse_args(arglist)
+    assert parser.get_qt_args(args) == expected

--- a/vimiv/app.py
+++ b/vimiv/app.py
@@ -22,9 +22,14 @@ class Application(QApplication):
     """Main application class."""
 
     @api.objreg.register
-    def __init__(self) -> None:
-        """Initialize the main Qt application."""
-        super().__init__([vimiv.__name__])  # Only pass program name to Qt
+    def __init__(self, *qtargs: str) -> None:
+        """Initialize the main Qt application.
+
+        Args:
+            qtargs: Arguments passed directly to the QApplication.
+        """
+        _logger.debug("Passing %s to qt", utils.quotedjoin(qtargs))
+        super().__init__([vimiv.__name__, *qtargs])
         self.setApplicationVersion(vimiv.__version__)
         self.setDesktopFileName(vimiv.__name__)
         self._set_icon()

--- a/vimiv/parser.py
+++ b/vimiv/parser.py
@@ -10,6 +10,8 @@ import argparse
 import contextlib
 import logging
 import os
+import shlex
+from typing import List
 
 from PyQt5.QtCore import QSize
 
@@ -56,7 +58,7 @@ def get_argparser() -> argparse.ArgumentParser:
         "-s",
         "--set",
         nargs=2,
-        default=[],  # List is required for action="append"
+        default=[],  # List is required for iterating
         action="append",
         dest="cmd_settings",
         metavar=("OPTION", "VALUE"),
@@ -101,6 +103,11 @@ def get_argparser() -> argparse.ArgumentParser:
         metavar="MODULE",
         default=(),
         help="Force showing debug log messages of MODULE",
+    )
+    devel.add_argument(
+        "--qt-args",
+        metavar="ARGS",
+        help="Arguments to pass to qt directly, use quotes to pass multiple arguments",
     )
     return parser
 
@@ -177,3 +184,10 @@ def loglevel(value: str) -> int:
     with contextlib.suppress(AttributeError):
         return getattr(logging, value.upper())
     raise argparse.ArgumentTypeError(f"Invalid log level '{value}'")
+
+
+def get_qt_args(args: argparse.Namespace) -> List[str]:
+    """Retrieve list of arguments to pass to qt from argparse namespace."""
+    if args.qt_args:
+        return shlex.split(args.qt_args)
+    return []

--- a/vimiv/startup.py
+++ b/vimiv/startup.py
@@ -42,7 +42,8 @@ _logger = log.module_logger(__name__)
 def main() -> int:
     """Run startup and the Qt main loop."""
     args = setup_pre_app(sys.argv[1:])
-    qapp = app.Application()
+    qt_args = parser.get_qt_args(args)
+    qapp = app.Application(*qt_args)
     crash_handler.CrashHandler(qapp)
     setup_post_app(args)
     _logger.debug("Startup completed, starting Qt main loop")


### PR DESCRIPTION
This is a possible solution to #384 which can now be done by starting vimiv with `--qt-args '--name WM_CLASS_INSTANCE'`. The implementation here is nowhere near as complete as the one of qutebrowser, but worked fine for the simple use-cases I could think of. With this, we could even deprecate / remove the `--geometry` flag as this is now possible using `--qt-args '--geometry WIDTHxHEIGHT'`. All of this would certainly benefit from some additional examples as described in #382.

@loiccoyle maybe you could give this a try as it is based on your idea?

Fixes #384.