### PR TITLE
Allow bool settings to be toggled

### DIFF
--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -151,7 +151,7 @@ class BoolSetting(Setting):
         self.value = not self.value
 
     def suggestions(self) -> List[str]:
-        return ["True", "False"]
+        return ["True", "False", "Toggle"]
 
     def convertstr(self, text: str) -> bool:
         text = text.lower()
@@ -159,6 +159,8 @@ class BoolSetting(Setting):
             return True
         if text in ("no", "false", "0"):
             return False
+        if text == "toggle":
+            return not self.value
         raise ValueError
 
     def __str__(self) -> str:


### PR DESCRIPTION
Creating this PR to start a discussion about the feature.

I'd like to create a shortcut that toggles the `library.show_hidden` setting. When I first tried, I typed the command `:set library.show_hidden toggle` and, of course, it failed. Also tried `:toggle library.show_hidden`, but seems that toggle only works for toggling modes (image/library/thumbnail/manipulate).

Then I decided to look at the source code and see if it is possible to implement that. Only a toggle should be easy. It was, indeed, the code looks very clean, it was VERY easy.

But I'm not sure if the way I'm doing it in this PR is OK. There is a `toggle()` method in the `BoolSetting()`, but I have no idea how to call that using vimiv's command.

So if there is no way to call it, is it acceptable the change I've done here?