### PR TITLE
Fix statusbar inconsistencies

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -64,6 +64,8 @@ Added:
   arguments, they must be quoted accordingly, e.g.
   ``vimiv --qt-args '--name floating'``.
   Thanks `@loiccoyle`_ for the discussion!
+* Statusbar modules ``name``, ``thumbnail-basename``, ``extension`` and
+  ``thumbnail-extension``.
 
 Changed:
 ^^^^^^^^
@@ -73,6 +75,8 @@ Changed:
   the same index.
 * Using the mouse to scroll in the library now changes the selection instead of just
   scrolling the view.
+* Default statusbar module ``thumbnail-name`` was changed to ``thumbnail-basename`` for
+  ``left_thumbnail``.
 
 Fixed:
 ^^^^^^
@@ -85,6 +89,7 @@ Fixed:
 * Crash when extracting metadata using piexif from a non JPEG or TIFF image. Thanks `@BachoSeven`_ for pointing this out!
 * Crash when searching in a symlinked directory. Thanks `@BachoSeven`_ for pointing this
   out!
+* Inconsistencies between the base status bar module and the thumbnail- modules.
 
 
 v0.8.0 (2021-01-18)

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -451,7 +451,7 @@ class statusbar:  # pylint: disable=invalid-name
     )
     StrSetting(
         "statusbar.left_thumbnail",
-        "{thumbnail-index}/{thumbnail-total} {thumbnail-name}{read-only}",
+        "{thumbnail-index}/{thumbnail-total} {thumbnail-basename}{read-only}",
     )
     StrSetting(
         "statusbar.left_manipulate",

--- a/vimiv/gui/thumbnail.py
+++ b/vimiv/gui/thumbnail.py
@@ -379,14 +379,31 @@ class ThumbnailView(
         padding = int(styles.get("thumbnail.padding").replace("px", ""))
         return self.iconSize().width() + 2 * padding
 
-    @api.status.module("{thumbnail-name}")
-    def _thumbnail_name(self):
-        """Name of the currently selected thumbnail."""
+    @api.status.module("{thumbnail-basename}")
+    def _thumbnail_basename(self):
+        """Basename of the currently selected thumbnail."""
         try:
             abspath = self._paths[self.current_index()]
             basename = os.path.basename(abspath)
-            name, _ = os.path.splitext(basename)
+            return basename
+        except IndexError:
+            return ""
+
+    @api.status.module("{thumbnail-name}")
+    def _thumbnail_name(self):
+        """Name without extension of the currently selected thumbnail."""
+        try:
+            name, _ = os.path.splitext(self._thumbnail_basename())
             return name
+        except IndexError:
+            return ""
+
+    @api.status.module("{thumbnail-extension}")
+    def _thumbnail_extension(self):
+        """Extension of the currently selected thumbnail."""
+        try:
+            _, extension = os.path.splitext(self._thumbnail_basename())
+            return extension.replace(".", "")
         except IndexError:
             return ""
 
@@ -411,7 +428,7 @@ class ThumbnailView(
     @api.status.module("{thumbnail-index}")
     def current_index_statusbar(self) -> str:
         """Index of the currently selected thumbnail."""
-        return str(self.current_index() + 1)
+        return str(self.current_index() + 1).zfill(len(self.total()))
 
     @api.status.module("{thumbnail-total}")
     def total(self):

--- a/vimiv/imutils/filelist.py
+++ b/vimiv/imutils/filelist.py
@@ -104,6 +104,20 @@ def basename() -> str:
     return os.path.basename(current())
 
 
+@api.status.module("{name}")
+def name() -> str:
+    """Name without extension of the current image."""
+    filename, _ = os.path.splitext(basename())
+    return filename
+
+
+@api.status.module("{extension}")
+def extension() -> str:
+    """File extension of the current image."""
+    _, fileextension = os.path.splitext(basename())
+    return fileextension.replace(".", "")
+
+
 @api.status.module("{index}")
 def get_index() -> str:  # Needs to be called get as we use index as variable often
     """Index of the current image."""


### PR DESCRIPTION
There were some inconsistencies between the base modules and some thumbnail-* modules. Namely, `basename` contained the file extension while it was striped for `thumbnail-name`, and `index` was zero padded while `thumbnail-index` was not.

The first point was fixed by distinguishing between `name` (name w/o extension), `basename` (name w extension) and `extension` (i.e. adding seperate modules for each of them).

The default statusbar module for `left_thumbnail` was changed from `thumbnail-name` to `thumbnail-basename` to be consistent with `left_image`.

@karlch feel free to merge if you agree