### PR TITLE
CI: Replace pycodestyle with black

### DIFF
--- a/misc/requirements/requirements_lint.txt
+++ b/misc/requirements/requirements_lint.txt
@@ -1,3 +1,3 @@
 pylint==2.17.4
-pycodestyle==2.10.0
+black==23.7.0
 pydocstyle==6.3.0

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -23,7 +23,6 @@ def cached_method_cls(mocker):
     """Fixture to retrieve a class with mock utilities and a cached method."""
 
     class CachedMethodCls:
-
         RESULT = 42
 
         def __init__(self):
@@ -143,7 +142,6 @@ def test_parameter_names(function):
 @pytest.mark.parametrize("type_hint", ("int", int))
 def test_slot(type_hint):
     class Dummy(QObject):
-
         signal = pyqtSignal(int)
 
         def __init__(self):

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ deps =
 commands =
     pylint vimiv scripts/pylint_checkers
     {toxinidir}/scripts/lint_tests.py tests
-    pycodestyle vimiv tests scripts/pylint_checkers
+    black --check --diff vimiv tests scripts/pylint_checkers
     pydocstyle vimiv scripts/pylint_checkers
 allowlist_externals =
     {toxinidir}/scripts/lint_tests.py
@@ -80,14 +80,6 @@ deps = {[testenv:docs]deps}
 commands =
     {toxinidir}/scripts/src2rst.py
     sphinx-build -b man docs misc
-
-# Settings for pycodestyle
-[pycodestyle]
-max-line-length = 88
-# E203: whitespace before ':' wrongly raised for slicing
-# E501: line too long checked by pylint
-# W503: line break before binary operator does not conform to pep8
-ignore = E203,E501,W503
 
 # Settings for check-manifest
 [check-manifest]

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ deps =
 commands =
     pylint vimiv scripts/pylint_checkers
     {toxinidir}/scripts/lint_tests.py tests
-    black --check --diff vimiv tests scripts/pylint_checkers
+    black --check --diff --exclude ".*syntax_error.*" vimiv tests scripts/pylint_checkers
     pydocstyle vimiv scripts/pylint_checkers
 allowlist_externals =
     {toxinidir}/scripts/lint_tests.py


### PR DESCRIPTION
fixes #661 

Decided to keep the (few) pylint formatting issues, as they do sometimes make it easier to detect the change (e.g. for trailing whitespace) and the additional noise doesn't seem too bad.