### PR TITLE
Lazy Loading Overhaul

### DIFF
--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -472,7 +472,7 @@ class thumbnail:  # pylint: disable=invalid-name
     save = BoolSetting("thumbnail.save", True, desc="Save thumbnails to disk")
     max_behind = IntSetting("thumbnail.max_behind", 50, desc="Maximum number of thumbnails to render behind the currently selected one.")
     max_ahead = IntSetting("thumbnail.max_ahead", 50, desc="Maximum number of thumbnails to render ahead of the currently selected one.")
-
+    max_count = IntSetting("thumbnail.max_count", 200, desc="Maximum number of thumbnails to render in general.")
 
 class slideshow:  # pylint: disable=invalid-name
     """Namespace for slideshow related settings."""

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -470,9 +470,9 @@ class thumbnail:  # pylint: disable=invalid-name
 
     size = ThumbnailSizeSetting("thumbnail.size", 128, desc="Size of thumbnails")
     save = BoolSetting("thumbnail.save", True, desc="Save thumbnails to disk")
-    max_behind = IntSetting("thumbnail.max_behind", 50, desc="Maximum number of thumbnails to render behind the currently selected one.")
-    max_ahead = IntSetting("thumbnail.max_ahead", 50, desc="Maximum number of thumbnails to render ahead of the currently selected one.")
-    max_count = IntSetting("thumbnail.max_count", 200, desc="Maximum number of thumbnails to render in general.")
+    max_behind = IntSetting("thumbnail.max_behind", 0, desc="Maximum number of thumbnails to render behind the currently selected one.")
+    max_ahead = IntSetting("thumbnail.max_ahead", 0, desc="Maximum number of thumbnails to render ahead of the currently selected one.")
+    max_count = IntSetting("thumbnail.max_count", 0, desc="Maximum number of thumbnails to render in general.")
 
 class slideshow:  # pylint: disable=invalid-name
     """Namespace for slideshow related settings."""

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -469,6 +469,7 @@ class thumbnail:  # pylint: disable=invalid-name
     """Namespace for thumbnail related settings."""
 
     size = ThumbnailSizeSetting("thumbnail.size", 128, desc="Size of thumbnails")
+    save = BoolSetting("thumbnail.save", True, desc="Save thumbnails to disk")
 
 
 class slideshow:  # pylint: disable=invalid-name

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -450,6 +450,11 @@ class image:  # pylint: disable=invalid-name
         True,
         desc="Require holding the control modifier for zooming with the mouse wheel",
     )
+    id_by_extension = BoolSetting(
+        "image.id_by_extension",
+        False,
+        desc="Instead of scanning the image to determine that it's a compatible format, assume the extension accurately represents the format.",
+    )
 
 
 class library:  # pylint: disable=invalid-name

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -470,6 +470,8 @@ class thumbnail:  # pylint: disable=invalid-name
 
     size = ThumbnailSizeSetting("thumbnail.size", 128, desc="Size of thumbnails")
     save = BoolSetting("thumbnail.save", True, desc="Save thumbnails to disk")
+    max_behind = IntSetting("thumbnail.max_behind", 50, desc="Maximum number of thumbnails to render behind the currently selected one.")
+    max_ahead = IntSetting("thumbnail.max_ahead", 50, desc="Maximum number of thumbnails to render ahead of the currently selected one.")
 
 
 class slideshow:  # pylint: disable=invalid-name

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -325,6 +325,7 @@ class OrderSetting(Setting):
         "alphabetical": str,
         "natural": natural_sort,
         "recently-modified": os.path.getmtime,
+		"passthrough": None
     }
 
     STR_ORDER_TYPES = "alphabetical", "natural"
@@ -347,6 +348,8 @@ class OrderSetting(Setting):
 
     def sort(self, values: Iterable[str]) -> List[str]:
         """Sort values according to the current ordering."""
+        if self.value == "passthrough":
+            return values
         ordering = self._get_ordering()
         return sorted(values, key=ordering, reverse=sort.reverse.value)
 
@@ -473,6 +476,7 @@ class thumbnail:  # pylint: disable=invalid-name
     max_behind = IntSetting("thumbnail.max_behind", 0, desc="Maximum number of thumbnails to render behind the currently selected one.")
     max_ahead = IntSetting("thumbnail.max_ahead", 0, desc="Maximum number of thumbnails to render ahead of the currently selected one.")
     max_count = IntSetting("thumbnail.max_count", 0, desc="Maximum number of thumbnails to render in general.")
+
 
 class slideshow:  # pylint: disable=invalid-name
     """Namespace for slideshow related settings."""
@@ -613,3 +617,4 @@ class sort:  # pylint: disable=invalid-name
         False,
         desc="Randomly shuffle images and ignoring all other sort settings",
     )
+

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -455,6 +455,11 @@ class image:  # pylint: disable=invalid-name
         False,
         desc="Instead of scanning the image to determine that it's a compatible format, assume the extension accurately represents the format.",
     )
+    imghdr_fallback = BoolSetting(
+        "image.imghdr_fallback",
+        True,
+        desc="If identifying a file by extension (when image.id_by_extension is set) files to open a file, try identifying it using imghdr before giving up."
+    )
 
 
 class library:  # pylint: disable=invalid-name

--- a/vimiv/gui/thumbnail.py
+++ b/vimiv/gui/thumbnail.py
@@ -173,10 +173,10 @@ class ThumbnailView(
     def _prune_index(self, index) -> None:
         """Unload the icon associated with a particular path index."""
         item = self.item(index)
-		# Otherwise it has been deleted in the meanwhile
+        # Otherwise it has been deleted in the meanwhile
         if item is not None and\
-		   (api.settings.thumbnail.max_count.value == 0 or\
-		   len(self._rendered_paths) > api.settings.thumbnail.max_count.value):
+           (api.settings.thumbnail.max_count.value == 0 or\
+           len(self._rendered_paths) > api.settings.thumbnail.max_count.value):
             item.setIcon(ThumbnailItem.default_icon())
             self._rendered_paths.discard(self._paths[index])
 

--- a/vimiv/gui/thumbnail.py
+++ b/vimiv/gui/thumbnail.py
@@ -226,6 +226,7 @@ class ThumbnailView(
             _logger.debug("No new images to load")
             return
         _logger.debug("Updating thumbnails...")
+        self._rendered_paths.clear()
         removed = set(self._paths) - set(paths)
         for path in removed:
             _logger.debug("Removing existing thumbnail '%s'", path)
@@ -233,8 +234,6 @@ class ThumbnailView(
             del self._paths[idx]  # Remove as the index also changes in the QListWidget
             if not self.takeItem(idx):
                 _logger.error("Error removing thumbnail for '%s'", path)
-            else:
-                self._rendered_paths.remove(path)
         size_hint = QSize(self.item_size(), self.item_size())
         for i, path in enumerate(paths):
             if path not in self._paths:  # Add new path

--- a/vimiv/gui/thumbnail.py
+++ b/vimiv/gui/thumbnail.py
@@ -187,7 +187,7 @@ class ThumbnailView(
 
     def _prune_icons_ahead(self) -> None:
         """Prune indexes after the current index."""
-        for index in range(self._last_index() + 1, len(self._paths)):
+        for index in reversed(range(self._last_index() + 1, len(self._paths))):
             self._prune_index(index)
 
     def _prune_icons(self) -> None:

--- a/vimiv/utils/files.py
+++ b/vimiv/utils/files.py
@@ -13,11 +13,26 @@ from typing import List, Tuple, Optional, BinaryIO, Iterable, Callable
 
 from PyQt5.QtGui import QImageReader
 
+from vimiv import api
 from vimiv.utils import imagereader
 
 
 ImghdrTestFuncT = Callable[[bytes, Optional[BinaryIO]], bool]
 
+image_format_names = set(('.rgb',
+                          '.gif',
+                          '.pbm',
+                          '.pgm',
+                          '.ppm',
+                          '.tiff',
+                          '.rast',
+                          '.xbm',
+                          '.jpeg',
+                          '.jpg',
+                          '.bmp',
+                          '.png',
+                          '.webp',
+                          '.exr'))
 
 def listdir(directory: str, show_hidden: bool = False) -> List[str]:
     """Wrapper around os.listdir.
@@ -121,7 +136,14 @@ def is_image(filename: str) -> bool:
         filename: Name of file to check.
     """
     try:
-        return os.path.isfile(filename) and imghdr.what(filename) is not None
+        if not os.path.isfile(filename):
+            return False
+        elif api.settings.image.id_by_extension:
+            return os.path.splitext(filename)[1].lower() in image_format_names
+        elif imghdr.what(filename) is not None:
+            return True
+        else:
+            return False
     except OSError:
         return False
 
@@ -164,6 +186,7 @@ def add_image_format(name: str, check: ImghdrTestFuncT) -> None:
             imghdr.tests.remove(test)
         return None
 
+    image_format_names.add(name)
     imghdr.tests.insert(add_image_format.index, test)  # type: ignore
     add_image_format.index += 1  # type: ignore
 

--- a/vimiv/utils/files.py
+++ b/vimiv/utils/files.py
@@ -186,7 +186,8 @@ def add_image_format(name: str, check: ImghdrTestFuncT) -> None:
             imghdr.tests.remove(test)
         return None
 
-    image_format_names.add(name)
+    global image_format_names
+    image_format_names.add(''.join(('.', name)))
     imghdr.tests.insert(add_image_format.index, test)  # type: ignore
     add_image_format.index += 1  # type: ignore
 
@@ -199,7 +200,6 @@ def test_svg(h: bytes, _f: Optional[BinaryIO]) -> bool:
 
 
 add_image_format("svg", test_svg)
-
 
 def test_ico(h: bytes, _f: Optional[BinaryIO]) -> bool:
     return h.startswith(bytes.fromhex("00000100"))

--- a/vimiv/utils/imagereader.py
+++ b/vimiv/utils/imagereader.py
@@ -8,10 +8,12 @@
 
 import abc
 from typing import Dict, Callable
+from os.path import splitext
 
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QImageReader, QPixmap, QImage
 
+from vimiv import api
 from .files import imghdr
 
 external_handler: Dict[str, Callable[[str], QPixmap]] = {}
@@ -109,7 +111,12 @@ def get_reader(path: str) -> BaseReader:
     """Retrieve the appropriate image reader class for path."""
     error = ValueError(f"'{path}' cannot be read as image")
     try:
-        file_format = imghdr.what(path)
+        if api.settings.image.id_by_extension:
+            file_format = splitext(path)[1].lower()[1:]
+            if file_format == 'jpg':
+                file_format = 'jpeg'
+        else:
+            file_format = imghdr.what(path)
     except OSError:
         raise error
     if file_format is None:

--- a/vimiv/utils/thumbnail_manager.py
+++ b/vimiv/utils/thumbnail_manager.py
@@ -72,14 +72,15 @@ class ThumbnailManager(QObject):
         xdg.makedirs(self.directory, self.fail_directory)
         self.fail_pixmap = fail_pixmap
 
-    def create_thumbnails_async(self, paths: List[str]) -> None:
+    def create_thumbnails_async(self, indices: List[int], paths: List[str]) -> None:
         """Start ThumbnailsCreator for each path to create thumbnails.
 
         Args:
+            indices: The corresponding index of the thumbnail for each path.
             paths: Paths to create thumbnails for.
         """
         self.pool.clear()
-        for i, path in enumerate(paths):
+        for i, path in zip(indices, paths):
             self.pool.start(ThumbnailCreator(i, path, self))
 
 


### PR DESCRIPTION
Included in this pull request are a number of changes to the way images are loaded by vimiv, with special focus on lazy loading. The code is most certainly not ready to be merged with the upstream project. Tests need to be written for it, the code generally needs to be cleaned up and the style made consistent, and any ideas that don't work well with the vision for upstream vimiv must be removed.

The rationale for these changes is primarily to accommodate the author's niche and specific use case. That is browsing sets of thousands of images, while minimizing memory usage and redundant disk IO. These images are typically sorted externally and fed in through stdin, so their order must be maintained.

The intention was to make all changes opt-in by means of configuration variables, the default values of which would maintain the original behavior of the software. These changes are already seeing use in my personal fork, so I will not be offended if they are turned down.

The following configuration variables are added to change the behavior of the software:

|                         |                                                                                                                                                                                                                                                        |
|:------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
|`thumbnail.save`         |If set to False, thumbnails will not be cached to the drive.                                                                                                                                                                                            |
|`thumbnail.max_ahead`    |Only this number of thumbnails after the current selection will be loaded. Changing the selection will modify the range of loaded thumbnails accordingly. If zero, load unlimited, as is the default.                                                   |
|`thumbnail.max_behind`   |Like `thumbnail.max_ahead`, but for thumbnails preceding the current selection.                                                                                                                                                                         |
|`thumbnail.max_count`    |Thumbnails will not be unloaded unless the number of them exceeds this. Note, that this does not cause thumbnails to be forcibly unloaded, so this variable should probably be renamed. Anyway, set to 0 to immediately unload out of range thumbnails. |
|`image.id_by_extension`  |If set to True, use the extension to assume the filetype, instead of reading with `imghdr`. This prevents large sets of images from being all opened when starting.                                                                                     |
|`image.imghdr_fallback`  |If set to True and an image fails to load by a reader guessed by `image.id_by_extension`, try using imghdr to find an appropriate reader. In light of the pending replacement of imghdr, this should perhaps be renamed.                                |


`sort.image_order` and `sort.directory_order` also now have a `passthrough` sort option, which will maintain the order that images were provided to vimiv from the command line or stdin. Will probably remove `sort.directory_order`, since it's unlikely to be very useful. And I don't think it works properly.