### PR TITLE
Add `Qt.Key_Delete` to `special_keys` dict

### DIFF
--- a/vimiv/gui/eventhandler.py
+++ b/vimiv/gui/eventhandler.py
@@ -277,6 +277,7 @@ def _get_base_keysequence(event: QKeyEvent) -> SequenceT:
         Qt.Key_End: "<end>",
         Qt.Key_PageUp: "<page-up>",
         Qt.Key_PageDown: "<page-down>",
+        Qt.Key_Delete: "<delete>",
     }
     separator_keys = {
         Qt.Key_Colon: "<colon>",


### PR DESCRIPTION
Allows to bind `<delete>`, as suggested in https://github.com/karlch/vimiv-qt/issues/682#issuecomment-1675769321

Should fix #682, works fine on my end