### PR TITLE
Add :cancel command bound to <escape>

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,9 @@ Added:
   * ``6`` or ``PyQt6``: Use PyQt6.
   * ``PySide6``: Use PySide6 (Qt for Python). This is highly experimental and should be
     used with care.
+* The generic ``:cancel`` command bound to ``<escape>`` together with the
+  ``api.signals.cancel`` signal which can be used by plugins in case they need some sort
+  of resetting.
 
 Fixed:
 ^^^^^^

--- a/vimiv/api/signals.py
+++ b/vimiv/api/signals.py
@@ -37,6 +37,8 @@ class _SignalHandler(QObject):
             arg2: True if it is only reloaded.
 
         plugins_loaded: Emitted when the user plugins have been loaded.
+
+        cancel: Emitted when the generic cancel command was called.
     """
 
     # Emitted when new images should be loaded
@@ -58,6 +60,9 @@ class _SignalHandler(QObject):
     # Plugins loaded
     plugins_loaded = Signal()
 
+    # Cancel command (bound to <escape> by default)
+    cancel = Signal()
+
 
 _signal_handler = _SignalHandler()  # Instance of Qt signal handler to work with
 
@@ -71,3 +76,4 @@ pixmap_loaded = _signal_handler.pixmap_loaded
 movie_loaded = _signal_handler.movie_loaded
 svg_loaded = _signal_handler.svg_loaded
 plugins_loaded = _signal_handler.plugins_loaded
+cancel = _signal_handler.cancel

--- a/vimiv/commands/search.py
+++ b/vimiv/commands/search.py
@@ -57,6 +57,7 @@ class Search(QObject):
         super().__init__()
         self._text = ""
         self._reverse = False
+        api.signals.cancel.connect(self.clear)
 
     def __call__(
         self, text, mode, count=0, reverse=False, incremental=False

--- a/vimiv/gui/mainwindow.py
+++ b/vimiv/gui/mainwindow.py
@@ -85,6 +85,12 @@ class MainWindow(QWidget):
         else:
             self.showFullScreen()
 
+    @api.keybindings.register("<escape>", "cancel")
+    @api.commands.register()
+    def cancel(self):
+        """Emit a generic cancel signal, e.g., to reset search or clear keys."""
+        api.signals.cancel.emit()
+
     @api.commands.register()
     def version(self, copy: bool = False) -> None:
         """Show a pop-up with version information.


### PR DESCRIPTION
The cancel command emits a generic api.signals.cancel signal. This has two advantages:

1) <escape> is no longer handled specially via hard-code.
2) The eventhandler does not have to explicitly know "what to cancel".
   In addition, plugins can also connect to api.signals.cancel in case
   they need some sort of "resetting".

Related to #682 

@xfzv this should allow binding `<escape>` as usual, do make sure to bind `:cancel` to something else though. Honestly, I don't quite see why one would want to do this, e.g. what will you bind  to "abort" keysequences such as `g?`? But the overall flexibility of the signal was on my mind in any case for some time.