### PR TITLE
Disable qt logging at higher log levels

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -114,6 +114,8 @@ Changed:
   backend is installed. The default behaviour can be overridden by explicitly loading a
   metadata plugin.
 * Vimiv now requires at least Python 3.8 and thus PyQt 5.13.2.
+* Qt logs of level warning / critical are now suppressed if the corresponding vimiv log
+  level is higher.
 
 Fixed:
 ^^^^^^

--- a/vimiv/utils/log.py
+++ b/vimiv/utils/log.py
@@ -47,7 +47,7 @@ In case you want to ensure that a log message is only logged a single time, pass
 import logging
 from typing import Dict, List, Optional, Any, Set
 
-from PyQt5.QtCore import pyqtSignal, QObject
+from PyQt5.QtCore import pyqtSignal, QObject, QLoggingCategory
 
 import vimiv
 
@@ -111,6 +111,11 @@ def setup_logging(level: int, *debug_modules: str) -> None:
     _app_logger.level = level
     _app_logger.handlers = [file_handler, console_handler, statusbar_loghandler]
     LazyLogger.handlers = [console_handler, file_handler]
+    # Disable qt logging at higher log levels
+    if level > logging.ERROR:
+        QLoggingCategory.setFilterRules("*.warning=false\n*.critical=false")
+    elif level > logging.WARNING:
+        QLoggingCategory.setFilterRules("*.warning=false")
     # Setup debug logging for specific module loggers
     _debug_loggers.extend(debug_modules)
     for name, logger in _module_loggers.items():


### PR DESCRIPTION
This allows us to also suppress various Qt messages.

fixes #601

@jcjgraf @Yutsuten could one of you give it a quick shot, e.g. with `vimiv --log-level error`. For me, a libpng warning is now successfully suppressed :blush: 