### PR TITLE
Update icons cache on manual install

### DIFF
--- a/docs/documentation/install.rst
+++ b/docs/documentation/install.rst
@@ -81,6 +81,8 @@ should work.
 
 .. include:: dependency_info.rst
 
+.. include:: updating_icon_cache.rst
+
 .. _install_using_tox:
 
 Using Tox

--- a/docs/documentation/updating_icon_cache.rst
+++ b/docs/documentation/updating_icon_cache.rst
@@ -1,0 +1,6 @@
+.. note::
+
+    You may need to run ``gtk-update-icon-cache /usr/share/icons/hicolor`` (replace the
+    path if installing the icons somewhere else) after the install to get the vimiv icon
+    in your application launcher. It has been reported that the command was needed for
+    `wofi <https://hg.sr.ht/~scoopta/wofi>`_.

--- a/misc/Makefile
+++ b/misc/Makefile
@@ -37,7 +37,6 @@ install:
 	gzip -n -9 -f  $(MANDIR)/man1/vimiv.1
 	$(foreach i,$(ICONSIZES),install -Dm644 icons/vimiv_${i}x${i}.png $(DATADIR)/icons/hicolor/${i}x${i}/apps/vimiv.png;)
 	install -Dm644 icons/vimiv.svg $(DATADIR)/icons/hicolor/scalable/apps/vimiv.svg
-	-gtk-update-icon-cache $(DATADIR)/icons/hicolor
 
 uninstall:
 	scripts/uninstall_pythonpkg.sh
@@ -47,7 +46,6 @@ uninstall:
 	rm $(MANDIR)/man1/vimiv.1.gz
 	$(foreach i,$(ICONSIZES),rm $(DATADIR)/icons/hicolor/${i}x${i}/apps/vimiv.png;)
 	rm $(DATADIR)/icons/hicolor/scalable/apps/vimiv.svg
-	-gtk-update-icon-cache $(DATADIR)/icons/hicolor
 
 clean:
 	rm -rf build vimiv.egg-info/

--- a/misc/Makefile
+++ b/misc/Makefile
@@ -37,6 +37,7 @@ install:
 	gzip -n -9 -f  $(MANDIR)/man1/vimiv.1
 	$(foreach i,$(ICONSIZES),install -Dm644 icons/vimiv_${i}x${i}.png $(DATADIR)/icons/hicolor/${i}x${i}/apps/vimiv.png;)
 	install -Dm644 icons/vimiv.svg $(DATADIR)/icons/hicolor/scalable/apps/vimiv.svg
+	-gtk-update-icon-cache $(DATADIR)/icons/hicolor
 
 uninstall:
 	scripts/uninstall_pythonpkg.sh
@@ -46,6 +47,7 @@ uninstall:
 	rm $(MANDIR)/man1/vimiv.1.gz
 	$(foreach i,$(ICONSIZES),rm $(DATADIR)/icons/hicolor/${i}x${i}/apps/vimiv.png;)
 	rm $(DATADIR)/icons/hicolor/scalable/apps/vimiv.svg
+	-gtk-update-icon-cache $(DATADIR)/icons/hicolor
 
 clean:
 	rm -rf build vimiv.egg-info/


### PR DESCRIPTION
Today I spent about two hours searching why when installing `vimiv-qt` manually (using `sudo make install`), vimiv's icon wouldn't appear in my application launcher (wofi).

According to [wofi man page](https://man.archlinux.org/man/wofi.7.en):

> When images are enabled drun mode will pull icon themes however being a GTK app it's possible you'll need to run gtk-update-icon-cache to get them to apply.

Then after searching about how to use `gtk-update-icon-cache` [[1]](https://manpages.ubuntu.com/manpages/xenial/man1/gtk-update-icon-cache.1.html) [[2]](https://man.archlinux.org/man/gtk4-update-icon-cache.1.en), I came up with this fix.

As I don't know if every system contains `gtk-update-icon-cache`, I allowed the command to fail by prepending it with `-`.

Hope this is an acceptable change.