### PR TITLE
Add the 'none' sorting setting

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,6 +3,7 @@ Wolfgang Popp (woefe) <mail at wolfgang-popp dot de>
 Ankur Sinha (sanjayankur31) <ankursinha at fedoraproject dot org>
 Jean-Claude Graf (jcjgraf) <jeanggi90 at gmail dot com>
 Mateus Etto (Yutsuten) <mateus dot etto at gmail dot com>
+buzzingwires (buzzingwires) <buzzingwires at outlook dot com>
 
 All contributors of non-trivial code are listed here. Please send an email to
 <karlch at protonmail dot com> or open an issue / pull request if you feel like your

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -537,3 +537,4 @@ Initial release of the Qt version.
 .. _@timsofteng: https://github.com/timsofteng
 .. _@kAldown: https://github.com/kaldown
 .. _@Yutsuten: https://github.com/Yutsuten
+.. _@buzzingwires: https://github.com/buzzingwires

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -89,6 +89,8 @@ Added:
   the changes with ``<return>`` and reject them with ``<escape>``. The
   ``{transformation-info}`` status module displays the currently selected geometry of
   the original image. Thanks `@Yutsuten`_ for reviving this!
+* Add the ``none`` sorting type for the ``sort.image_order`` and ``sort.directory_order``
+  options, implemented by `@buzzingwires`_
 
 Changed:
 ^^^^^^^^

--- a/docs/documentation/configuration/settings.rst
+++ b/docs/documentation/configuration/settings.rst
@@ -56,7 +56,7 @@ directories. The ordering principle is defined by the ``sort.image_order`` and
    natural                   Natural ordering by basename, i.e. image2.jpg comes before image11.jpg
    recently-modified         Ordering by modification time (``mtime``)
    size                      Ordering by filesize, in bytes for images, in number of files for directories
-   none                      Do not sort or reverse. Use the previous order of the images. If changed to from another sorting type, that order will be used.
+   none                      Do not sort or reverse. Use the existing order of the images (including that of a previous sort type). This is mostly for keeping the order from the command line or stdin.
    ========================= ===========
 
 In addition, the ordering can be reversed using ``sort.reverse`` and the string-like

--- a/docs/documentation/configuration/settings.rst
+++ b/docs/documentation/configuration/settings.rst
@@ -56,9 +56,11 @@ directories. The ordering principle is defined by the ``sort.image_order`` and
    natural                   Natural ordering by basename, i.e. image2.jpg comes before image11.jpg
    recently-modified         Ordering by modification time (``mtime``)
    size                      Ordering by filesize, in bytes for images, in number of files for directories
+   none                      Do not sort or reverse. Use the previous order of the images. If changed to from another sorting type, that order will be used.
    ========================= ===========
 
 In addition, the ordering can be reversed using ``sort.reverse`` and the string-like
 orderings (``alphabetical`` and ``natural``) can be made case-insensitive using
-``sort.ignore_case``. When ``sort.shuffle`` is set, the image filelist is shuffled
-regardless of the other orderings, but the library remains ordered.
+``sort.ignore_case`` except for when the ``none`` ordering type is used.
+When ``sort.shuffle`` is set, the image filelist is shuffled regardless of the other
+orderings, but the library remains ordered.

--- a/tests/end2end/features/image/imageorder.feature
+++ b/tests/end2end/features/image/imageorder.feature
@@ -8,6 +8,26 @@ Feature: Ordering the image filelist.
         And the image number 2 should be image_2.jpg
         And the image number 11 should be image_11.jpg
 
+	Scenario: Set none sorting after another sort
+        Given I open 12 images without leading zeros in their name
+        When I run set sort.image_order natural
+        Then the image should have the index 1
+        And the image number 1 should be image_1.jpg
+        And the image number 2 should be image_2.jpg
+        And the image number 11 should be image_11.jpg
+        When I run set sort.image_order none
+        Then the image should have the index 1
+        And the image number 1 should be image_1.jpg
+        And the image number 2 should be image_2.jpg
+        And the image number 11 should be image_11.jpg
+
+    Scenario: Reverse none sorting
+        Given I open 5 images
+        When I run set sort.image_order none
+        Then the image should have the index 1
+        When I run set sort.reverse
+        Then the image should have the index 1
+
     Scenario: Reverse current filelist
         Given I open 5 images
         When I run set sort.reverse!

--- a/tests/unit/api/test_settings.py
+++ b/tests/unit/api/test_settings.py
@@ -189,6 +189,17 @@ def test_order_setting_sort(
     assert sorted_values == expected_values
 
 
+@pytest.mark.parametrize("reverse", [True, False])
+@pytest.mark.parametrize("ignore_case", [True, False])
+def test_order_setting_sort_none(monkeypatch, reverse, ignore_case):
+    values = ["a5.j", "A6.j", "a11.j", "a3.j"]
+    monkeypatch.setattr(settings.sort.reverse, "value", reverse)
+    monkeypatch.setattr(settings.sort.ignore_case, "value", ignore_case)
+    o = settings.OrderSetting("order", "none")
+    sorted_values = o.sort(values)
+    assert sorted_values == values
+
+
 @pytest.mark.parametrize("ignore_case", [True, False])
 def test_order_setting_sort_ignore_case(monkeypatch, ignore_case):
     monkeypatch.setattr(settings.sort.ignore_case, "value", ignore_case)

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -325,6 +325,7 @@ class OrderSetting(Setting):
         "alphabetical": str,
         "natural": natural_sort,
         "recently-modified": os.path.getmtime,
+        "none": lambda x: 0
     }
 
     STR_ORDER_TYPES = "alphabetical", "natural"


### PR DESCRIPTION
Starting with what I consider to be one of the simplest changes discussed in #651 and as always, nothing is as simple as expected.

It works pretty much as discussed, but it's worth noting that I found reversing the sort order does not work, probably because `lambda x: 0` doesn't provide the sorting algorithm varied numbers to meaningfully reverse. I toyed around with ways of making reversing work, but figured I'd stay with the agreed upon approach of keeping this setting simple for now.

---

For sort 'image_order' and 'directory_order', the 'none' setting can be used to allow images to follow the last order they were encountered in by the software, instead of re-sorting.

Note that setting another sorting mode while the software is running then switching back to 'none' will see files remain in the previous sort order. The original order of images is *not* tracked.

Additionally, 'none' sort cannot be reversed.