### PR TITLE
Add more supported formats in vimiv.desktop

### DIFF
--- a/misc/vimiv.desktop
+++ b/misc/vimiv.desktop
@@ -7,4 +7,4 @@ Icon=vimiv
 Terminal=false
 Exec=vimiv %F
 Categories=Graphics;
-MimeType=image/bmp;image/gif;image/jpeg;image/jp2;image/jpeg2000;image/jpx;image/png;image/svg;image/tiff;
+MimeType=image/bmp;image/gif;image/icns;image/jp2;image/jpeg;image/jpeg2000;image/jpx;image/png;image/svg;image/tiff;image/webp;image/x-portable-anymap;image/x-portable-bitmap;image/x-portable-graymap;image/x-portable-greymap;image/x-portable-pixmap;image/x-tga;image/x-xbitmap;image/x-xpixmap;


### PR DESCRIPTION
Closes #754 (Oops, I forgot to add this in the commit message)

Supported formats according to [this](https://github.com/karlch/vimiv-qt/blob/master/vimiv/utils/imageheader.py#L11C1-L25C85) (referring to [the comment](https://github.com/karlch/vimiv-qt/issues/754#issuecomment-1856502245)) are added in the desktop entry file.

I have included the formats supported by the `qtimageformats` module. If that's an issue, I think it can be mitigated by showing a in-program warning to install optional dependencies. However, not including them will not solve the issue and can't be mitigated later.