### PR TITLE
CI: Make use of codecov report merging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        toxenv: [pyqt515-cov, piexif, lint, packaging, mypy]
+        toxenv: [pyqt515-cov, pyqt515-piexif-cov, lint, packaging, mypy]
       fail-fast: false
     steps:
     - uses: actions/checkout@v3.3.0
@@ -81,9 +81,7 @@ jobs:
       env:
         CI: Github-Actions
     - name: Upload coverage to codecov
-      run: |
-        pip install codecov
-        codecov -X gcov
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      if: matrix.toxenv == 'pyqt515-cov'
+      if: "endsWith(matrix.toxenv, '-cov')"
+      uses: codecov/codecov-action@v3
+      with:
+        name: "${{ matrix.toxenv }}"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pyqt-cov,piexif,pyexiv2,lint,packaging,mypy
+envlist = pyqt,pyqt-piexif,pyqt-pyexiv2,lint,packaging,mypy
 
 # Standard test suite using pytest
 [testenv]
@@ -16,23 +16,11 @@ deps =
     pyqt514: PyQt5==5.14.2
     pyqt515: -r{toxinidir}/misc/requirements/requirements.txt
     cov: -r{toxinidir}/misc/requirements/requirements_cov.txt
+    piexif: -r{toxinidir}/misc/requirements/requirements_piexif.txt
+    pyexiv2: -r{toxinidir}/misc/requirements/requirements_pyexiv2.txt
 
 commands_pre = {envpython} scripts/maybe_build_cextension.py
 commands = pytest {posargs}
-
-# Test suite using piexif
-[testenv:piexif]
-deps =
-    -r{toxinidir}/misc/requirements/requirements.txt
-    -r{toxinidir}/misc/requirements/requirements_tests.txt
-    -r{toxinidir}/misc/requirements/requirements_piexif.txt
-
-# Test suite without optional dependencies
-[testenv:pyexiv2]
-deps =
-    -r{toxinidir}/misc/requirements/requirements.txt
-    -r{toxinidir}/misc/requirements/requirements_tests.txt
-    -r{toxinidir}/misc/requirements/requirements_pyexiv2.txt
 
 # Linters and checkers for the source code
 [testenv:lint]

--- a/vimiv/gui/metadatawidget.py
+++ b/vimiv/gui/metadatawidget.py
@@ -177,5 +177,5 @@ if exif.has_exif_support:
             if self.isVisible():
                 self._update_text()
 
-else:  # No exif support  # pragma: no cover  # Covered in another CI
+else:
     MetadataWidget = None  # type: ignore


### PR DESCRIPTION
We now combine coverage of the test suite without exif support, and the one using piexif. This can be extended to other Qt versions, other dependencies, ... in the future.