### PR TITLE
Detect SVGs that do not start with a header

### DIFF
--- a/vimiv/utils/imageheader.py
+++ b/vimiv/utils/imageheader.py
@@ -208,9 +208,14 @@ def _test_svg(h: bytes, f: BinaryIO) -> bool:
      ->  <  ?  x  m  l
     --> 3C 3F 73 76 67 (with stripped xml header)
      ->  <  ?  s  v  g
+    --> 3C 73 76 67 (inline without header)
+     ->  <  s  v  g
 
     Native QT support.
     """
+    if h[:4] == b"\x3C\x73\x76\x67":
+        return True
+
     # Check if start with <?
     if h[:2] != b"\x3C\x3F":
         return False


### PR DESCRIPTION
Indeed, there are (actually many) SVGs that do not start with a `<?` header but simply `<svg`. I have added detection for them.Though, I still did not manage to find documentation on all possible header of SVG files. What when the `<svg` line is preceded by a comment line? `file` detects such SVGs as HTML.

@infinitewhileloop Thanks for reporting and the submission of the sample.

fixes #748 