### PR TITLE
Improve JPEG Header Detection

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,11 @@ Added:
   * ``PySide6``: Use PySide6 (Qt for Python). This is highly experimental and should be
     used with care.
 
+Changed:
+^^^^^^^^
+* The JPEG image header check was simplified to have a false negative rate of 0, while
+  maintaining a decently low false positive rate.
+
 Fixed:
 ^^^^^^
 

--- a/vimiv/utils/imageheader.py
+++ b/vimiv/utils/imageheader.py
@@ -140,28 +140,36 @@ def register(
 
 
 def _test_jpg(h: bytes, _f: BinaryIO) -> bool:
-    """Joint Photographic Experts Group (JPEG) in different kinds of "subtypes"(?).
+    """Joint Photographic Experts Group (JPEG).
 
-    Extension: .jpeg, .jpg
+    Extension: .jpeg, .jpg (and probably more)
+
+    Most JPEG images are of JPEG/JFIF or JPEG/Exif format, but every manufacturer can
+    create their own JPEG-based file formats. Therefore, there are many different JPEG-
+    based file formats.
+
+    JPEGs are a list of segments. Each segments starts with a 1 byte marker. Each marker
+    is preceded by byte 0xFF. Each valid JPEG starts with segment "Start of Image
+    (SOI)", which has marker 0xD8.
+
+    The SOI section is followed by the APP[0-14] section, which are used by different
+    file formats. Since there are more than 15 file formats, the APPn section often
+    starts with a header signature itself, like JFIF or Exif for JPEG/JFIF or JPEG/Exif,
+    respectively.
+
+    However, there are also "Raw" JPEGs, that do not start with APPn but with the image
+    data directly.
+
+    The only common denominator for all JPEG file formats seem to be the first three
+    bytes. As apparently, not even the end segment is consistently used.
 
     Magic bytes:
-    --> FF D8 FF DB
-     -> .. .. .. ..
-    --> FF D8 FF E0 (only for JPG and not JPEG, but no need to differentiate)
-     -> .. .. .. ..
-    --> FF D8 FF E0 00 10 4A 46 49 46 00 01 (covered be prior)
-     -> .. .. .. .. .. ..  J  F  I  F .. ..
-    --> FF D8 FF EE
-     -> .. .. .. ..
-    --> FF D8 FF E1 ?? ?? 45 78 69 66 00 00
-     -> .. .. .. .. .. ..  E  x  i  f .. ..
+        --> FF D8 FF
+         -> .. .. ..
 
     Support: native
     """
-    return h[:3] == b"\xFF\xD8\xFF" and (
-        h[3] in [0xDB, 0xE0, 0xEE]
-        or (h[3] == 0xE1 and h[6:12] == b"\x45\x78\x69\x66\x00\x00")
-    )
+    return h[:3] == b"\xFF\xD8\xFF"
 
 
 def _test_png(h: bytes, _f: BinaryIO) -> bool:


### PR DESCRIPTION
I have just come across a JPEG what was not detected by vimiv. I have adapted the check function to also detect that image as a valid JPEG.

At the same time I had to realize that the detection of JPEGs is not as straight-forward as for other file formats. That is because JPEG is itself not a file format, but only a standard for the used compression function. The two most common JPEG file formats are JPEG/JFIF and JPEG/Exif. But every manufacturer can create their own JPEG-based file formats. Therefore, there are many different JPEG-based file formats which are different in their structure. (Obviously) There is also no central place to get information about all available formats.

JPEGs are a list of segments. Each segments starts with a 1 byte marker. Each marker is preceded by byte `0xFF`. Each valid JPEG starts with segment "Start of Image (SOI)", which has marker `0xD8`.

The SOI section is followed by the APP[0-14] section, which are used by different file formats. Since there are more than 15 file formats, the APPn section often starts with a header signature itself, like `JFIF\x00\x01` or `Exif\x00\x00` for JPEG/JFIF or JPEG/Exif, respectively.

Apparently, there are also "Raw"[2] JPEGs, that do not start with APPn but with the image data directly. But I did not find any complete information about which segments follows the SOI in this case.

The difficulty with the JPEG test function is to get the right balance between false positives (FPs) and false negatives (FNs). The only thing that all JPEGs have in common the first bytes `\xFF\xD8` [1]. Prior to #650 we actually also used [this in the test function](https://github.com/karlch/vimiv-qt/pull/650/files#diff-73ba771a3fe0222469f67eb6da4fbd77531ca78279b681b5423a1068f917cdc4L202-L204), but due to its FP rate I removed that in #650.

As by far most JPEGs are of JPEG/JFIF or JPEG/Exif. And since we detect them, the majority of JPEGs should be detected by vimiv. However, there are also an (unknown) number of formats that are not detected.

Now, I am thinking about what philosophy we should follow with the JPEG test function. I can think of:
- Have it as conservative as now, and update once we encounter a JPEG that was not detected (as I have done in this PR).
- Maximize utility by checking only the first two bytes. This solution has FN=0, but maybe a considerable amount of FPs.
- Have something in-between; For example check that the section following the SOI is a APPn, without validating the signature of the APPn.
- Combine both worlds; Follow the conservative approach, but also accept as JPEG if the first two bytes are correct (as it as prior to #650). If only the first two bytes match, but not the conservative check, we could notify the user and ask them to submit that particular file for analysis.

[1] JPEGs also have an specific section at the end of the file, however not even that is used consistently.
[2] Raw meaning  that they have a "simplified header", not to be confused with RAW image formats like `.cr2`.
