### PR TITLE
Fix showing both real and symlink image from different directories

### DIFF
--- a/tests/end2end/features/misc/symlink.feature
+++ b/tests/end2end/features/misc/symlink.feature
@@ -1,14 +1,18 @@
 Feature: Handling symbolic links
 
-    Background:
-        Given I open the symlink test directory
-
     Scenario: Open real path when opening symlink
+        Given I open the symlink test directory
         When I run open lnstem
         Then the working directory should be stem
 
     Scenario: Crash when searching in symlinked directory
+        Given I open the symlink test directory
         When I run open lnstem
         And I run search
         And I press 'k'
         Then no crash should happen
+
+    Scenario: Do not load path pointed to by symlink into filelist
+        Given I open the symlink image test directory
+        When I run open-selected --close
+        Then the filelist should contain 1 images

--- a/tests/end2end/features/misc/test_symlink_bdd.py
+++ b/tests/end2end/features/misc/test_symlink_bdd.py
@@ -4,6 +4,8 @@
 # Copyright 2017-2021 Christian Karl (karlch) <karlch at protonmail dot com>
 # License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
 
+from PyQt5.QtGui import QPixmap
+
 import pytest_bdd as bdd
 
 from vimiv import startup
@@ -28,5 +30,26 @@ def open_symlink_test_directory(tmp_path):
     stem_symlink = base_directory / "lnstem"
     stem_symlink.symlink_to(stem_directory)
     argv = [str(base_directory)]
+    args = startup.setup_pre_app(argv)
+    startup.setup_post_app(args)
+
+
+@bdd.given("I open the symlink image test directory")
+def open_symlink_image_test_directory(tmp_path):
+    """Create a test directory with symlink(s) and open the child directory in vimiv.
+
+    Structure:
+    ├── image.jpg
+    └── child
+        └── ln.jpg -> ../image.jpg
+    """
+    base_directory = tmp_path / "directory"
+    base_image_path = base_directory / "image.jpg"
+    child_directory = base_directory / "child"
+    child_image_path = child_directory / "ln.jpg"
+    child_directory.mkdir(parents=True)
+    QPixmap(300, 300).save(str(base_image_path))
+    child_image_path.symlink_to(base_image_path)
+    argv = [str(child_directory)]
     args = startup.setup_pre_app(argv)
     startup.setup_post_app(args)

--- a/vimiv/api/commands.py
+++ b/vimiv/api/commands.py
@@ -206,7 +206,7 @@ class _CommandArguments(argparse.ArgumentParser):
         parsed_args = super().parse_args(args)
         with contextlib.suppress(AttributeError):
             parsed_args.paths = [
-                os.path.realpath(path) for path in sorted(flatten(parsed_args.paths))
+                os.path.abspath(path) for path in sorted(flatten(parsed_args.paths))
             ]
         return parsed_args
 

--- a/vimiv/api/working_directory.py
+++ b/vimiv/api/working_directory.py
@@ -121,7 +121,7 @@ class WorkingDirectoryHandler(QFileSystemWatcher):
 
     def chdir(self, directory: str, reload_current: bool = False) -> None:
         """Change the current working directory to directory."""
-        directory = os.path.realpath(directory)  # os.chdir always enters the realpath
+        directory = os.path.abspath(directory)
         if directory != self._dir or reload_current:
             _logger.debug("Changing directory to '%s'", directory)
             if self.directories():  # Unmonitor old directories

--- a/vimiv/api/working_directory.py
+++ b/vimiv/api/working_directory.py
@@ -121,7 +121,7 @@ class WorkingDirectoryHandler(QFileSystemWatcher):
 
     def chdir(self, directory: str, reload_current: bool = False) -> None:
         """Change the current working directory to directory."""
-        directory = os.path.abspath(directory)
+        directory = os.path.realpath(directory)
         if directory != self._dir or reload_current:
             _logger.debug("Changing directory to '%s'", directory)
             if self.directories():  # Unmonitor old directories

--- a/vimiv/completion/completionmodels.py
+++ b/vimiv/completion/completionmodels.py
@@ -104,10 +104,10 @@ class PathModel(api.completion.BaseModel):
         """Update completion options when text changes."""
         directory = self._get_directory(text)
         # Nothing changed
-        if os.path.realpath(directory) == self._last_directory:
+        if os.path.abspath(directory) == self._last_directory:
             return
         # Prepare
-        self._last_directory = os.path.realpath(directory)
+        self._last_directory = os.path.abspath(directory)
         # No completions for non-existent directory
         if not os.path.isdir(os.path.expanduser(directory)):
             return

--- a/vimiv/gui/library.py
+++ b/vimiv/gui/library.py
@@ -246,7 +246,7 @@ class Library(
             self._open_path(current, close=current == self._last_selected)
         elif direction == direction.Left:
             self.store_position()
-            parent = os.path.realpath(os.pardir)
+            parent = os.path.abspath(os.pardir)
             self._positions[parent] = Position(os.getcwd())
             api.working_directory.handler.chdir(parent)
         else:
@@ -312,7 +312,7 @@ class Library(
         with contextlib.suppress(IndexError):  # No path selected
             basename = self.selectedIndexes()[1].data()
             basename = strip(basename)
-            return os.path.realpath(basename)
+            return os.path.abspath(basename)
         return ""
 
     def pathlist(self):

--- a/vimiv/imutils/filelist.py
+++ b/vimiv/imutils/filelist.py
@@ -12,7 +12,7 @@ new image in the filelist is selected, it is passed on to the file handler to op
 
 import os
 import random
-from typing import List, Optional
+from typing import List, Iterable, Optional
 
 from PyQt5.QtCore import QObject, pyqtSlot
 
@@ -248,13 +248,15 @@ def _load_single(path: str) -> None:
         _load_paths(api.working_directory.handler.images, path)
 
 
-def _load_paths(paths: List[str], focused_path: str) -> None:
+def _load_paths(paths: Iterable[str], focused_path: str) -> None:
     """Populate imstorage with a new list of paths.
 
     Args:
         paths: List of paths to load.
         focused_path: The path to display.
     """
+    paths = [os.path.abspath(path) for path in paths]
+    focused_path = os.path.abspath(focused_path)
     if api.settings.shuffle.value:
         random.shuffle(paths)
     previous = current()

--- a/vimiv/parser.py
+++ b/vimiv/parser.py
@@ -151,7 +151,7 @@ def existing_file(value: str) -> str:
     Returns:
         Path to the file as string if it exists.
     """
-    path = os.path.realpath(os.path.expanduser(value))
+    path = os.path.abspath(os.path.expanduser(value))
     if not os.path.isfile(path):
         raise argparse.ArgumentTypeError(f"No file called '{value}'")
     return path
@@ -167,7 +167,7 @@ def existing_path(value: str) -> str:
     Returns:
         Path to the file as string if it exists.
     """
-    path = os.path.realpath(os.path.expanduser(value))
+    path = os.path.abspath(os.path.expanduser(value))
     if not os.path.exists(path):
         raise argparse.ArgumentTypeError(f"No path called '{value}'")
     return path

--- a/vimiv/utils/files.py
+++ b/vimiv/utils/files.py
@@ -28,7 +28,7 @@ def listdir(directory: str, show_hidden: bool = False) -> List[str]:
     Returns:
         Sorted list of files in the directory with their absolute path.
     """
-    directory = os.path.realpath(os.path.expanduser(directory))
+    directory = os.path.abspath(os.path.expanduser(directory))
     return sorted(
         os.path.join(directory, path)
         for path in os.listdir(directory)


### PR DESCRIPTION
The new usage of realpath introduced in 0cc236327662dbf18c5f1d82cee287941d4e1350 also introduced a new bug. The image filelist would load both the symlink and the original image, even if they are not in the same directory. This PR attempts to save this issue while also fixing the initial issue that the mentioned commit tried to address.

Related to #374 
