### PR TITLE
Add setting to toggle need of ctrl for wheel-zoom

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -71,6 +71,9 @@ Added:
 * Support for the ``jp2`` file format using the imageformats plugin. To enable it, add
   ``imageformats = jp2`` to the ``[PLUGINS]`` section of your ``vimiv.conf``. Requires
   the qt imageformats plugin. Thanks `@szsdk`_ for testing!
+* The ``image.zoom_wheel_ctrl`` setting which toggles the need to hold the ``<ctrl>``
+  modifier for zooming an image with the mouse wheel. Thanks `@ArtemSmaznov`_ for the
+  idea!
 
 Changed:
 ^^^^^^^^
@@ -507,3 +510,4 @@ Initial release of the Qt version.
 .. _@Kakupakat: https://github.com/Kakupakat
 .. _@loiccoyle: https://github.com/loiccoyle
 .. _@szsdk: https://github.com/szsdk
+.. _@ArtemSmaznov: https://github.com/ArtemSmaznov

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -389,6 +389,11 @@ class image:  # pylint: disable=invalid-name
         suggestions=["1.0", "1.5", "2.0", "5.0"],
         min_value=1.0,
     )
+    zoom_wheel_ctrl = BoolSetting(
+        "image.zoom_wheel_ctrl",
+        True,
+        desc="Require holding the control modifier for zooming with the mouse wheel",
+    )
 
 
 class library:  # pylint: disable=invalid-name

--- a/vimiv/gui/image.py
+++ b/vimiv/gui/image.py
@@ -359,7 +359,8 @@ class ScrollableImage(eventhandler.EventHandlerMixin, QGraphicsView):
 
     def wheelEvent(self, event):
         """Update mouse wheel to zoom with control."""
-        if event.modifiers() & Qt.ControlModifier:
+        require_ctrl = api.settings.image.zoom_wheel_ctrl
+        if not require_ctrl or event.modifiers() & Qt.ControlModifier:
             # We divide by 120 as this is the regular delta multiple
             # See https://doc.qt.io/qt-5/qwheelevent.html#angleDelta
             steps = event.angleDelta().y() / 120


### PR DESCRIPTION
The new `image.zoom_wheel_ctrl` setting defines if the user needs to hold the `<ctrl>` modifier to zoom the current image. The default is `True` to keep the current behaviour.

fixes #448 