### PR TITLE
Fix empty lines in tag file  

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -30,6 +30,8 @@ Fixed:
 
 * The SVG image header check to no longer return true for all XML files.
 * Binding the ``<delete>`` key as special key. Thanks `@xfzv`_!
+* Consecutive `:tag-write` would insert empty lines into the tag file, which would on
+  `:tag-load` getting interpreted as file paths.
 
 
 v0.9.0 (2023-07-15)

--- a/tests/end2end/features/api/mark.feature
+++ b/tests/end2end/features/api/mark.feature
@@ -24,6 +24,7 @@ Feature: Mark and tag images.
         When I run mark image_01.jpg image_02.jpg
         And I run tag-write test
         Then the tag file test should exist with 2 paths
+        And the tag file test should not contain any empty lines
 
     Scenario: Append to a tag file
         Given I open 5 images
@@ -32,6 +33,15 @@ Feature: Mark and tag images.
         And I run mark image_03.jpg
         And I run tag-write test
         Then the tag file test should exist with 3 paths
+        And the tag file test should not contain any empty lines
+
+    Scenario: Multiple write to a tag file
+        Given I open 5 images
+        When I run mark image_01.jpg image_02.jpg
+        And I run tag-write test
+        And I run tag-write test
+        Then the tag file test should exist with 2 paths
+        And the tag file test should not contain any empty lines
 
     Scenario: Load a tag file
         Given I open 5 images

--- a/tests/end2end/features/api/mark.feature
+++ b/tests/end2end/features/api/mark.feature
@@ -40,6 +40,14 @@ Feature: Mark and tag images.
         And I run tag-load test
         Then there should be 2 marked images
 
+    Scenario: Load a tag file with empty line
+        Given I open 5 images
+        When I run mark image_01.jpg image_02.jpg
+        And I run tag-write test
+        And I insert an empty line into the tag file test
+        And I run tag-load test
+        Then there should be 2 marked images
+
     Scenario: Delete a tag file
         Given I open 5 images
         When I run mark image_01.jpg image_02.jpg

--- a/tests/end2end/features/api/test_mark_bdd.py
+++ b/tests/end2end/features/api/test_mark_bdd.py
@@ -43,6 +43,13 @@ def check_tag_file(name, n_paths):
     assert len(paths) == n_paths
 
 
+@bdd.then(bdd.parsers.parse("the tag file {name} should not contain any empty lines"))
+def check_tag_file_no_empty_line(name):
+    assert os.path.isfile(Tag.path(name)), f"Tag file {name} does not exist"
+    with open(Tag.path(name), "r") as f:
+        assert all([line.strip() for line in f])
+
+
 @bdd.then(bdd.parsers.parse("the tag file {name} should not exist"))
 def check_tag_file_not_exists(name):
     assert not os.path.exists(Tag.path(name))

--- a/tests/end2end/features/api/test_mark_bdd.py
+++ b/tests/end2end/features/api/test_mark_bdd.py
@@ -31,7 +31,7 @@ def create_tag_with_permission(name, mode):
 @bdd.when(bdd.parsers.parse("I insert an empty line into the tag file {name}"))
 def insert_empty_lines_into_tag_file(name):
     assert os.path.isfile(Tag.path(name)), f"Tag file {name} does not exist"
-    with open(Tag.path(name), "a") as f:
+    with open(Tag.path(name), "a", encoding="utf-8") as f:
         f.write("\n")
 
 
@@ -46,8 +46,8 @@ def check_tag_file(name, n_paths):
 @bdd.then(bdd.parsers.parse("the tag file {name} should not contain any empty lines"))
 def check_tag_file_no_empty_line(name):
     assert os.path.isfile(Tag.path(name)), f"Tag file {name} does not exist"
-    with open(Tag.path(name), "r") as f:
-        assert all([line.strip() for line in f])
+    with open(Tag.path(name), "r", encoding="utf-8") as f:
+        assert all(line.strip() for line in f)
 
 
 @bdd.then(bdd.parsers.parse("the tag file {name} should not exist"))

--- a/tests/end2end/features/api/test_mark_bdd.py
+++ b/tests/end2end/features/api/test_mark_bdd.py
@@ -28,6 +28,13 @@ def create_tag_with_permission(name, mode):
     os.chmod(path, 0o000)
 
 
+@bdd.when(bdd.parsers.parse("I insert an empty line into the tag file {name}"))
+def insert_empty_lines_into_tag_file(name):
+    assert os.path.isfile(Tag.path(name)), f"Tag file {name} does not exist"
+    with open(Tag.path(name), "a") as f:
+        f.write("\n")
+
+
 @bdd.then(bdd.parsers.parse("the tag file {name} should exist with {n_paths:d} paths"))
 def check_tag_file(name, n_paths):
     assert os.path.isfile(Tag.path(name)), f"Tag file {name} does not exist"

--- a/vimiv/api/_mark.py
+++ b/vimiv/api/_mark.py
@@ -371,7 +371,9 @@ class Tag:
     def read(self) -> List[str]:
         """Read paths from the tag file."""
         paths = [
-            path.strip() for path in self._file if not path.startswith(Tag.COMMENTCHAR)
+            path.strip()
+            for path in self._file
+            if not path.startswith(Tag.COMMENTCHAR) and path.strip()
         ]
         _logger.debug("%s: read %d paths from tag", self, len(paths))
         return paths

--- a/vimiv/api/_mark.py
+++ b/vimiv/api/_mark.py
@@ -204,11 +204,7 @@ class Mark(QObject):
         _logger.debug("Loading tag '%s'", name)
         with Tag(name) as tag:
             paths = tag.read()
-        self._marked = paths
-        for path in paths:
-            self.marked.emit(path)
-            _logger.debug("Marked '%s'", path)
-        self.markdone.emit()
+        self.mark(paths, self.Action.Mark)
 
     @commands.register()
     def tag_open(self, name: str) -> None:

--- a/vimiv/api/_mark.py
+++ b/vimiv/api/_mark.py
@@ -365,8 +365,11 @@ class Tag:
         """Write paths to the tag file."""
         existing = {path.strip() for path in self.read()}
         new_paths = set(paths) - existing
-        _logger.debug("Adding %d paths to tag file", len(new_paths))
-        self._file.write("\n".join(sorted(new_paths)) + "\n")
+        if new_paths:
+            _logger.debug("Adding %d paths to tag file", len(new_paths))
+            self._file.write("\n".join(sorted(new_paths)) + "\n")
+        else:
+            _logger.debug("No new images to add to tag file")
 
     def read(self) -> List[str]:
         """Read paths from the tag file."""


### PR DESCRIPTION
It is possible to insert empty lines into the tag files. Once the tagged images of that tag are loaded again, an empty string is inserted into the marked list. This leads to issues (e.g. `:open :m` fails).

## How to insert empty lines into the tag file
Simply run `:tag-write test` multiple times without adding marking a new image in-between.


## This PR fixes the issue at several levels
- Prevent insertion of empty lines into the tag file: 3561980c3a61f2e615c6009bfd2b65cf4400e7bb
- Prevent empty line getting read tags: 9b657c44979253e24147d8f94afa323a338eae9c [1]


[1] 96abdba02681d0f6716e8b4b00f38359555e4efa would also have fixed the second point. But I added that commit rather to get rid of repeated code. In addition, it ensures that images loaded from the tag are actually also added to the watcher, which they are not without this commit.