### PR TITLE
Improve startup time by reducing stat() calls

### DIFF
--- a/vimiv/api/working_directory.py
+++ b/vimiv/api/working_directory.py
@@ -65,7 +65,7 @@ from PyQt5.QtCore import pyqtSignal, QFileSystemWatcher
 
 from vimiv.api import settings, signals, status
 from vimiv.utils import files, slot, log, throttled
-
+from vimiv.utils.files import SupportedMeta
 
 _logger = log.module_logger(__name__)
 
@@ -215,7 +215,7 @@ class WorkingDirectoryHandler(QFileSystemWatcher):
             self._directories = directories
             self.changed.emit(images, directories)
 
-    def _get_content(self, directory: str) -> Tuple[List[str], List[str]]:
+    def _get_content(self, directory: str) -> SupportedMeta:
         """Get supported content of directory.
 
         Returns:
@@ -224,7 +224,7 @@ class WorkingDirectoryHandler(QFileSystemWatcher):
         """
         show_hidden = settings.library.show_hidden.value
         paths = files.listdir(directory, show_hidden=show_hidden)
-        return files.supported(paths)
+        return files.supported_with_meta(paths)
 
 
 handler = cast(WorkingDirectoryHandler, None)

--- a/vimiv/api/working_directory.py
+++ b/vimiv/api/working_directory.py
@@ -156,8 +156,9 @@ class WorkingDirectoryHandler(QFileSystemWatcher):
     def _load_directory(self, directory: str) -> None:
         """Load supported files for new directory."""
         self._dir = directory
-        self._images, self._directories = self._get_content(directory)
-        self.loaded.emit(self._images, self._directories)
+        images, directories = self._get_content(directory)
+        self._images, self._directories = files.strip_meta((images, directories))
+        self.loaded.emit(images, directories)
 
     @throttled(delay_ms=WAIT_TIME_MS)
     def _reload_directory(self, _path: str) -> None:
@@ -193,14 +194,19 @@ class WorkingDirectoryHandler(QFileSystemWatcher):
         _logger.debug("Image file updated")
         status.update("image file changed")
 
-    def _emit_changes(self, images: List[str], directories: List[str]) -> None:
+    def _emit_changes(
+        self,
+        images_meta: List[Tuple[str, os.stat_result]],
+        directories_meta: List[Tuple[str, os.stat_result]]
+    ) -> None:
         """Emit changed signals if the content in the directory has changed.
 
         Args:
-            images: Updated list of images in the working directory.
-            directories: Updated list of directories in the working directory.
+            images_meta: Updated list of images in the working directory.
+            directories_meta: Updated list of directories in the working directory.
         """
         # Image filelist has changed, relevant for thumbnail and image mode
+        images, directories = files.strip_meta((images_meta, directories_meta))
         if images != self._images:
             new = set(images)
             old = set(self._images)

--- a/vimiv/gui/library.py
+++ b/vimiv/gui/library.py
@@ -386,7 +386,11 @@ class LibraryModel(QStandardItemModel):
         api.working_directory.handler.loaded.connect(self._update_content)
 
     @pyqtSlot(list, list)
-    def _update_content(self, images: List[Tuple[str, os.stat_result]], directories: List[Tuple[str, os.stat_result]]):
+    def _update_content(
+        self,
+        images: List[Tuple[str, os.stat_result]],
+        directories: List[Tuple[str, os.stat_result]],
+    ):
         """Update library content with new images and directories.
 
         Args:
@@ -399,7 +403,11 @@ class LibraryModel(QStandardItemModel):
         self._library.load_directory()
 
     @pyqtSlot(list, list)
-    def _on_directory_changed(self, images: List[Tuple[str, os.stat_result]], directories: List[Tuple[str, os.stat_result]]):
+    def _on_directory_changed(
+        self,
+        images: List[Tuple[str, os.stat_result]],
+        directories: List[Tuple[str, os.stat_result]],
+    ):
         """Reload library when directory content has changed.
 
         In addition to _update_content() the position is stored.
@@ -458,7 +466,9 @@ class LibraryModel(QStandardItemModel):
         """Return True if the index is highlighted as search result."""
         return index.row() in self._highlighted
 
-    def _add_rows(self, paths: List[Tuple[str, os.stat_result]], are_directories: bool = False):
+    def _add_rows(
+        self, paths: List[Tuple[str, os.stat_result]], are_directories: bool = False
+    ):
         """Generate a library row for each path and add it to the model.
 
         Args:

--- a/vimiv/utils/files.py
+++ b/vimiv/utils/files.py
@@ -10,7 +10,7 @@ import imghdr
 import functools
 import os
 from stat import S_ISDIR, S_ISREG
-from typing import List, Tuple, Optional, BinaryIO, Iterable, Callable
+from typing import List, Tuple, Optional, BinaryIO, Iterable, Callable, Any
 
 from PyQt5.QtGui import QImageReader
 
@@ -37,10 +37,20 @@ def listdir(directory: str, show_hidden: bool = False) -> List[str]:
     )
 
 
-SupportedMeta = Tuple[List[Tuple[str, os.stat_result]], List[Tuple[str, os.stat_result]]]
+SupportedMeta = Tuple[
+    List[Tuple[str, os.stat_result]], List[Tuple[str, os.stat_result]]
+]
 
 
 def supported_with_meta(paths: Iterable[str]) -> SupportedMeta:
+    """Get supported images and directories from paths including metadata.
+
+    Args:
+        paths: List containing paths to parse.
+    Returns:
+        supported_meta: lists of images and directories including os.stat_result
+            metadata.
+    """
     directories = []
     images = []
     for path in paths:
@@ -53,8 +63,18 @@ def supported_with_meta(paths: Iterable[str]) -> SupportedMeta:
 
 
 def strip_meta(files: SupportedMeta) -> Tuple[List[str], List[str]]:
-    def first(it):
+    """Remove metadata from a SupportedMeta tuple.
+
+    Args:
+        files: Lists of files and directories including os.stat_result metadata.
+    Returns:
+        images: List of images without os.stat_result metadata.
+        directories: List of directories without os.stat_result metadata.
+    """
+
+    def first(it: Iterable[Tuple[str, Any]]) -> List[str]:
         return list(map(lambda a: a[0], it))
+
     images, directories = files
     return first(images), first(directories)
 
@@ -98,7 +118,8 @@ def get_size_file(path: str, stat_result: Optional[os.stat_result] = None) -> st
 
     Args:
         path: Path to the file
-        stat_result: Result of os.stat() to determine node type of filename without disk access.
+        stat_result: Result of os.stat() to determine node type of filename without disk
+            access.
     """
     try:
         if stat_result is not None:
@@ -128,14 +149,16 @@ def sizeof_fmt(num: float) -> str:
     return f"{num:.1f}Y"
 
 
-def get_size_directory(path: str) -> str:
+def get_size_directory(path: str, stat_result: Optional[os.stat_result] = None) -> str:
     """Get size of directory by checking amount of supported paths.
 
     Args:
         path: Path to directory to check.
+        stat_result: Currently unused argument to unify get_size_* functions.
     Returns:
         Size as formatted string.
     """
+    # pylint: disable=unused-argument
     try:
         return str(len(os.listdir(path)))
     except OSError:
@@ -147,7 +170,8 @@ def is_image(filename: str, stat_result: Optional[os.stat_result] = None) -> boo
 
     Args:
         filename: Name of file to check.
-        stat_result: Result of os.stat() to determine node type of filename without disk access.
+        stat_result: Result of os.stat() to determine node type of filename without disk
+            access.
     """
     try:
         if stat_result is not None:


### PR DESCRIPTION
On startup, multiple functions check properties of loaded files and
directories. Each of those functions like isdir(), isfile(), or
getsize() cause a stat() syscall. By calling stat() directly and reusing
the result we can improve startup time on remote and slow storage.

Related to #363 

Edit: This is relatively untested. Haven't checked what happens on reloads of the library etc.