### PR TITLE
DOCS Indicate default path for XDG_DATA_HOME

### DIFF
--- a/docs/documentation/configuration/plugins.rst
+++ b/docs/documentation/configuration/plugins.rst
@@ -6,7 +6,8 @@ Plugins
 Vimiv provides the option to extend its functionality with python module plugins. To add
 a new plugin:
 
-#. Put the python module into the plugins folder ``$XDG_DATA_HOME/vimiv/plugins/``.
+#. Put the python module into the plugins folder ``$XDG_DATA_HOME/vimiv/plugins/``,
+   where ``$XDG_DATA_HOME`` is usually ``~/.local/share`` if you have not updated it.
 #. Activate it in the ``PLUGINS`` section of the configuration file by adding:
    ``plugin_name = any additional information`` where ``plugin_name`` is the name of the
    python module added and ``any additional information`` is passed on to the plugin


### PR DESCRIPTION
We also mentione the default path of `XDG_CACHE_HOME` at several places in the docs (e.g. [here](https://github.com/karlch/vimiv-qt/blob/master/docs/documentation/configuration/settings.rst)), therfore we could also mentione it for `XDG_DATE_HOME`.

Is an attempt to fix the confusion raised in #712

fix #712 