### PR TITLE
Setting to set the desired file ordering

### DIFF
--- a/tests/unit/api/test_settings.py
+++ b/tests/unit/api/test_settings.py
@@ -151,3 +151,21 @@ def test_ask_prompt_setting(mocker, prompt_setting, answer):
     mocker.patch("vimiv.api.prompt.ask_question", ask_question)
 
     assert bool(prompt_setting) == answer
+
+
+def test_set_order_setting():
+    o = settings.ImageOrderSetting("imageorder", "name")
+    o.value = "name-desc"
+    assert o.value == "name-desc"
+
+
+def test_set_order_setting_non_str():
+    o = settings.OrderSetting("order", "name")
+    with pytest.raises(ValueError, match="must be one of"):
+        o.value = 1
+
+
+def test_set_order_setting_non_valid():
+    o = settings.OrderSetting("order", "name")
+    with pytest.raises(ValueError, match="must be one of"):
+        o.value = "invalid"

--- a/tests/unit/api/test_settings.py
+++ b/tests/unit/api/test_settings.py
@@ -154,18 +154,18 @@ def test_ask_prompt_setting(mocker, prompt_setting, answer):
 
 
 def test_set_order_setting():
-    o = settings.ImageOrderSetting("imageorder", "name")
-    o.value = "name-desc"
-    assert o.value == "name-desc"
+    o = settings.ImageOrderSetting("imageorder", "alphabetical")
+    o.value = "alphabetical-desc"
+    assert o.value == "alphabetical-desc"
 
 
 def test_set_order_setting_non_str():
-    o = settings.OrderSetting("order", "name")
+    o = settings.OrderSetting("order", "alphabetical")
     with pytest.raises(ValueError, match="must be one of"):
         o.value = 1
 
 
 def test_set_order_setting_non_valid():
-    o = settings.OrderSetting("order", "name")
+    o = settings.OrderSetting("order", "alphabetical")
     with pytest.raises(ValueError, match="must be one of"):
         o.value = "invalid"

--- a/tests/unit/api/test_settings.py
+++ b/tests/unit/api/test_settings.py
@@ -154,7 +154,7 @@ def test_ask_prompt_setting(mocker, prompt_setting, answer):
 
 
 def test_set_order_setting():
-    o = settings.ImageOrderSetting("imageorder", "alphabetical")
+    o = settings.OrderSetting("order", "alphabetical")
     o.value = "alphabetical-desc"
     assert o.value == "alphabetical-desc"
 

--- a/tests/unit/utils/test_files.py
+++ b/tests/unit/utils/test_files.py
@@ -87,12 +87,6 @@ def test_listdir_wrapper_returns_abspath(mocker):
     assert files.listdir("directory") == expected
 
 
-def test_listdir_wrapper_sort(mocker):
-    mocker.patch("os.listdir", return_value=["b.txt", "a.txt"])
-    mocker.patch("os.path.abspath", return_value="")
-    assert files.listdir("directory") == ["a.txt", "b.txt"]
-
-
 def test_listdir_wrapper_remove_hidden(mocker):
     mocker.patch("os.listdir", return_value=[".dotfile.txt", "a.txt"])
     mocker.patch("os.path.abspath", return_value="")
@@ -120,6 +114,13 @@ def test_images_supported(mocker):
     images, directories = files.supported(["a", "b"])
     assert images == ["a", "b"]
     assert not directories
+
+
+def test_order():
+    assert files.order((["b.txt", "a.txt"], ["b", "a"])) == (
+        ["a.txt", "b.txt"],
+        ["a", "b"],
+    )
 
 
 def test_tar_gz_not_an_image(tmp_path):

--- a/tests/unit/utils/test_files.py
+++ b/tests/unit/utils/test_files.py
@@ -116,11 +116,25 @@ def test_images_supported(mocker):
     assert not directories
 
 
-def test_order():
-    assert files.order(["b.txt", "a.txt"], ["b", "a"]) == (
-        ["a.txt", "b.txt"],
-        ["a", "b"],
-    )
+@pytest.mark.parametrize(
+    "input_img, input_dir, sorted_img, sorted_dir",
+    (
+        (
+            ["a.j", "c.j", "b.j"],
+            ["a", "c", "b"],
+            ["a.j", "b.j", "c.j"],
+            ["a", "b", "c"],
+        ),
+        (
+            ["a2.j", "a3.j", "a1.j"],
+            ["a2", "a3", "a1"],
+            ["a1.j", "a2.j", "a3.j"],
+            ["a1", "a2", "a3"],
+        ),
+    ),
+)
+def test_order(input_img, input_dir, sorted_img, sorted_dir):
+    assert files.order(input_img, input_dir) == (sorted_img, sorted_dir)
 
 
 def test_tar_gz_not_an_image(tmp_path):

--- a/tests/unit/utils/test_files.py
+++ b/tests/unit/utils/test_files.py
@@ -117,7 +117,7 @@ def test_images_supported(mocker):
 
 
 def test_order():
-    assert files.order((["b.txt", "a.txt"], ["b", "a"])) == (
+    assert files.order(["b.txt", "a.txt"], ["b", "a"]) == (
         ["a.txt", "b.txt"],
         ["a", "b"],
     )

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -332,3 +332,19 @@ def test_is_hex_true(text):
 @pytest.mark.parametrize("text", ("00x234", "0xGC7", "not-hex", "A-67", "a:9e"))
 def test_is_hex_false(text):
     assert not utils.is_hex(text)
+
+
+@pytest.mark.parametrize(
+    "input_list, sorted_list",
+    (
+        (["a100a", "a10a", "a1a"], ["a1a", "a10a", "a100a"]),
+        (
+            ["a10a1a", "a1a10a", "a10a10a", "a1a1a"],
+            ["a1a1a", "a1a10a", "a10a1a", "a10a10a"],
+        ),
+        (["100", "50", "10", "20"], ["10", "20", "50", "100"]),
+        (["aa", "a", "aaa"], ["a", "aa", "aaa"]),
+    ),
+)
+def test_natural_sort(input_list, sorted_list):
+    assert sorted(input_list, key=utils.natural_sort) == sorted_list

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -13,7 +13,8 @@ Module attributes:
 import abc
 import contextlib
 import enum
-from typing import Any, Dict, ItemsView, List
+from typing import Any, Dict, ItemsView, List, Callable, Tuple
+import os
 
 from PyQt5.QtCore import QObject, pyqtSignal
 
@@ -315,6 +316,37 @@ class StrSetting(Setting):
         return "String"
 
 
+class ImageOrderSetting(Setting):
+    """Stores a image ordering setting."""
+
+    typ = str
+
+    ORDER_TYPES = {
+        "name": (os.path.basename, False),
+        "name-desc": (os.path.basename, True),
+        "modify": (os.path.getmtime, False),
+        "modify-desc": (os.path.getmtime, True),
+        "size": (os.path.getsize, False),
+        "size-desc": (os.path.getsize, True),
+    }
+
+    def convert(self, value: str) -> str:
+        if value not in self.ORDER_TYPES:
+            raise ValueError(f"Option must be one of {', '.join(self.ORDER_TYPES)}")
+
+        return value
+
+    def get_para(self) -> Tuple[Callable[..., Any], bool]:
+        """Returns the ordering parameters according to the current set value."""
+        try:
+            return self.ORDER_TYPES[self.value]
+        except KeyError:
+            raise ValueError(f"Option must be one of {', '.join(self.ORDER_TYPES)}")
+
+    def __str__(self) -> str:
+        return "ImageOrder"
+
+
 # Initialize all settings
 
 monitor_fs = BoolSetting(
@@ -333,6 +365,7 @@ style = StrSetting("style", "default", hidden=True)
 read_only = BoolSetting(
     "read_only", False, desc="Disable any commands that are able to edit files on disk"
 )
+image_order = ImageOrderSetting("image_order", "name", desc="Set ordering.",)
 
 
 class command:  # pylint: disable=invalid-name

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -359,14 +359,14 @@ class ImageOrderSetting(OrderSetting):
     """Stores an image ordering setting."""
 
     ORDER_TYPES = {
-        "name": (os.path.basename, False),
-        "name-desc": (os.path.basename, True),
-        "name-natural": (OrderSetting._natural_sort, False),
-        "name-natural-desc": (OrderSetting._natural_sort, True),
-        "modify": (os.path.getmtime, False),
-        "modify-desc": (os.path.getmtime, True),
-        "size": (os.path.getsize, False),
-        "size-desc": (os.path.getsize, True),
+        "alphabetical": (os.path.basename, False),
+        "alphabetical-desc": (os.path.basename, True),
+        "natural": (OrderSetting._natural_sort, False),
+        "natural-desc": (OrderSetting._natural_sort, True),
+        "recently-modify-first": (os.path.getmtime, False),
+        "recently-modify-last": (os.path.getmtime, True),
+        "smallest-first": (os.path.getsize, False),
+        "largest-first": (os.path.getsize, True),
     }
 
     def __str__(self) -> str:
@@ -377,14 +377,14 @@ class DirectoryOrderSetting(OrderSetting):
     """Stores an directory ordering setting."""
 
     ORDER_TYPES = {
-        "name": (os.path.basename, False),
-        "name-desc": (os.path.basename, True),
-        "name-natural": (OrderSetting._natural_sort, False),
-        "name-natural-desc": (OrderSetting._natural_sort, True),
-        "modify": (os.path.getmtime, False),
-        "modify-desc": (os.path.getmtime, True),
-        "size": (lambda e: len(os.listdir(e)), True),
-        "size-desc": (lambda e: len(os.listdir(e)), False),
+        "alphabetical": (os.path.basename, False),
+        "alphabetical-desc": (os.path.basename, True),
+        "natural": (OrderSetting._natural_sort, False),
+        "natural-desc": (OrderSetting._natural_sort, True),
+        "recently-modify-first": (os.path.getmtime, False),
+        "recently-modify-last": (os.path.getmtime, True),
+        "smallest-first": (lambda e: len(os.listdir(e)), True),
+        "largest-first": (lambda e: len(os.listdir(e)), False),
     }
 
     def __str__(self) -> str:
@@ -409,9 +409,11 @@ style = StrSetting("style", "default", hidden=True)
 read_only = BoolSetting(
     "read_only", False, desc="Disable any commands that are able to edit files on disk"
 )
-image_order = ImageOrderSetting("image_order", "name", desc="Set image ordering.",)
+image_order = ImageOrderSetting(
+    "image_order", "alphabetical", desc="Set image ordering.",
+)
 directory_order = DirectoryOrderSetting(
-    "directory_order", "name", desc="Set directory ordering.",
+    "directory_order", "alphabetical", desc="Set directory ordering.",
 )
 
 

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -13,9 +13,9 @@ Module attributes:
 import abc
 import contextlib
 import enum
-from typing import Any, Dict, ItemsView, List, Callable, Tuple, Union
 import os
 import re
+from typing import Any, Dict, ItemsView, List, Callable, Tuple, Union
 
 from PyQt5.QtCore import QObject, pyqtSignal
 

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -13,8 +13,9 @@ Module attributes:
 import abc
 import contextlib
 import enum
-from typing import Any, Dict, ItemsView, List, Callable, Tuple
+from typing import Any, Dict, ItemsView, List, Callable, Tuple, Union
 import os
+import re
 
 from PyQt5.QtCore import QObject, pyqtSignal
 
@@ -338,6 +339,18 @@ class OrderSetting(Setting):
     def suggestions(self) -> List[str]:
         return [str(value) for value in self.ORDER_TYPES]
 
+    @staticmethod
+    def _natural_sort(text: str) -> List[Union[str, int]]:
+        """Key function for natural sort.
+
+        Credits to https://stackoverflow.com/a/5967539/5464989
+        """
+
+        def convert(t: str) -> Union[str, int]:
+            return int(t) if t.isdigit() else t
+
+        return [convert(c) for c in re.split(r"(\d+)", text)]
+
     def __str__(self) -> str:
         return "Order"
 
@@ -348,6 +361,8 @@ class ImageOrderSetting(OrderSetting):
     ORDER_TYPES = {
         "name": (os.path.basename, False),
         "name-desc": (os.path.basename, True),
+        "name-natural": (OrderSetting._natural_sort, False),
+        "name-natural-desc": (OrderSetting._natural_sort, True),
         "modify": (os.path.getmtime, False),
         "modify-desc": (os.path.getmtime, True),
         "size": (os.path.getsize, False),
@@ -364,6 +379,8 @@ class DirectoryOrderSetting(OrderSetting):
     ORDER_TYPES = {
         "name": (os.path.basename, False),
         "name-desc": (os.path.basename, True),
+        "name-natural": (OrderSetting._natural_sort, False),
+        "name-natural-desc": (OrderSetting._natural_sort, True),
         "modify": (os.path.getmtime, False),
         "modify-desc": (os.path.getmtime, True),
         "size": (lambda e: len(os.listdir(e)), True),

--- a/vimiv/api/working_directory.py
+++ b/vimiv/api/working_directory.py
@@ -110,6 +110,7 @@ class WorkingDirectoryHandler(QFileSystemWatcher):
 
         settings.monitor_fs.changed.connect(self._on_monitor_fs_changed)
         settings.image_order.changed.connect(self._reload_directory)
+        settings.directory_order.changed.connect(self._reload_directory)
         # TODO Fix upstream and open PR
         self.directoryChanged.connect(self._reload_directory)  # type: ignore
         self.fileChanged.connect(self._on_file_changed)  # type: ignore
@@ -225,7 +226,7 @@ class WorkingDirectoryHandler(QFileSystemWatcher):
         """
         show_hidden = settings.library.show_hidden.value
         paths = files.listdir(directory, show_hidden=show_hidden)
-        return files.supported(paths)
+        return files.order(files.supported(paths))
 
 
 handler = cast(WorkingDirectoryHandler, None)

--- a/vimiv/api/working_directory.py
+++ b/vimiv/api/working_directory.py
@@ -109,6 +109,7 @@ class WorkingDirectoryHandler(QFileSystemWatcher):
         self._directories: List[str] = []
 
         settings.monitor_fs.changed.connect(self._on_monitor_fs_changed)
+        settings.image_order.changed.connect(self._reload_directory)
         # TODO Fix upstream and open PR
         self.directoryChanged.connect(self._reload_directory)  # type: ignore
         self.fileChanged.connect(self._on_file_changed)  # type: ignore

--- a/vimiv/api/working_directory.py
+++ b/vimiv/api/working_directory.py
@@ -221,12 +221,12 @@ class WorkingDirectoryHandler(QFileSystemWatcher):
         """Get supported content of directory.
 
         Returns:
-            images: List of images inside the directory.
-            directories: List of directories inside the directory.
+            images: Ordered list of images inside the directory.
+            directories: Ordered list of directories inside the directory.
         """
         show_hidden = settings.library.show_hidden.value
         paths = files.listdir(directory, show_hidden=show_hidden)
-        return files.order(files.supported(paths))
+        return files.order(*files.supported(paths))
 
 
 handler = cast(WorkingDirectoryHandler, None)

--- a/vimiv/utils/__init__.py
+++ b/vimiv/utils/__init__.py
@@ -526,3 +526,15 @@ class Throttle(QTimer):
         """Stop all running throttles."""
         for throttle in cls.throttles:
             throttle.stop()
+
+
+def natural_sort(text: str) -> typing.List[typing.Union[str, int]]:
+    """Key function for natural sort.
+
+    Credits to https://stackoverflow.com/a/5967539/5464989
+    """
+
+    def convert(t: str) -> typing.Union[str, int]:
+        return int(t) if t.isdigit() else t
+
+    return [convert(c) for c in re.split(r"(\d+)", text)]

--- a/vimiv/utils/files.py
+++ b/vimiv/utils/files.py
@@ -28,7 +28,7 @@ def listdir(directory: str, show_hidden: bool = False) -> List[str]:
         directory: Directory to check for files in via os.listdir(directory).
         show_hidden: Include hidden files in output.
     Returns:
-        Sorted list of files in the directory with their absolute path.
+        List of files in the directory with their absolute path.
     """
     directory = os.path.abspath(os.path.expanduser(directory))
     order_function, reverse = api.settings.image_order.get_para()
@@ -59,6 +59,26 @@ def supported(paths: Iterable[str]) -> Tuple[List[str], List[str]]:
             directories.append(path)
         elif is_image(path):
             images.append(path)
+    return images, directories
+
+
+def order(files: Tuple[List[str], List[str]]) -> Tuple[List[str], List[str]]:
+    """Orders images and directories according to the settings.
+
+    Args:
+        files: Tuple of list of images and list of directories.
+    Returns:
+        images: Ordered list of images.
+        directories: Orderd list of directories.
+    """
+
+    images, directories = files
+
+    image_order, image_reverse = api.settings.image_order.get_para()
+    directory_order, directory_reverse = api.settings.directory_order.get_para()
+    images = sorted(images, key=image_order, reverse=image_reverse)
+    directories = sorted(directories, key=directory_order, reverse=directory_reverse)
+
     return images, directories
 
 

--- a/vimiv/utils/files.py
+++ b/vimiv/utils/files.py
@@ -15,6 +15,8 @@ from PyQt5.QtGui import QImageReader
 
 from vimiv.utils import imagereader
 
+from vimiv import api
+
 
 ImghdrTestFuncT = Callable[[bytes, Optional[BinaryIO]], bool]
 
@@ -29,10 +31,15 @@ def listdir(directory: str, show_hidden: bool = False) -> List[str]:
         Sorted list of files in the directory with their absolute path.
     """
     directory = os.path.abspath(os.path.expanduser(directory))
+    order_function, reverse = api.settings.image_order.get_para()
     return sorted(
-        os.path.join(directory, path)
-        for path in os.listdir(directory)
-        if show_hidden or not path.startswith(".")
+        [
+            os.path.join(directory, path)
+            for path in os.listdir(directory)
+            if show_hidden or not path.startswith(".")
+        ],
+        key=order_function,
+        reverse=reverse,
     )
 
 

--- a/vimiv/utils/files.py
+++ b/vimiv/utils/files.py
@@ -62,7 +62,7 @@ def supported(paths: Iterable[str]) -> Tuple[List[str], List[str]]:
     return images, directories
 
 
-def order(files: Tuple[List[str], List[str]]) -> Tuple[List[str], List[str]]:
+def order(images: List[str], directories: List[str]) -> Tuple[List[str], List[str]]:
     """Orders images and directories according to the settings.
 
     Args:
@@ -71,8 +71,6 @@ def order(files: Tuple[List[str], List[str]]) -> Tuple[List[str], List[str]]:
         images: Ordered list of images.
         directories: Orderd list of directories.
     """
-
-    images, directories = files
 
     image_order, image_reverse = api.settings.image_order.get_para()
     directory_order, directory_reverse = api.settings.directory_order.get_para()


### PR DESCRIPTION
Adds settings to specify the desired ordering of the images and the desired order of folders.

Todo:
- [x] Seperate options for folder and images
- [x] `Size` for directory not working
- [x] Alias to conveniently change the ordering; @karlch do you like them or shall I get rid of them again?
- [ ] Implement other types of ordering. @all any ideas?
- [ ] Test
    - [x] Unit test natural sort
    - [ ] files.order using mock
    - [x] OrderSetting
    - [ ] end2end 
- [ ] Changelog

Partially based on #76. Some code was taken directly from there

resolves #75
