### PR TITLE
Fix wrong statement that `imageformats` supports jp2

### DIFF
--- a/docs/documentation/configuration/plugins.rst
+++ b/docs/documentation/configuration/plugins.rst
@@ -46,4 +46,3 @@ Currently the following formats are supported:
 
 * cr2 (requires `qt raw <https://gitlab.com/mardy/qtraw>`_)
 * avif (requires `qt-avif-image-plugin <https://github.com/novomesk/qt-avif-image-plugin>`_)
-* jp2 (requires qt imageformats plugin)


### PR DESCRIPTION
This should have been changed as part of #650.
This plugin is no longer needed for jp2 support, but jp2 is natively supported, given that the qt-imageformats module is installed.