### PR TITLE
Add support for jp2 via imageformats plugin

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -70,7 +70,7 @@ Added:
   ``thumbnail-extension``.
 * Support for the ``jp2`` file format using the imageformats plugin. To enable it, add
   ``imageformats = jp2`` to the ``[PLUGINS]`` section of your ``vimiv.conf``. Requires
-  the qt imageformats plugin.
+  the qt imageformats plugin. Thanks `@szsdk`_ for testing!
 
 Changed:
 ^^^^^^^^
@@ -506,3 +506,4 @@ Initial release of the Qt version.
 .. _@willemw12: https://github.com/willemw12
 .. _@Kakupakat: https://github.com/Kakupakat
 .. _@loiccoyle: https://github.com/loiccoyle
+.. _@szsdk: https://github.com/szsdk

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -68,6 +68,9 @@ Added:
   Thanks `@loiccoyle`_ for the discussion!
 * Statusbar modules ``name``, ``thumbnail-basename``, ``extension`` and
   ``thumbnail-extension``.
+* Support for the ``jp2`` file format using the imageformats plugin. To enable it, add
+  ``imageformats = jp2`` to the ``[PLUGINS]`` section of your ``vimiv.conf``. Requires
+  the qt imageformats plugin.
 
 Changed:
 ^^^^^^^^

--- a/docs/documentation/configuration/plugins.rst
+++ b/docs/documentation/configuration/plugins.rst
@@ -45,3 +45,5 @@ add separated by a comma.
 Currently the following formats are supported:
 
 * cr2 (requires `qt raw <https://gitlab.com/mardy/qtraw>`_)
+* avif (requires `qt-avif-image-plugin <https://github.com/novomesk/qt-avif-image-plugin>`_)
+* jp2 (requires qt imageformats plugin)

--- a/vimiv/plugins/imageformats.py
+++ b/vimiv/plugins/imageformats.py
@@ -41,9 +41,14 @@ def test_avif(header: bytes, _f: Optional[BinaryIO]) -> bool:
     return header[4:12] in (b"ftypavif", b"ftypavis")
 
 
+def test_jp2(header: bytes, _f: Optional[BinaryIO]) -> bool:
+    return header[:6] == b"\x00\x00\x00\x0cjP"
+
+
 FORMATS = {
     "cr2": test_cr2,
     "avif": test_avif,
+    "jp2": test_jp2,
 }
 
 


### PR DESCRIPTION
To enable `jp2` support via the imageformats plugin, add
```
imageformats = jp2
```
to the `[PLUGINS]` section of your `vimiv.conf`. This requires the qt imageformats plugin for `jp2` support in qt.

@szsdk could you give this a shot with some of your `jp2` files? I have had limited success with the samples I found online (one worked, one didn't :sweat_smile:), but obviously the sample size was rather tiny..