### PR TITLE
Add thumbnail.save configuration option.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -91,6 +91,7 @@ Added:
   the original image. Thanks `@Yutsuten`_ for reviving this!
 * Add the ``none`` sorting type for the ``sort.image_order`` and ``sort.directory_order``
   options, implemented by `@buzzingwires`_
+* Add the ``thumbnail.save`` option, implemented by `@buzzingwires`_
 
 Changed:
 ^^^^^^^^

--- a/tests/integration/test_read_settings.py
+++ b/tests/integration/test_read_settings.py
@@ -19,7 +19,7 @@ from vimiv.config import configfile
 UPDATED_CONFIG = {
     "SORT": {"shuffle": "True"},
     "IMAGE": {"overzoom": "4.2"},
-    "THUMBNAIL": {"size": "64", "save": "False"},
+    "THUMBNAIL": {"size": "64"},
 }
 
 
@@ -46,7 +46,7 @@ UPDATED_EXIF_KEY_SETS = {
 UPDATED_CONFIG_INVALID = {
     "SORT": {"shuffle": "not a bool"},
     "IMAGE": {"overzoom": "not a float"},
-    "THUMBNAIL": {"size": "not an int", "save": "not a bool"},
+    "THUMBNAIL": {"size": "not an int"},
 }
 
 
@@ -86,7 +86,6 @@ def test_read_config(configpath):
     assert api.settings.sort.shuffle.value is True
     assert api.settings.image.overzoom.value == 4.2
     assert api.settings.thumbnail.size.value == 64
-    assert api.settings.thumbnail.save.value is False
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/test_read_settings.py
+++ b/tests/integration/test_read_settings.py
@@ -19,7 +19,7 @@ from vimiv.config import configfile
 UPDATED_CONFIG = {
     "SORT": {"shuffle": "True"},
     "IMAGE": {"overzoom": "4.2"},
-    "THUMBNAIL": {"size": "64"},
+    "THUMBNAIL": {"size": "64", "save": "False"},
 }
 
 
@@ -46,7 +46,7 @@ UPDATED_EXIF_KEY_SETS = {
 UPDATED_CONFIG_INVALID = {
     "SORT": {"shuffle": "not a bool"},
     "IMAGE": {"overzoom": "not a float"},
-    "THUMBNAIL": {"size": "not an int"},
+    "THUMBNAIL": {"size": "not an int", "save": "not a bool"},
 }
 
 
@@ -86,6 +86,7 @@ def test_read_config(configpath):
     assert api.settings.sort.shuffle.value is True
     assert api.settings.image.overzoom.value == 4.2
     assert api.settings.thumbnail.size.value == 64
+    assert api.settings.thumbnail.save.value is False
 
 
 @pytest.mark.parametrize(

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -470,6 +470,7 @@ class thumbnail:  # pylint: disable=invalid-name
     """Namespace for thumbnail related settings."""
 
     size = ThumbnailSizeSetting("thumbnail.size", 128, desc="Size of thumbnails")
+    save = BoolSetting("thumbnail.save", True, desc="Save new thumbnails to disk for later use")
 
 
 class slideshow:  # pylint: disable=invalid-name

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -470,7 +470,9 @@ class thumbnail:  # pylint: disable=invalid-name
     """Namespace for thumbnail related settings."""
 
     size = ThumbnailSizeSetting("thumbnail.size", 128, desc="Size of thumbnails")
-    save = BoolSetting("thumbnail.save", True, desc="Save new thumbnails to disk for later use")
+    save = BoolSetting(
+        "thumbnail.save", True, desc="Save new thumbnails to disk for later use"
+    )
 
 
 class slideshow:  # pylint: disable=invalid-name

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -472,8 +472,8 @@ class thumbnail:  # pylint: disable=invalid-name
     size = ThumbnailSizeSetting("thumbnail.size", 128, desc="Size of thumbnails")
     save = BoolSetting(
         "thumbnail.save",
-		True,
-		desc="Save new thumbnails to the disk in the shared icon cache for later use"
+        True,
+        desc="Save new thumbnails to the disk in the shared icon cache for later use"
     )
 
 

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -471,7 +471,9 @@ class thumbnail:  # pylint: disable=invalid-name
 
     size = ThumbnailSizeSetting("thumbnail.size", 128, desc="Size of thumbnails")
     save = BoolSetting(
-        "thumbnail.save", True, desc="Save new thumbnails to disk for later use"
+        "thumbnail.save",
+		True,
+		desc="Save new thumbnails to the disk in the shared icon cache for later use"
     )
 
 

--- a/vimiv/utils/thumbnail_manager.py
+++ b/vimiv/utils/thumbnail_manager.py
@@ -22,6 +22,7 @@ from PyQt5.QtCore import QRunnable, pyqtSignal, QObject
 from PyQt5.QtGui import QIcon, QPixmap, QImage
 
 import vimiv
+from vimiv import api
 from vimiv.utils import xdg, imagereader, Pool
 
 
@@ -131,6 +132,24 @@ class ThumbnailCreator(QRunnable):
     def _get_source_mtime(path: str) -> int:
         return int(os.path.getmtime(path))
 
+    def _save_thumbnail(self, image: QImage, thumbnail_path: str) -> None:
+        """Save the thumbnail file to the disk.
+
+        Args:
+            image: The QImage representing the thumbnail.
+            thumbnail_path: Path to which the thumbnail is stored.
+        Returns:
+            None.
+        """
+        # First create temporary file and then move it. This avoids
+        # problems with concurrent access of the thumbnail cache, since
+        # "move" is an atomic operation
+        handle, tmp_filename = tempfile.mkstemp(dir=self._manager.directory)
+        os.close(handle)
+        os.chmod(tmp_filename, 0o600)
+        image.save(tmp_filename, format="png")
+        os.replace(tmp_filename, thumbnail_path)
+
     def _create_thumbnail(self, path: str, thumbnail_path: str) -> QPixmap:
         """Create thumbnail for an image.
 
@@ -153,14 +172,8 @@ class ThumbnailCreator(QRunnable):
             return self._manager.fail_pixmap
         for key, value in attributes.items():
             image.setText(key, value)
-        # First create temporary file and then move it. This avoids
-        # problems with concurrent access of the thumbnail cache, since
-        # "move" is an atomic operation
-        handle, tmp_filename = tempfile.mkstemp(dir=self._manager.directory)
-        os.close(handle)
-        os.chmod(tmp_filename, 0o600)
-        image.save(tmp_filename, format="png")
-        os.replace(tmp_filename, thumbnail_path)
+        if api.settings.thumbnail.save:
+            self._save_thumbnail(image, thumbnail_path)
         return QPixmap(image)
 
     def _get_thumbnail_attributes(self, path: str, image: QImage) -> Dict[str, str]:


### PR DESCRIPTION
Continuing #651 changes. Also, the `check_thumbails_created` in `tests/unit/utils/test_thumbnail_manager.py` might be a typo. Figured this should probably be another pull request or quick commit from maintainers, though.

---

If this option is set to False, then do not save newly-generated thumbnails to the disk. Previously saved thumbnail images will be used normally and will never be deleted.

This saves space and reduces drive writes at the cost of extra computational overhead by making the original image be reopened each time the thumbnail is loaded.