### PR TITLE
Replace imghdr

### DIFF
--- a/docs/documentation/hacking.rst
+++ b/docs/documentation/hacking.rst
@@ -145,9 +145,7 @@ raw images using ``dcraw``.
 
 To make this work, you need to implement two functions:
 
-#. A function which checks if a path is of your filetype. The function must be of the
-   same form as used by the standard library module
-   `imghdr <https://docs.python.org/3/library/imghdr.html>`_.
+#. A function which checks if a path is of your filetype.
 #. The actual loading function which creates a ``QPixmap`` from the path.
 
 Finally, you tell vimiv about the newly supported filetype::

--- a/tests/end2end/features/image/test_imageopen_bdd.py
+++ b/tests/end2end/features/image/test_imageopen_bdd.py
@@ -4,11 +4,10 @@
 # Copyright 2017-2023 Christian Karl (karlch) <karlch at protonmail dot com>
 # License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
 
-import imghdr  # pylint: disable=deprecated-module
-
 import pytest_bdd as bdd
 
 from vimiv import api
+from vimiv.utils import imageheader
 
 
 bdd.scenarios("imageopen.feature")
@@ -16,10 +15,10 @@ bdd.scenarios("imageopen.feature")
 
 @bdd.when("I open broken images")
 def open_broken_images(tmp_path):
-    _open_file(tmp_path, b"\211PNG\r\n\032\n")  # PNG
-    _open_file(tmp_path, b"000000JFIF")  # JPG
+    _open_file(tmp_path, b"\x89PNG\x0D\x0A\x1A\x0A")  # PNG
+    _open_file(tmp_path, b"\xFF\xD8\xFF\xDB")  # JPG
     _open_file(tmp_path, b"GIF89a")  # GIF
-    _open_file(tmp_path, b"II")  # TIFF
+    _open_file(tmp_path, b"II\x2A\x00")  # TIFF
     _open_file(tmp_path, b"BM")  # BMP
 
 
@@ -28,5 +27,5 @@ def _open_file(directory, data):
     path = directory / "broken"
     path.write_bytes(data)
     filename = str(path)
-    assert imghdr.what(filename) is not None, "Invalid magic bytes in test setup"
+    assert imageheader.detect(filename) is not None, "Invalid magic bytes in test setup"
     api.open_paths([filename])

--- a/tests/end2end/features/plugins/test_plugins_bdd.py
+++ b/tests/end2end/features/plugins/test_plugins_bdd.py
@@ -4,8 +4,6 @@
 # Copyright 2017-2023 Christian Karl (karlch) <karlch at protonmail dot com>
 # License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
 
-import contextlib
-
 import pytest_bdd as bdd
 
 from vimiv import plugins
@@ -22,9 +20,6 @@ def load_plugin(name, info):
 
 @bdd.then(bdd.parsers.parse("The {name} format should be supported"))
 def check_format_supported(name):
-    for filetype, check in imageheader._registry:
-        with contextlib.suppress(IndexError):
-            format_name = check.__name__.split("_")[-1]
-            if format_name == name:
-                return
-    assert False, f"Image format {name} is not supported"
+    assert name in [
+        filetype for filetype, _ in imageheader._registry
+    ], f"Image format {name} is not supported"

--- a/tests/end2end/features/plugins/test_plugins_bdd.py
+++ b/tests/end2end/features/plugins/test_plugins_bdd.py
@@ -5,11 +5,11 @@
 # License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
 
 import contextlib
-import imghdr  # pylint: disable=deprecated-module
 
 import pytest_bdd as bdd
 
 from vimiv import plugins
+from vimiv.utils import imageheader
 
 
 bdd.scenarios("plugins.feature")
@@ -22,9 +22,9 @@ def load_plugin(name, info):
 
 @bdd.then(bdd.parsers.parse("The {name} format should be supported"))
 def check_format_supported(name):
-    for func in imghdr.tests:
+    for filetype, check in imageheader._registry:
         with contextlib.suppress(IndexError):
-            format_name = func.__name__.split("_")[-1]
+            format_name = check.__name__.split("_")[-1]
             if format_name == name:
                 return
     assert False, f"Image format {name} is not supported"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,16 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2023 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+"""Fixtures for pytest unit tests."""
+
+import pytest
+
+
+@pytest.fixture()
+def tmpfile(tmp_path):
+    path = tmp_path / "anything"
+    path.touch()
+    yield str(path)

--- a/tests/unit/utils/test_files.py
+++ b/tests/unit/utils/test_files.py
@@ -158,8 +158,3 @@ def test_get_size_with_permission_error(mocker):
 def test_listfiles(directory_tree):
     expected = sorted(directory_tree.files)
     assert expected == sorted(files.listfiles(str(directory_tree.root)))
-
-
-def _test_dummy(h, f):
-    """Dummy image file test that always returns True."""
-    return True

--- a/tests/unit/utils/test_files.py
+++ b/tests/unit/utils/test_files.py
@@ -16,13 +16,6 @@ from vimiv.utils import files
 
 
 @pytest.fixture()
-def tmpfile(tmp_path):
-    path = tmp_path / "anything"
-    path.touch()
-    yield str(path)
-
-
-@pytest.fixture()
 def directory_tree(tmp_path):
     """Fixture to create a directory tree.
 

--- a/tests/unit/utils/test_imageheader.py
+++ b/tests/unit/utils/test_imageheader.py
@@ -1,7 +1,7 @@
 # vim: ft=python fileencoding=utf-8 sw=4 et sts=4
 
 # This file is part of vimiv.
-# Copyright 2023-2023 Christian Karl (karlch) <karlch at protonmail dot com>
+# Copyright 2017-2023 Christian Karl (karlch) <karlch at protonmail dot com>
 # License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
 
 """Tests for vimiv.utils.imageheader."""

--- a/tests/unit/utils/test_imageheader.py
+++ b/tests/unit/utils/test_imageheader.py
@@ -46,13 +46,6 @@ def mockimageheader(mocker):
     yield mocker.patch("vimiv.utils.imageheader._registry", [])
 
 
-@pytest.fixture()
-def tmpfile(tmp_path):
-    path = tmp_path / "anything"
-    path.touch()
-    yield str(path)
-
-
 def create_image(filename: str, *, size=(300, 300)):
     QPixmap(*size).save(filename)
 

--- a/tests/unit/utils/test_imageheader.py
+++ b/tests/unit/utils/test_imageheader.py
@@ -1,0 +1,28 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2023-2023 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+"""Tests for vimiv.utils.imageheader."""
+
+from PyQt5.QtGui import QPixmap
+
+import pytest
+
+
+from vimiv.utils import imageheader
+
+SUPPORTED_IMAGE_FORMATS = ["jpg", "png", "pbm", "pgm", "ppm", "bmp"]
+
+
+def create_image(filename: str, *, size=(300, 300)):
+    QPixmap(*size).save(filename)
+
+
+@pytest.mark.parametrize("imagetype", SUPPORTED_IMAGE_FORMATS)
+def test_test(qtbot, tmp_path, imagetype):
+    name = f"img.{imagetype}"
+    filename = str(tmp_path / name)
+    create_image(filename)
+    assert imageheader.detect(filename) == imagetype

--- a/tests/unit/utils/test_imageheader.py
+++ b/tests/unit/utils/test_imageheader.py
@@ -85,6 +85,14 @@ def test_register_unsupported_format(mockimageheader, tmpfile):
     assert not mockimageheader, "Unsupported test not removed"
 
 
+def test_register_unsupported_format_not_verify(mockimageheader, tmpfile):
+    """Test if check of invalid remains when registered without verification."""
+    dummy_format = "not_a_format"
+    imageheader.register(dummy_format, _check_dummy, validate=False)
+    assert imageheader.detect(tmpfile) == dummy_format
+    assert (dummy_format, _check_dummy) in imageheader._registry
+
+
 @pytest.mark.parametrize("name", QT_READ_FORMATS)
 def test_full_support(name):
     """Tests if all formats readable by QT are also detected."""

--- a/tests/unit/utils/test_imageheader.py
+++ b/tests/unit/utils/test_imageheader.py
@@ -45,7 +45,7 @@ def test_test(qtbot, tmp_path, imagetype):
     assert imageheader.detect(filename) == imagetype
 
 
-def _check_dummy(h):
+def _check_dummy(h, f):
     """Dummy image file check that always returns True."""
     return True
 

--- a/tests/unit/utils/test_imageheader.py
+++ b/tests/unit/utils/test_imageheader.py
@@ -6,14 +6,31 @@
 
 """Tests for vimiv.utils.imageheader."""
 
-from PyQt5.QtGui import QPixmap
+from PyQt5.QtGui import QPixmap, QImageReader
 
 import pytest
 
 
 from vimiv.utils import imageheader
 
+# Image types which QPixmap is capable of creating, and not what is supported by vimiv!
 SUPPORTED_IMAGE_FORMATS = ["jpg", "png", "pbm", "pgm", "ppm", "bmp"]
+
+
+@pytest.fixture()
+def mockimageheader(mocker):
+    """Fixture to mock imageheader._registry and QImageReader supportedImageFormats."""
+    mocker.patch.object(
+        QImageReader, "supportedImageFormats", return_value=SUPPORTED_IMAGE_FORMATS
+    )
+    yield mocker.patch("vimiv.utils.imageheader._registry", [])
+
+
+@pytest.fixture()
+def tmpfile(tmp_path):
+    path = tmp_path / "anything"
+    path.touch()
+    yield str(path)
 
 
 def create_image(filename: str, *, size=(300, 300)):
@@ -26,3 +43,21 @@ def test_test(qtbot, tmp_path, imagetype):
     filename = str(tmp_path / name)
     create_image(filename)
     assert imageheader.detect(filename) == imagetype
+
+
+def _check_dummy(h):
+    """Dummy image file check that always returns True."""
+    return True
+
+
+@pytest.mark.parametrize("name", SUPPORTED_IMAGE_FORMATS)
+def test_register_supported_format(mockimageheader, tmpfile, name):
+    imageheader.register(name, _check_dummy)
+    assert mockimageheader, "No test added by add image format"
+    assert imageheader.detect(tmpfile) == name
+
+
+def test_register_unsupported_format(mockimageheader, tmpfile):
+    imageheader.register("not_a_format", _check_dummy)
+    assert imageheader.detect(tmpfile) is None
+    assert not mockimageheader, "Unsupported test not removed"

--- a/vimiv/api/__init__.py
+++ b/vimiv/api/__init__.py
@@ -94,6 +94,7 @@ def add_external_format(
         test_func: Function returning True if load_func supports this type.
         load_func: Function to load a QPixmap from the passed path.
     """
-    # Priority to overwrite potential "default behaviour"
+    # Prioritize external formats over all default formats, to ensure that on signature
+    # collision, the explicitly registered handler is used.
     imageheader.register(file_format, test_func, priority=True)
     imagereader.external_handler[file_format] = load_func

--- a/vimiv/api/__init__.py
+++ b/vimiv/api/__init__.py
@@ -84,7 +84,7 @@ def open_paths(paths: Iterable[str]) -> None:
 
 def add_external_format(
     file_format: str,
-    test_func: Callable[[str], bool],
+    test_func: imageheader.CheckFuncT,
     load_func: Callable[[str], QPixmap],
 ) -> None:
     """Add support for new fileformat.

--- a/vimiv/api/__init__.py
+++ b/vimiv/api/__init__.py
@@ -10,7 +10,7 @@ import os
 from typing import List, Iterable, Callable, BinaryIO
 from PyQt5.QtGui import QPixmap
 
-from vimiv.utils import files, imagereader
+from vimiv.utils import files, imagereader, imageheader
 
 from vimiv.api import (
     commands,
@@ -84,7 +84,7 @@ def open_paths(paths: Iterable[str]) -> None:
 
 def add_external_format(
     file_format: str,
-    test_func: files.ImghdrTestFuncT,
+    test_func: Callable[[str], bool],
     load_func: Callable[[str], QPixmap],
 ) -> None:
     """Add support for new fileformat.
@@ -94,5 +94,6 @@ def add_external_format(
         test_func: Function returning True if load_func supports this type.
         load_func: Function to load a QPixmap from the passed path.
     """
-    files.add_image_format(file_format, test_func)
+    # Priority to overwrite potential "default behaviour"
+    imageheader.register(file_format, test_func, priority=True)
     imagereader.external_handler[file_format] = load_func

--- a/vimiv/plugins/imageformats.py
+++ b/vimiv/plugins/imageformats.py
@@ -6,8 +6,8 @@
 
 """Plugin enabling support for additional image formats.
 
-Adds support for image formats what are not natively or by qtimageformats supported, but
-though some other QT module.
+Adds support for image formats that are not supported by Qt natively or by the
+qtimageformats add-on, but instead require some other Qt module.
 
 The required Qt module is not installed by Vimiv and requires explicit installation.
 

--- a/vimiv/plugins/imageformats.py
+++ b/vimiv/plugins/imageformats.py
@@ -6,6 +6,11 @@
 
 """Plugin enabling support for additional image formats.
 
+Adds support for image formats what are not natively or by qtimageformats supported, but
+though some other QT module.
+
+The required Qt module is not installed by Vimiv and requires explicit installation.
+
 Activate it by adding::
 
     imageformats = name, ...
@@ -26,29 +31,43 @@ To implement a new format::
        ``QImageReader.supportedImageFormats()``.
 """
 
-from typing import Any, Optional, BinaryIO
+from typing import Any
 
-from vimiv.utils import log, files
+
+from vimiv.utils import log, imageheader
 
 _logger = log.module_logger(__name__)
 
 
-def test_cr2(header: bytes, _f: Optional[BinaryIO]) -> bool:
-    return header[:2] in (b"II", b"MM") and header[8:10] == b"CR"
+def _test_cr2(h: bytes) -> bool:
+    """Canon Raw 2 (CR2).
+
+    Extension: .cr2
+
+    Magic bytes:
+    - 49 49 2A 00 10 00 00 00 43 52
+
+    Support: QtRaw https://gitlab.com/mardy/qtraw
+    """
+    return h[:10] == b"\x49\x49\x2A\x00\x10\x00\x00\x00\x43\x52"
 
 
-def test_avif(header: bytes, _f: Optional[BinaryIO]) -> bool:
-    return header[4:12] in (b"ftypavif", b"ftypavis")
+def _test_avif(h: bytes) -> bool:
+    """AV1 Image File (AVIF).
 
+    Extension: .avif
 
-def test_jp2(header: bytes, _f: Optional[BinaryIO]) -> bool:
-    return header[:6] == b"\x00\x00\x00\x0cjP"
+    Magic bytes:
+    - ?
+
+    Support: qt-qvif-image-plugin https://github.com/novomesk/qt-avif-image-plugin
+    """
+    return h[4:12] in (b"ftypavif", b"ftypavis")
 
 
 FORMATS = {
-    "cr2": test_cr2,
-    "avif": test_avif,
-    "jp2": test_jp2,
+    "cr2": _test_cr2,
+    "avif": _test_avif,
 }
 
 
@@ -61,8 +80,9 @@ def init(names: str, *_args: Any, **_kwargs: Any) -> None:
     for name in names.split(","):
         name = name.lower().strip()
         try:
-            test = FORMATS[name]
-            files.add_image_format(name, test)
+            check = FORMATS[name]
+            # Set priority as these types are explicitly enables
+            imageheader.register(name, check, priority=True)
             _logger.debug("Added image format '%s'", name)
         except KeyError:
             _logger.error("Ignoring unknown image format '%s'", name)

--- a/vimiv/plugins/imageformats.py
+++ b/vimiv/plugins/imageformats.py
@@ -31,7 +31,7 @@ To implement a new format::
        ``QImageReader.supportedImageFormats()``.
 """
 
-from typing import Any
+from typing import Any, BinaryIO
 
 
 from vimiv.utils import log, imageheader
@@ -39,7 +39,7 @@ from vimiv.utils import log, imageheader
 _logger = log.module_logger(__name__)
 
 
-def _test_cr2(h: bytes) -> bool:
+def _test_cr2(h: bytes, _f: BinaryIO) -> bool:
     """Canon Raw 2 (CR2).
 
     Extension: .cr2
@@ -52,7 +52,7 @@ def _test_cr2(h: bytes) -> bool:
     return h[:10] == b"\x49\x49\x2A\x00\x10\x00\x00\x00\x43\x52"
 
 
-def _test_avif(h: bytes) -> bool:
+def _test_avif(h: bytes, _f: BinaryIO) -> bool:
     """AV1 Image File (AVIF).
 
     Extension: .avif

--- a/vimiv/utils/imageheader.py
+++ b/vimiv/utils/imageheader.py
@@ -99,7 +99,7 @@ def register(
     """
 
     @functools.wraps(check)
-    def test(header: bytes) -> bool:
+    def check_verified(header: bytes) -> bool:
         """Tests at runtime whether a filetype is actually supported.
 
         If not, then the filetype check is unregistered.
@@ -108,25 +108,25 @@ def register(
             return check(header)
 
         if check(header):
-            if hasattr(test, "checked"):
+            if hasattr(check_verified, "checked"):
                 return True
             if (
                 filetype in QImageReader.supportedImageFormats()
                 or filetype in imagereader.external_handler
             ):
-                setattr(test, "checked", True)
+                setattr(check_verified, "checked", True)
                 return True
             _logger.warning(
                 f"Check for {filetype} was register, but display is not supported."
                 "Probably you need to install the required backend module."
             )
-            _registry.remove((filetype, check))
+            _registry.remove((filetype, check_verified))
         return False
 
     if priority:
-        _registry.insert(0, (filetype, check))
+        _registry.insert(0, (filetype, check_verified))
     else:
-        _registry.append((filetype, check))
+        _registry.append((filetype, check_verified))
 
 
 def _test_jpg(h: bytes) -> bool:

--- a/vimiv/utils/imageheader.py
+++ b/vimiv/utils/imageheader.py
@@ -37,7 +37,7 @@ Extended QT Support:
 | ICNS   | icns                      | yes                        |
 | ICNS   | cur                       | no (what are magic bytes?) |
 | JP2    | TODO: ?                   | yes                        |
-| MNG    | TODO: ?                   | no (what are magic bytes?) |
+| MNG    | TODO: ?                   | yes                        |
 | TGA    | tga                       | no (undetectable)          |
 | TIFF   | tif, tiff                 | yes                        |
 | WBMP   | wbmp                      | no (what are magic bytes?) |
@@ -370,12 +370,11 @@ def _test_mng(h: bytes) -> bool:
     Extension: .mng
 
     Magic Bytes:
-    - (I do not know)
+    - 8A 4D 4E 47 0D 0A 1A 0A
 
     Support: extended
     """
-    # TODO: implement check
-    raise NotImplementedError()
+    return h[:8] == b"\x8A\x4D\x4E\x47\x0D\x0A\x1A\x0A"
 
 
 def _test_tga(h: bytes) -> bool:
@@ -409,3 +408,4 @@ register("pgm", _test_pgm, validate=False)
 register("ppm", _test_ppm, validate=False)
 register("bmp", _test_bmp, validate=False)
 register("xpm", _test_xpm, validate=False)
+register("mng", _test_mng)

--- a/vimiv/utils/imageheader.py
+++ b/vimiv/utils/imageheader.py
@@ -48,7 +48,6 @@ A great list of magic bytes is provided here:
 https://en.wikipedia.org/wiki/List_of_file_signatures
 """
 
-import contextlib
 import functools
 
 from typing import Optional, List, Callable, Tuple, BinaryIO
@@ -81,10 +80,13 @@ def detect(filename: str) -> Optional[str]:
         header = f.read(32)
 
         for filetype, check in _registry:
-            with contextlib.suppress(IndexError):
+            # Use try instead of contextlib.suppress due to zero-overhead.
+            try:
                 if check(header, f):
                     _logger.debug(f"Detected {filename} as {filetype}")
                     return filetype
+            except IndexError:
+                pass
     return None
 
 

--- a/vimiv/utils/imageheader.py
+++ b/vimiv/utils/imageheader.py
@@ -1,7 +1,7 @@
 # vim: ft=python fileencoding=utf-8 sw=4 et sts=4
 
 # This file is part of vimiv.
-# Copyright 2023-2023 Christian Karl (karlch) <karlch at protonmail dot com>
+# Copyright 2017-2023 Christian Karl (karlch) <karlch at protonmail dot com>
 # License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
 
 

--- a/vimiv/utils/imageheader.py
+++ b/vimiv/utils/imageheader.py
@@ -263,9 +263,10 @@ def _test_xbm(h: bytes, f: BinaryIO) -> bool:
     if h[:7] == b"#define":
         import re
 
-        h = h + f.read()
+        f.seek(0, 0)
+        h = f.read()
         pattern = (
-            b"#define [a-zA-Z0-9]+_width [0-9]+\n#define [a-zA-Z0-9]+_height [0-9]+"
+            b"#define [a-zA-Z0-9]*_width [0-9]+\n#define [a-zA-Z0-9]*_height [0-9]+"
         )
         return re.search(pattern, h) is not None
     return False

--- a/vimiv/utils/imageheader.py
+++ b/vimiv/utils/imageheader.py
@@ -406,9 +406,13 @@ def _test_tga(_h: bytes, f: BinaryIO) -> bool:
     Support: extended
     """
     # Get signature located at end of file
-    f.seek(-18, 2)
-    h = f.read(16)
-    return h == b"\x54\x52\x55\x45\x56\x49\x53\x49\x4F\x4E\x2D\x58\x46\x49\x4C\x45"
+    # Seek relative to end of file for some files
+    try:
+        f.seek(-18, 2)
+        h = f.read(16)
+        return h == b"\x54\x52\x55\x45\x56\x49\x53\x49\x4F\x4E\x2D\x58\x46\x49\x4C\x45"
+    except OSError:
+        return False
 
 
 def _test_wbmp(h: bytes, _f: BinaryIO) -> bool:

--- a/vimiv/utils/imageheader.py
+++ b/vimiv/utils/imageheader.py
@@ -7,8 +7,8 @@
 
 """Image type detection based on magic bytes.
 
-The following table shows which image types can be read by QT natively, while the second
-one shows which can be read when having the `qtimageformats` ad-on module installed.
+The following table shows which image types can be read by Qt natively, while the second
+one shows which can be read when having the `qtimageformats` add-on module installed.
 
 This module allows to detect images of these types based on the magic bytes of the file.
 
@@ -67,7 +67,7 @@ def detect(filename: str) -> Optional[str]:
     """Determine type of image based on the magic bytes.
 
     Evaluates each registered check function in the order they were registered. If
-    registered with `priority`, then that check is evaluated before all checks with out
+    registered with `priority`, then that check is evaluated before all checks without
     `priority`.
 
     Args:

--- a/vimiv/utils/imageheader.py
+++ b/vimiv/utils/imageheader.py
@@ -30,19 +30,19 @@ Native QT Support:
 | ---    | ---                       | ---                                     |
 
 Extended QT Support:
-| ---    | ---                       | ---                               |
-| Format | Extension according to QT | Vimiv Supported                   |
-| ---    | ---                       | ---                               |
-| ICNS   | ico                       | yes                               |
-| ICNS   | icns                      | yes                               |
-| ICNS   | cur                       | yes (TODO: is it really correct?) |
-| JP2    | TODO: ?                   | yes                               |
-| MNG    | TODO: ?                   | yes                               |
-| TGA    | tga                       | no (undetectable)                 |
-| TIFF   | tif, tiff                 | yes                               |
-| WBMP   | wbmp                      | no (what are magic bytes?)        |
-| WEBP   | webp                      | yes                               |
-| ---    | ---                       | ---                               |
+| ---    | ---                       | ---                                             |
+| Format | Extension according to QT | Vimiv Supported                                 |
+| ---    | ---                       | ---                                             |
+| ICNS   | ico                       | yes                                             |
+| ICNS   | icns                      | yes                                             |
+| ICNS   | cur                       | yes (TODO: is it really correct?)               |
+| JP2    | TODO: ?                   | yes                                             |
+| MNG    | TODO: ?                   | yes                                             |
+| TGA    | tga                       | yes (only version 2, version 1 is undetectable) |
+| TIFF   | tif, tiff                 | yes                                             |
+| WBMP   | wbmp                      | no (what are magic bytes?)                      |
+| WEBP   | webp                      | yes                                             |
+| ---    | ---                       | ---                                             |
 
 A great list of magic bytes is provided here:
 https://en.wikipedia.org/wiki/List_of_file_signatures
@@ -391,18 +391,24 @@ def _test_mng(h: bytes, _f: BinaryIO) -> bool:
     return h[:8] == b"\x8A\x4D\x4E\x47\x0D\x0A\x1A\x0A"
 
 
-def _test_tga(h: bytes, _f: BinaryIO) -> bool:
+def _test_tga(_h: bytes, f: BinaryIO) -> bool:
     """Truevision Graphics Adapter (TGA).
+
+    There are two versions of this file. Version 1 has no signature, and hence, is
+    undetectable, while Version 2 has one at the end of the file.
 
     Extension: .tga, .icb, .vda, .vst
 
     Magic Bytes:
-    - ?? ?? ?? (impossible to detect)
+    - impossible to detect (Version 1)
+    - 54 52 55 45 56 49 53 49 4F 4E 2D 58 46 49 4C 45 (Version 2; footer at end of file)
 
     Support: extended
     """
-    # TODO: implement check
-    raise NotImplementedError()
+    # Get signature located at end of file
+    f.seek(-18, 2)
+    h = f.read(16)
+    return h == b"\x54\x52\x55\x45\x56\x49\x53\x49\x4F\x4E\x2D\x58\x46\x49\x4C\x45"
 
 
 # Register all check functions. Check functions of more frequently used types should be
@@ -417,6 +423,7 @@ register("tiff", _test_tiff)
 register("svg", _test_svg, validate=False)
 register("ico", _test_ico)
 register("icns", _test_icns)
+register("tga", _test_tga, validate=False)
 register("pbm", _test_pbm, validate=False)
 register("pgm", _test_pgm, validate=False)
 register("ppm", _test_ppm, validate=False)

--- a/vimiv/utils/imageheader.py
+++ b/vimiv/utils/imageheader.py
@@ -40,7 +40,7 @@ Extended QT Support:
 | MNG    | TODO: ?                   | yes                                             |
 | TGA    | tga                       | yes (only version 2, version 1 is undetectable) |
 | TIFF   | tif, tiff                 | yes                                             |
-| WBMP   | wbmp                      | no (what are magic bytes?)                      |
+| WBMP   | wbmp                      | no (is undetectable)                      |
 | WEBP   | webp                      | yes                                             |
 | ---    | ---                       | ---                                             |
 
@@ -409,6 +409,19 @@ def _test_tga(_h: bytes, f: BinaryIO) -> bool:
     f.seek(-18, 2)
     h = f.read(16)
     return h == b"\x54\x52\x55\x45\x56\x49\x53\x49\x4F\x4E\x2D\x58\x46\x49\x4C\x45"
+
+
+def _test_wbmp(h: bytes, _f: BinaryIO) -> bool:
+    """Wireless BitMaP (WBMP).
+
+    Extension: .wbmp
+
+    Magic Bytes:
+    - impossible to detect
+
+    Support: extended
+    """
+    raise NotImplementedError
 
 
 # Register all check functions. Check functions of more frequently used types should be

--- a/vimiv/utils/imageheader.py
+++ b/vimiv/utils/imageheader.py
@@ -30,19 +30,19 @@ Native QT Support:
 | ---    | ---                       | ---                                     |
 
 Extended QT Support:
-| ---    | ---                       | ---                        |
-| Format | Extension according to QT | Vimiv Supported            |
-| ---    | ---                       | ---                        |
-| ICNS   | ico                       | yes                        |
-| ICNS   | icns                      | yes                        |
-| ICNS   | cur                       | no (what are magic bytes?) |
-| JP2    | TODO: ?                   | yes                        |
-| MNG    | TODO: ?                   | yes                        |
-| TGA    | tga                       | no (undetectable)          |
-| TIFF   | tif, tiff                 | yes                        |
-| WBMP   | wbmp                      | no (what are magic bytes?) |
-| WEBP   | webp                      | yes                        |
-| ---    | ---                       | ---                        |
+| ---    | ---                       | ---                               |
+| Format | Extension according to QT | Vimiv Supported                   |
+| ---    | ---                       | ---                               |
+| ICNS   | ico                       | yes                               |
+| ICNS   | icns                      | yes                               |
+| ICNS   | cur                       | yes (TODO: is it really correct?) |
+| JP2    | TODO: ?                   | yes                               |
+| MNG    | TODO: ?                   | yes                               |
+| TGA    | tga                       | no (undetectable)                 |
+| TIFF   | tif, tiff                 | yes                               |
+| WBMP   | wbmp                      | no (what are magic bytes?)        |
+| WEBP   | webp                      | yes                               |
+| ---    | ---                       | ---                               |
 
 A great list of magic bytes is provided here:
 https://en.wikipedia.org/wiki/List_of_file_signatures
@@ -363,15 +363,17 @@ def _test_cur(h: bytes, _f: BinaryIO) -> bool:
 
     Windows' ICON format. Extended from ICO.
 
+    TODO: not sure if the bytes are correct, but should be according to
+    http://www.daubnet.com/en/file-format-cur
+
     Extension: .cur
 
     Magic Bytes:
-    - (I do not know)
+    - 00 00 02 00
 
     Support: extended
     """
-    # TODO: implement check
-    raise NotImplementedError()
+    return h[:4] == b"\x00\x00\x02\x00"
 
 
 def _test_mng(h: bytes, _f: BinaryIO) -> bool:
@@ -422,3 +424,4 @@ register("bmp", _test_bmp, validate=False)
 register("xbm", _test_xbm, validate=False)
 register("xpm", _test_xpm, validate=False)
 register("mng", _test_mng)
+register("cur", _test_cur)

--- a/vimiv/utils/imageheader.py
+++ b/vimiv/utils/imageheader.py
@@ -192,7 +192,7 @@ def _test_svg(h: bytes, _f: BinaryIO) -> bool:
 
 
 def _test_pbm(h: bytes, _f: BinaryIO) -> bool:
-    """Portable BitMap (PBM) in ASCII and Binary.
+    """Portable Bitmap (PBM) in ASCII and Binary.
 
     Extension: .pbm
 
@@ -206,7 +206,7 @@ def _test_pbm(h: bytes, _f: BinaryIO) -> bool:
 
 
 def _test_pgm(h: bytes, _f: BinaryIO) -> bool:
-    """Portable GrayMap (PGM) in ASCII and Binary.
+    """Portable Graymap (PGM) in ASCII and Binary.
 
     Extension: .pgm
 
@@ -220,7 +220,7 @@ def _test_pgm(h: bytes, _f: BinaryIO) -> bool:
 
 
 def _test_ppm(h: bytes, _f: BinaryIO) -> bool:
-    """Portable PixMap (PPM) in ASCII and Binary.
+    """Portable Pixmap (PPM) in ASCII and Binary.
 
     Extension: .ppm
 
@@ -234,7 +234,7 @@ def _test_ppm(h: bytes, _f: BinaryIO) -> bool:
 
 
 def _test_bmp(h: bytes, _f: BinaryIO) -> bool:
-    """BitMaP (BMP).
+    """Bitmap (BMP).
 
     Extension: .bmp, .dib
 
@@ -247,7 +247,7 @@ def _test_bmp(h: bytes, _f: BinaryIO) -> bool:
 
 
 def _test_xbm(h: bytes, f: BinaryIO) -> bool:
-    """X BitMap (XBM).
+    """X Bitmap (XBM).
 
     Are valid C source files.
 
@@ -272,7 +272,7 @@ def _test_xbm(h: bytes, f: BinaryIO) -> bool:
 
 
 def _test_xpm(h: bytes, _f: BinaryIO) -> bool:
-    """X PixMap (XPM).
+    """X Pixmap (XPM).
 
     Extension: .xpm
 
@@ -285,7 +285,7 @@ def _test_xpm(h: bytes, _f: BinaryIO) -> bool:
 
 
 def _test_webp(h: bytes, _f: BinaryIO) -> bool:
-    """Web Picture format (WebP).
+    """Web Picture Format (WebP).
 
     Raster graphics format intended to replace JPEG, PNG, GIF.
 
@@ -316,7 +316,7 @@ def _test_tiff(h: bytes, _f: BinaryIO) -> bool:
 
 
 def _test_ico(h: bytes, _f: BinaryIO) -> bool:
-    """ICOn (ICO).
+    """Icon (ICO).
 
     Windows' ICON format. Extended to CUR.
 
@@ -359,7 +359,7 @@ def _test_jp2(h: bytes, _f: BinaryIO) -> bool:
 
 
 def _test_cur(h: bytes, _f: BinaryIO) -> bool:
-    """CURsor (CUR).
+    """Cursor (CUR).
 
     Windows' ICON format. Extended from ICO.
 
@@ -416,7 +416,7 @@ def _test_tga(_h: bytes, f: BinaryIO) -> bool:
 
 
 def _test_wbmp(h: bytes, _f: BinaryIO) -> bool:
-    """Wireless BitMaP (WBMP).
+    """Wireless Bitmap (WBMP).
 
     Extension: .wbmp
 

--- a/vimiv/utils/imageheader.py
+++ b/vimiv/utils/imageheader.py
@@ -1,0 +1,379 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2023-2023 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+
+"""Image type detection based on magic bytes.
+
+The following table shows which image types can be read by QT natively, while the second
+one shows which can be read when having the `qtimageformats` ad-on module installed.
+
+This module allows to detect images of these types based on the magic bytes of the file.
+
+Native QT Support:
+| ---    | ---                       | ---                      |
+| Format | Extension according to QT | Vimiv Supported          |
+| ---    | ---                       | ---                      |
+| BMP    | bmp                       | yes                      |
+| GIF    | gif                       | yes                      |
+| JPG    | jpeg, jpg                 | yes                      |
+| PNG    | png                       | yes                      |
+| PBM    | pbm                       | yes                      |
+| PGM    | pgm                       | yes                      |
+| PPM    | ppm                       | yes                      |
+| XBM    | xbm                       | no (undetectable)        |
+| XPM    | xpm                       | yes                      |
+| SVG    | svg                       | yes                      |
+| SVG    | svgz                      | no (different from svg?) |
+| ---    | ---                       | ---                      |
+
+Extended QT Support:
+| ---    | ---                       | ---                        |
+| Format | Extension according to QT | Vimiv Supported            |
+| ---    | ---                       | ---                        |
+| ICNS   | ico                       | yes                        |
+| ICNS   | icns                      | yes                        |
+| ICNS   | cur                       | no (what are magic bytes?) |
+| JP2    | TODO: ?                   | yes                        |
+| MNG    | TODO: ?                   | no (what are magic bytes?) |
+| TGA    | tga                       | no (undetectable)          |
+| TIFF   | tif, tiff                 | yes                        |
+| WBMP   | wbmp                      | no (what are magic bytes?) |
+| WEBP   | webp                      | yes                        |
+| ---    | ---                       | ---                        |
+
+A great list of magic bytes is provided here:
+https://en.wikipedia.org/wiki/List_of_file_signatures
+"""
+
+import contextlib
+
+from typing import Optional, List, Callable, Any, Tuple
+
+from vimiv.utils import log
+
+_logger = log.module_logger(__name__)
+
+# List containing all registered check functions
+_registry: List[Tuple[str, Callable[[bytes], bool]]] = []
+
+
+def detect(filename: str) -> Optional[str]:
+    """Determine type of image based on the magic bytes.
+
+    Evaluates each registered check function in the order they were registered. If
+    registered with `priority`, then that check is evaluated before all checks with out
+    `priority`.
+
+    Args:
+        filename: Name of file to determine type of.
+
+    Returns:
+        Filetype or None if unknown.
+    """
+    with open(filename, "rb") as f:
+        header = f.read(32)
+
+    for filetype, check in _registry:
+        with contextlib.suppress(IndexError):
+            if check(header):
+                return filetype
+    return None
+
+
+def register(filetype: str, check: Any, priority: bool = False) -> None:
+    """Register format test function.
+
+    Args:
+        filetype: Name of the format to register.
+        check: Test function for that type.
+        priority: Evaluate check before all previously registered checks if true.
+    """
+
+    if priority:
+        _registry.insert(0, (filetype, check))
+    else:
+        _registry.append((filetype, check))
+
+
+def _test_jpg(h: bytes) -> bool:
+    """Joint Photographic Experts Group (JPEG) in different kinds of "subtypes"(?).
+
+    Extension: .jpeg, .jpg
+
+    Magic bytes:
+    - FF D8 FF DB
+    - FF D8 FF E0 (only for JPG, but no need to differentiate)
+    - FF D8 FF E0 00 10 4A 46 49 46 00 01 (covered be prior)
+    - FF D8 FF EE
+    - FF D8 FF E1 ?? ?? 45 78 69 66 00 00
+
+    Support: native
+    """
+    return h[:3] == b"\xFF\xD8\xFF" and (
+        h[3] in [0xDB, 0xE0, 0xEE]
+        or (h[3] == 0xE1 and h[6:12] == b"\x45\x78\x69\x66\x00\x00")
+    )
+
+
+def _test_png(h: bytes) -> bool:
+    """Portable Network Graphics (PNG).
+
+    Extension: .png
+
+    Magic bytes:
+    - 89 50 4E 47 0D 0A 1A 0A
+
+    Support: native
+    """
+    return h[:8] == b"\x89\x50\x4E\x47\x0D\x0A\x1A\x0A"
+
+
+def _test_gif(h: bytes) -> bool:
+    """Graphics Interchange Format (GIF).
+
+    Extension: .gif
+
+    Magic bytes:
+    - 47 49 46 38 37 61
+    - 47 49 46 38 39 61
+
+    Support: native
+    """
+    return h[:4] == b"\x47\x49\x46\x38" and h[4] in [0x37, 0x39] and h[5] == 0x61
+
+
+def _test_svg(h: bytes) -> bool:
+    """Scalable Vector Graphics (SVG).
+
+    Extension: .svg (TODO: also svgz?)
+
+    Magic bytes:
+    - 3C 3F 78 6D 6C
+    - 3C 3F 73 76 67
+
+    Native QT support.
+    """
+    return h[:2] == b"\x3C\x3F" and (h[2:5] in [b"\x78\x6D\x6C", b"\x73\x76\x67"])
+
+
+def _test_pbm(h: bytes) -> bool:
+    """Portable BitMap (PBM) in ASCII and Binary.
+
+    Extension: .pbm
+
+    Magic bytes:
+    - 50 31 0A
+    - 50 34 0A
+
+    Support: native
+    """
+    return h[0] == 0x50 and h[1] in [0x31, 0x34] and h[2] == 0x0A
+
+
+def _test_pgm(h: bytes) -> bool:
+    """Portable GrayMap (PGM) in ASCII and Binary.
+
+    Extension: .pgm
+
+    Magic bytes:
+    - 50 32 0A
+    - 50 35 0A
+
+    Support: native
+    """
+    return h[0] == 0x50 and h[1] in [0x32, 0x35] and h[2] == 0x0A
+
+
+def _test_ppm(h: bytes) -> bool:
+    """Portable PixMap (PPM) in ASCII and Binary.
+
+    Extension: .ppm
+
+    Magic bytes:
+    - 50 33 0A
+    - 50 36 0A
+
+    Support: native
+    """
+    return h[0] == 0x50 and h[1] in [0x33, 0x36] and h[2] == 0x0A
+
+
+def _test_bmp(h: bytes) -> bool:
+    """BitMaP (BMP).
+
+    Extension: .bmp, .dib
+
+    Magic bytes:
+    - 42 4D
+
+    Support: native
+    """
+    return h[0:2] == b"\x42\x4D"
+
+
+def _test_xbm(h: bytes) -> bool:
+    """X BitMap (XBM).
+
+    Extension: .xbm
+
+    Magic Bytes:
+    - ?? ?? (impossible to detect)
+
+    Support: native
+    """
+    # TODO: implement check
+    raise NotImplementedError()
+
+
+def _test_xpm(h: bytes) -> bool:
+    """X PixMap (XPM).
+
+    Extension: .xpm
+
+    Magic Bytes:
+    - 2F 2A 20 58 50 4D 20 2A 2F
+
+    Support: native
+    """
+    return h[:9] == b"\x2F\x2A\x20\x58\x50\x4D\x20\x2A\x2F"
+
+
+def _test_webp(h: bytes) -> bool:
+    """Web Picture format (WebP).
+
+    Raster graphics format intended to replace JPEG, PNG, GIF.
+
+    Extension: .webp
+
+    Magic bytes:
+    - 52 49 46 46 ?? ?? ?? ?? 57 45 42 50
+
+    Support: extended
+    """
+    return h[:4] == b"\x52\x49\x46\x46" and h[8:12] == b"\x57\x45\x42\x50"
+
+
+def _test_tiff(h: bytes) -> bool:
+    """Tagged Image File Format (TIFF).
+
+    Raster graphics format often used by professionals.
+
+    Extension: .tiff, .tif
+
+    Magic Bytes:
+    - 49 49 2A 00
+    - 4D 4D 00 2A
+
+    Support: extended
+    """
+    return h[:4] in [b"\x49\x49\x2A\x00", b"\x4D\x4D\x00\x2A"]
+
+
+def _test_ico(h: bytes) -> bool:
+    """ICOn (ICO).
+
+    Windows' ICON format. Extended to CUR.
+
+    Extension: .ico
+
+    Magic Bytes:
+    - 00 00 01 00
+
+    Support: extended
+    """
+    return h[:4] == b"\x00\x00\x01\x00"
+
+
+def _test_icns(h: bytes) -> bool:
+    """Icon Container (ICNS).
+
+    Apple's ICON format.
+
+    Extension: .icns
+
+    Magic Bytes:
+    - 69 63 6e 73
+
+    Support: extended
+    """
+    return h[:4] == b"\x69\x63\x6e\x73"
+
+
+def _test_jp2(h: bytes) -> bool:
+    """JPEP 2000.
+
+    Extension: .jp2 (TODO: maybe also others)
+
+    Magic Bytes:
+    - 00 00 00 0C 6A 50 20 20 0D 0A 87 0A
+
+    Support: extended
+    """
+    return h[:12] == b"\x00\x00\x00\x0C\x6A\x50\x20\x20\x0D\x0A\x87\x0A"
+
+
+def _test_cur(h: bytes) -> bool:
+    """CURsor (CUR).
+
+    Windows' ICON format. Extended from ICO.
+
+    Extension: .cur
+
+    Magic Bytes:
+    - (I do not know)
+
+    Support: extended
+    """
+    # TODO: implement check
+    raise NotImplementedError()
+
+
+def _test_mng(h: bytes) -> bool:
+    """Multiple-image Network Graphics (MNG).
+
+    Like PNG but supports animations.
+
+    Extension: .mng
+
+    Magic Bytes:
+    - (I do not know)
+
+    Support: extended
+    """
+    # TODO: implement check
+    raise NotImplementedError()
+
+
+def _test_tga(h: bytes) -> bool:
+    """Truevision Graphics Adapter (TGA).
+
+    Extension: .tga, .icb, .vda, .vst
+
+    Magic Bytes:
+    - ?? ?? ?? (impossible to detect)
+
+    Support: extended
+    """
+    # TODO: implement check
+    raise NotImplementedError()
+
+
+# Register all check functions. Check functions of more frequently used types should be
+# registered first, to make the detection more efficient.
+register("jpg", _test_jpg)
+register("png", _test_png)
+register("gif", _test_gif)
+register("jp2", _test_jp2)
+register("webp", _test_webp)
+register("tiff", _test_tiff)
+register("svg", _test_svg)
+register("ico", _test_ico)
+register("icns", _test_icns)
+register("pbm", _test_pbm)
+register("pgm", _test_pgm)
+register("ppm", _test_ppm)
+register("bmp", _test_bmp)
+register("xpm", _test_xpm)

--- a/vimiv/utils/imageheader.py
+++ b/vimiv/utils/imageheader.py
@@ -106,9 +106,6 @@ def register(
 
         If not, then the filetype check is unregistered.
         """
-        if not validate:
-            return check(header, file)
-
         if check(header, file):
             if hasattr(check_verified, "checked"):
                 return True
@@ -125,10 +122,12 @@ def register(
             _registry.remove((filetype, check_verified))
         return False
 
+    check_register = check_verified if validate else check
+
     if priority:
-        _registry.insert(0, (filetype, check_verified))
+        _registry.insert(0, (filetype, check_register))
     else:
-        _registry.append((filetype, check_verified))
+        _registry.append((filetype, check_register))
 
 
 def _test_jpg(h: bytes, _f: BinaryIO) -> bool:

--- a/vimiv/utils/imagereader.py
+++ b/vimiv/utils/imagereader.py
@@ -12,7 +12,7 @@ from typing import Dict, Callable
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QImageReader, QPixmap, QImage
 
-from .files import imghdr
+from vimiv.utils import imageheader
 
 external_handler: Dict[str, Callable[[str], QPixmap]] = {}
 
@@ -109,7 +109,7 @@ def get_reader(path: str) -> BaseReader:
     """Retrieve the appropriate image reader class for path."""
     error = ValueError(f"'{path}' cannot be read as image")
     try:
-        file_format = imghdr.what(path)
+        file_format = imageheader.detect(path)
     except OSError:
         raise error
     if file_format is None:


### PR DESCRIPTION
replaces #646 

Since imghdr is getting deprecated from the standard library (see #579), this PR replaces that module by a own (and thereby, legally completely decoupled independent (unlike in #646)), implementation of the magic byte file type detection.

Some advantages of this approach, over using the package:
- Detect (all) file types which are actually supported by QT natively or extended (by using qtiamgeformats)
    - Well, some are not detectable...
- Detect none which are not supported
- Have a central place for all magic byte checks
    - Cleanup of `utils/files` and `plugin/imageformats`
- Well structured magic byte checks allows for better maintainability
- `plugin/imageformats` has a specific and well defined purpose
    - I.e. enable image type support that require the (manual) installation of some other QT module

And something that I like particularly well:
The runtime validation of *check functions*, (used to be done for all checks that were registered using `utils/files/add_image_formats`), is now done for all image types, except the ones natively supported by QT. This way, clients get a notification when they try to open an image of a type that:
- is supported only by qtimageformats, without having that module installed
- is supported by a 3rd party QT module and was activated via `plugins/imageformats`, without having that module installed
This should prevent confusions as in #619, and previous similar issues.

## Steps
- [x] Add check function for all types natively or extended supported
    - WBMP is completely undetectable
    - TGA version 1 is undetectable, while version 2 is
    - XBM has no signature, but can be matched based on its content
    - See docstring in `utils/imagheader` for status supported types
- [x] Add registration function
    - [x] Allow for runtime check validation
- [x] Add type detection function
- [x] Cleanup and adaption of codebase to new `utils/imageheader`
- [x] Cleanup of `plugins/imageformats`
- [x] Tests

I have already added a basic tests that verifies the detection of all filetypes which `QPixmap` is capable of writing (/creating) (as you suggested in the other PR). Unfortunately, it is capable of creating less types than what it is able to read. I have to think about ways to create and test the other types.

So, code-wise this PR is done, and if time allows, you may have a look at it. I will spend some more time for testing.

In what way does it make sense that copyright in the header of the new file is required to start at 2017? Should it not start in the year the file was first added to the project (i.e. 2023 in this case)?

fixes #579 
replaces #646 