### PR TITLE
Implement lazy loading of thumbnails

### DIFF
--- a/tests/end2end/features/thumbnail/test_thumbnaillazy.feature
+++ b/tests/end2end/features/thumbnail/test_thumbnaillazy.feature
@@ -3,10 +3,11 @@ Feature: Lazy load thumbnails
     Scenario: Eager loading (default behavior)
         Given I open 10 images without leading zeros in their name
         And I enter thumbnail mode
+        Then there should be 10 rendered thumbnails
         When I run 5scroll right
-        Then the first index should be 0
+        Then there should be 10 rendered thumbnails
+        And the first index should be 0
         And the last index should be 9
-        And there should be 10 rendered thumbnails
 
     Scenario: Only display the selected thumbnail
         Given I open 10 images without leading zeros in their name

--- a/tests/end2end/features/thumbnail/test_thumbnaillazy.feature
+++ b/tests/end2end/features/thumbnail/test_thumbnaillazy.feature
@@ -62,4 +62,4 @@ Feature: Lazy load thumbnails
         Then there should be 6 rendered thumbnails
         And the first index should be 3
         And the last index should be 7
-		And image_8.jpg should be in the rendered thumbnails
+        And image_8.jpg should be in the rendered thumbnails

--- a/tests/end2end/features/thumbnail/test_thumbnaillazy.feature
+++ b/tests/end2end/features/thumbnail/test_thumbnaillazy.feature
@@ -1,0 +1,65 @@
+Feature: Lazy load thumbnails
+
+    Scenario: Eager loading (default behavior)
+        Given I open 10 images without leading zeros in their name
+        And I enter thumbnail mode
+        When I run 5scroll right
+        Then the first index should be 0
+        And the last index should be 9
+        And there should be 10 rendered thumbnails
+
+    Scenario: Only display the selected thumbnail
+        Given I open 10 images without leading zeros in their name
+        And I enter thumbnail mode
+        Then there should be 10 rendered thumbnails
+        When I run set thumbnail.load_behind 0
+        When I run set thumbnail.load_ahead 0
+        When I run set thumbnail.unload_threshold 0
+        When I run 5scroll right
+        Then there should be 1 rendered thumbnails
+        And the first index should be 5
+        And the last index should be 5
+
+    Scenario: Display two thumbnails behind and all ahead
+        Given I open 10 images without leading zeros in their name
+        And I enter thumbnail mode
+        Then there should be 10 rendered thumbnails
+        When I run set thumbnail.load_behind 2
+        When I run 5scroll right
+        Then there should be 7 rendered thumbnails
+        And the first index should be 3
+        And the last index should be 9
+
+    Scenario: Display two thumbnails ahead and all behind
+        Given I open 10 images without leading zeros in their name
+        And I enter thumbnail mode
+        Then there should be 10 rendered thumbnails
+        When I run set thumbnail.load_ahead 2
+        When I run 5scroll right
+        Then there should be 8 rendered thumbnails
+        And the first index should be 0
+        And the last index should be 7
+
+    Scenario: Display two thumbnails ahead and behind
+        Given I open 10 images without leading zeros in their name
+        And I enter thumbnail mode
+        Then there should be 10 rendered thumbnails
+        When I run set thumbnail.load_ahead 2
+        When I run set thumbnail.load_behind 2
+        When I run 5scroll right
+        Then there should be 5 rendered thumbnails
+        And the first index should be 3
+        And the last index should be 7
+
+    Scenario: Display two thumbnails ahead and behind but don't unload less than six tumbnails
+        Given I open 10 images without leading zeros in their name
+        And I enter thumbnail mode
+        Then there should be 10 rendered thumbnails
+        When I run set thumbnail.load_ahead 2
+        When I run set thumbnail.load_behind 2
+        When I run set thumbnail.unload_threshold 6
+        When I run 5scroll right
+        Then there should be 6 rendered thumbnails
+        And the first index should be 3
+        And the last index should be 7
+		And image_8.jpg should be in the rendered thumbnails

--- a/tests/end2end/features/thumbnail/test_thumbnaillazy_bdd.py
+++ b/tests/end2end/features/thumbnail/test_thumbnaillazy_bdd.py
@@ -1,0 +1,41 @@
+# vim: ft=python fileencoding=utf-8 sw=4 et sts=4
+
+# This file is part of vimiv.
+# Copyright 2017-2023 Christian Karl (karlch) <karlch at protonmail dot com>
+# License: GNU GPL v3, see the "LICENSE" and "AUTHORS" files for details.
+
+import pytest_bdd as bdd
+
+
+bdd.scenarios("test_thumbnaillazy.feature")
+
+
+def wait_for_thumbnails_to_load(qtbot, thumbnail):
+    def wait_thread():
+        assert thumbnail._manager.pool.activeThreadCount() == 0
+
+    qtbot.waitUntil(wait_thread, timeout=30000)
+
+
+@bdd.then(bdd.parsers.parse("{name} should be in the rendered thumbnails"))
+def check_name_in_rendered_thumbnails(tmp_path, qtbot, thumbnail, name):
+    wait_for_thumbnails_to_load(qtbot, thumbnail)
+    assert str(tmp_path / name) in thumbnail._rendered_paths
+
+
+@bdd.then(bdd.parsers.parse("there should be {number:d} rendered thumbnails"))
+def check_rendered_thumbnail_amount(qtbot, thumbnail, number):
+    wait_for_thumbnails_to_load(qtbot, thumbnail)
+    assert len(thumbnail._rendered_paths) == number
+
+
+@bdd.then(bdd.parsers.parse("the last index should be {number:d}"))
+def check_last_index(qtbot, thumbnail, number):
+    wait_for_thumbnails_to_load(qtbot, thumbnail)
+    assert thumbnail._last_index() == number
+
+
+@bdd.then(bdd.parsers.parse("the first index should be {number:d}"))
+def check_first_index(qtbot, thumbnail, number):
+    wait_for_thumbnails_to_load(qtbot, thumbnail)
+    assert thumbnail._first_index() == number

--- a/tests/unit/utils/test_thumbnail_manager.py
+++ b/tests/unit/utils/test_thumbnail_manager.py
@@ -29,7 +29,7 @@ def test_thumbnail_save_disabled(monkeypatch, qtbot, tmp_path, manager):
     monkeypatch.setattr(settings.thumbnail.save, "value", False)
     no_thumbnail_path = str(tmp_path / "no_thumbnail.jpg")
     QPixmap(300, 300).save(no_thumbnail_path, "jpg")
-    manager.create_thumbnails_async([no_thumbnail_path])
+    manager.create_thumbnails_async([0], [no_thumbnail_path])
     check_thumbails_created(qtbot, manager, 0)
 
 
@@ -37,13 +37,13 @@ def test_thumbnail_save_disabled_no_delete_old(monkeypatch, qtbot, tmp_path, man
     monkeypatch.setattr(settings.thumbnail.save, "value", True)
     has_thumbnail_path = str(tmp_path / "has_thumbnail.jpg")
     QPixmap(300, 300).save(has_thumbnail_path, "jpg")
-    manager.create_thumbnails_async([has_thumbnail_path])
+    manager.create_thumbnails_async([0], [has_thumbnail_path])
     check_thumbails_created(qtbot, manager, 1)
 
     monkeypatch.setattr(settings.thumbnail.save, "value", False)
     no_thumbnail_path = str(tmp_path / "no_thumbnail.jpg")
     QPixmap(300, 300).save(no_thumbnail_path, "jpg")
-    manager.create_thumbnails_async([has_thumbnail_path, no_thumbnail_path])
+    manager.create_thumbnails_async([0, 1], [has_thumbnail_path, no_thumbnail_path])
     check_thumbails_created(qtbot, manager, 1)
 
 
@@ -53,18 +53,18 @@ def test_create_n_thumbnails(qtbot, tmp_path, manager, n_paths):
     filenames = [str(tmp_path / f"image_{i}.jpg") for i in range(n_paths)]
     for filename in filenames:
         QPixmap(300, 300).save(filename, "jpg")
-    manager.create_thumbnails_async(filenames)
+    manager.create_thumbnails_async(range(0, len(filenames)), filenames)
     check_thumbails_created(qtbot, manager, n_paths)
 
 
 def test_create_thumbnails_for_non_existing_path(qtbot, manager):
-    manager.create_thumbnails_async(["this/is/not/a/path"])
+    manager.create_thumbnails_async([0], ["this/is/not/a/path"])
     check_thumbails_created(qtbot, manager, 0)
 
 
 def test_create_thumbnails_for_non_image_path(qtbot, tmp_path, manager):
     filename = str(tmp_path / "image.jpg")
-    manager.create_thumbnails_async([filename])
+    manager.create_thumbnails_async([0], [filename])
     check_thumbails_created(qtbot, manager, 0)
 
 
@@ -73,7 +73,7 @@ def test_do_not_create_thumbnail_for_thumbnail(qtbot, manager):
         manager.directory, hashlib.md5(b"thumbnail").hexdigest() + ".png"
     )
     QPixmap(256, 256).save(filename)
-    manager.create_thumbnails_async([filename])
+    manager.create_thumbnails_async([0], [filename])
     check_thumbails_created(qtbot, manager, 1)
 
 

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -475,6 +475,8 @@ class thumbnail:  # pylint: disable=invalid-name
         True,
         desc="Save new thumbnails to disk in the shared icon cache for later use",
     )
+    max_behind = IntSetting("thumbnail.max_behind", 50, desc="Maximum number of thumbnails to render behind the currently selected one.")
+    max_ahead = IntSetting("thumbnail.max_ahead", 50, desc="Maximum number of thumbnails to render ahead of the currently selected one.")
 
 
 class slideshow:  # pylint: disable=invalid-name

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -475,9 +475,22 @@ class thumbnail:  # pylint: disable=invalid-name
         True,
         desc="Save new thumbnails to disk in the shared icon cache for later use",
     )
-    load_behind = IntSetting("thumbnail.load_behind", -1, desc="Maximum number of thumbnails to render behind the currently selected one. -1 means no limit.")
-    load_ahead = IntSetting("thumbnail.load_ahead", -1, desc="Maximum number of thumbnails to render ahead of the currently selected one. -1 means no limit.")
-    unload_threshold = IntSetting("thumbnail.unload_threshold", -1, desc="Don't unload thumbnails unless there are more than this number rendered. -1 means no limit.")
+    load_behind = IntSetting(
+        "thumbnail.load_behind",
+        -1,
+        desc="Max thumbnails to render behind the selected one. -1 is no limit",
+    )
+    load_ahead = IntSetting(
+        "thumbnail.load_ahead",
+        -1,
+        desc="Max thumbnails to render ahead of the selected one. -1 is no limit",
+    )
+    unload_threshold = IntSetting(
+        "thumbnail.unload_threshold",
+        -1,
+        desc="Don't unload thumbnails unless more are loaded than this. -1 is no limit",
+    )
+
 
 class slideshow:  # pylint: disable=invalid-name
     """Namespace for slideshow related settings."""

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -475,9 +475,9 @@ class thumbnail:  # pylint: disable=invalid-name
         True,
         desc="Save new thumbnails to disk in the shared icon cache for later use",
     )
-    max_behind = IntSetting("thumbnail.max_behind", 50, desc="Maximum number of thumbnails to render behind the currently selected one.")
-    max_ahead = IntSetting("thumbnail.max_ahead", 50, desc="Maximum number of thumbnails to render ahead of the currently selected one.")
-    max_count = IntSetting("thumbnail.max_count", 200, desc="Maximum number of thumbnails to render in general.")
+    max_behind = IntSetting("thumbnail.max_behind", 0, desc="Maximum number of thumbnails to render behind the currently selected one.")
+    max_ahead = IntSetting("thumbnail.max_ahead", 0, desc="Maximum number of thumbnails to render ahead of the currently selected one.")
+    max_count = IntSetting("thumbnail.max_count", 0, desc="Maximum number of thumbnails to render in general.")
 
 class slideshow:  # pylint: disable=invalid-name
     """Namespace for slideshow related settings."""

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -475,9 +475,9 @@ class thumbnail:  # pylint: disable=invalid-name
         True,
         desc="Save new thumbnails to disk in the shared icon cache for later use",
     )
-    load_behind = IntSetting("thumbnail.load_behind", 0, desc="Maximum number of thumbnails to render behind the currently selected one.")
-    load_ahead = IntSetting("thumbnail.load_ahead", 0, desc="Maximum number of thumbnails to render ahead of the currently selected one.")
-    unload_threshold = IntSetting("thumbnail.unload_threshold", 0, desc="Don't unload thumbnails unless there are more than this number rendered.")
+    load_behind = IntSetting("thumbnail.load_behind", -1, desc="Maximum number of thumbnails to render behind the currently selected one. -1 means no limit.")
+    load_ahead = IntSetting("thumbnail.load_ahead", -1, desc="Maximum number of thumbnails to render ahead of the currently selected one. -1 means no limit.")
+    unload_threshold = IntSetting("thumbnail.unload_threshold", -1, desc="Don't unload thumbnails unless there are more than this number rendered. -1 means no limit.")
 
 class slideshow:  # pylint: disable=invalid-name
     """Namespace for slideshow related settings."""

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -477,7 +477,7 @@ class thumbnail:  # pylint: disable=invalid-name
     )
     max_behind = IntSetting("thumbnail.max_behind", 50, desc="Maximum number of thumbnails to render behind the currently selected one.")
     max_ahead = IntSetting("thumbnail.max_ahead", 50, desc="Maximum number of thumbnails to render ahead of the currently selected one.")
-
+    max_count = IntSetting("thumbnail.max_count", 200, desc="Maximum number of thumbnails to render in general.")
 
 class slideshow:  # pylint: disable=invalid-name
     """Namespace for slideshow related settings."""

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -475,9 +475,9 @@ class thumbnail:  # pylint: disable=invalid-name
         True,
         desc="Save new thumbnails to disk in the shared icon cache for later use",
     )
-    max_behind = IntSetting("thumbnail.max_behind", 0, desc="Maximum number of thumbnails to render behind the currently selected one.")
-    max_ahead = IntSetting("thumbnail.max_ahead", 0, desc="Maximum number of thumbnails to render ahead of the currently selected one.")
-    max_count = IntSetting("thumbnail.max_count", 0, desc="Maximum number of thumbnails to render in general.")
+    load_behind = IntSetting("thumbnail.load_behind", 0, desc="Maximum number of thumbnails to render behind the currently selected one.")
+    load_ahead = IntSetting("thumbnail.load_ahead", 0, desc="Maximum number of thumbnails to render ahead of the currently selected one.")
+    unload_threshold = IntSetting("thumbnail.unload_threshold", 0, desc="Don't unload thumbnails unless there are more than this number rendered.")
 
 class slideshow:  # pylint: disable=invalid-name
     """Namespace for slideshow related settings."""

--- a/vimiv/gui/thumbnail.py
+++ b/vimiv/gui/thumbnail.py
@@ -173,10 +173,10 @@ class ThumbnailView(
     def _prune_index(self, index) -> None:
         """Unload the icon associated with a particular path index."""
         item = self.item(index)
-		# Otherwise it has been deleted in the meanwhile
+        # Otherwise it has been deleted in the meanwhile
         if item is not None and\
-		   (api.settings.thumbnail.max_count.value == 0 or\
-		   len(self._rendered_paths) > api.settings.thumbnail.max_count.value):
+           (api.settings.thumbnail.max_count.value == 0 or\
+           len(self._rendered_paths) > api.settings.thumbnail.max_count.value):
             item.setIcon(ThumbnailItem.default_icon())
             self._rendered_paths.discard(self._paths[index])
 

--- a/vimiv/gui/thumbnail.py
+++ b/vimiv/gui/thumbnail.py
@@ -226,6 +226,7 @@ class ThumbnailView(
             _logger.debug("No new images to load")
             return
         _logger.debug("Updating thumbnails...")
+        self._rendered_paths.clear()
         removed = set(self._paths) - set(paths)
         for path in removed:
             _logger.debug("Removing existing thumbnail '%s'", path)
@@ -233,8 +234,6 @@ class ThumbnailView(
             del self._paths[idx]  # Remove as the index also changes in the QListWidget
             if not self.takeItem(idx):
                 _logger.error("Error removing thumbnail for '%s'", path)
-            else:
-                self._rendered_paths.remove(path)
         size_hint = QSize(self.item_size(), self.item_size())
         for i, path in enumerate(paths):
             if path not in self._paths:  # Add new path

--- a/vimiv/gui/thumbnail.py
+++ b/vimiv/gui/thumbnail.py
@@ -147,11 +147,11 @@ class ThumbnailView(
     def _first_index(self) -> int:
         """Return the index of the first thumbnail to be rendered."""
         result: int
-        if api.settings.thumbnail.max_behind.value == 0:
+        if api.settings.thumbnail.load_behind.value == 0:
             result = 0
         else:
             result = max(0,
-                       self.current_index() - api.settings.thumbnail.max_behind.value)
+                       self.current_index() - api.settings.thumbnail.load_behind.value)
         return result
 
     def _last_index(self) -> int:
@@ -159,11 +159,11 @@ class ThumbnailView(
         result: int
         if len(self._paths) == 0:
             result = 0
-        elif api.settings.thumbnail.max_ahead.value == 0:
+        elif api.settings.thumbnail.load_ahead.value == 0:
             result = len(self._paths) - 1
         else:
             result = min(len(self._paths) - 1,
-                       self.current_index() + api.settings.thumbnail.max_ahead.value)
+                       self.current_index() + api.settings.thumbnail.load_ahead.value)
         return result
 
     def _index_range(self) -> tuple[int, int]:
@@ -175,8 +175,8 @@ class ThumbnailView(
         item = self.item(index)
         # Otherwise it has been deleted in the meanwhile
         if item is not None and\
-           (api.settings.thumbnail.max_count.value == 0 or\
-           len(self._rendered_paths) > api.settings.thumbnail.max_count.value):
+           (api.settings.thumbnail.unload_threshold.value == 0 or\
+           len(self._rendered_paths) > api.settings.thumbnail.unload_threshold.value):
             item.setIcon(ThumbnailItem.default_icon())
             self._rendered_paths.discard(self._paths[index])
 

--- a/vimiv/gui/thumbnail.py
+++ b/vimiv/gui/thumbnail.py
@@ -187,7 +187,7 @@ class ThumbnailView(
 
     def _prune_icons_ahead(self) -> None:
         """Prune indexes after the current index."""
-        for index in range(self._last_index() + 1, len(self._paths)):
+        for index in reversed(range(self._last_index() + 1, len(self._paths))):
             self._prune_index(index)
 
     def _prune_icons(self) -> None:

--- a/vimiv/gui/thumbnail.py
+++ b/vimiv/gui/thumbnail.py
@@ -147,7 +147,7 @@ class ThumbnailView(
     def _first_index(self) -> int:
         """Return the index of the first thumbnail to be rendered."""
         result: int
-        if api.settings.thumbnail.load_behind.value == 0:
+        if api.settings.thumbnail.load_behind.value == -1:
             result = 0
         else:
             result = max(0,
@@ -159,7 +159,7 @@ class ThumbnailView(
         result: int
         if len(self._paths) == 0:
             result = 0
-        elif api.settings.thumbnail.load_ahead.value == 0:
+        elif api.settings.thumbnail.load_ahead.value == -1:
             result = len(self._paths) - 1
         else:
             result = min(len(self._paths) - 1,
@@ -175,7 +175,7 @@ class ThumbnailView(
         item = self.item(index)
         # Otherwise it has been deleted in the meanwhile
         if item is not None and\
-           (api.settings.thumbnail.unload_threshold.value == 0 or\
+           (api.settings.thumbnail.unload_threshold.value == -1 or\
            len(self._rendered_paths) > api.settings.thumbnail.unload_threshold.value):
             item.setIcon(ThumbnailItem.default_icon())
             self._rendered_paths.discard(self._paths[index])

--- a/vimiv/utils/thumbnail_manager.py
+++ b/vimiv/utils/thumbnail_manager.py
@@ -72,14 +72,15 @@ class ThumbnailManager(QObject):
         xdg.makedirs(self.directory, self.fail_directory)
         self.fail_pixmap = fail_pixmap
 
-    def create_thumbnails_async(self, paths: List[str]) -> None:
+    def create_thumbnails_async(self, indices: List[int], paths: List[str]) -> None:
         """Start ThumbnailsCreator for each path to create thumbnails.
 
         Args:
+            indices: The corresponding index of the thumbnail for each path.
             paths: Paths to create thumbnails for.
         """
         self.pool.clear()
-        for i, path in enumerate(paths):
+        for i, path in zip(indices, paths):
             self.pool.start(ThumbnailCreator(i, path, self))
 
 

--- a/vimiv/utils/thumbnail_manager.py
+++ b/vimiv/utils/thumbnail_manager.py
@@ -16,7 +16,7 @@ import contextlib
 import hashlib
 import os
 import tempfile
-from typing import Dict, List
+from typing import Dict, List, Iterable
 
 from PyQt5.QtCore import QRunnable, pyqtSignal, QObject
 from PyQt5.QtGui import QIcon, QPixmap, QImage
@@ -72,7 +72,7 @@ class ThumbnailManager(QObject):
         xdg.makedirs(self.directory, self.fail_directory)
         self.fail_pixmap = fail_pixmap
 
-    def create_thumbnails_async(self, indices: List[int], paths: List[str]) -> None:
+    def create_thumbnails_async(self, indices: Iterable[int], paths: List[str]) -> None:
         """Start ThumbnailsCreator for each path to create thumbnails.
 
         Args:


### PR DESCRIPTION
Now for one of the more ambitious changes discussed in #651 The general goal is to allow thumbnails to be displayed in a lazy-loaded manner, and unloaded when they fall out of a certain range. The number of thumbnails displayed at any given time being configurable to this end by the following options:

* `thumbnail.load_behind` : Max thumbnails to render behind the selected one. -1 (default) is no limit
* `thumbnail.load_ahead`  : Max thumbnails to render ahead of the selected one. -1 (default) is no limit
* `thumbnail.unload_threshold` : Don't unload thumbnails unless more are loaded than this. -1 (default) is no limit