### PR TITLE
Implement cancel signal emitted by <escape>

### DIFF
--- a/vimiv/api/signals.py
+++ b/vimiv/api/signals.py
@@ -33,6 +33,8 @@ class _SignalHandler(QObject):
             arg2: True if it is only reloaded.
 
         plugins_loaded: Emitted when the user plugins have been loaded.
+
+        cancel: Emitted when <escape> was pressed to initiate generic cancelling.
     """
 
     # Emitted when new images should be loaded
@@ -54,6 +56,9 @@ class _SignalHandler(QObject):
     # Plugins loaded
     plugins_loaded = Signal()
 
+    # Cancel initiated (via <escape>)
+    cancel = Signal()
+
 
 _signal_handler = _SignalHandler()  # Instance of Qt signal handler to work with
 
@@ -67,3 +72,4 @@ pixmap_loaded = _signal_handler.pixmap_loaded
 movie_loaded = _signal_handler.movie_loaded
 svg_loaded = _signal_handler.svg_loaded
 plugins_loaded = _signal_handler.plugins_loaded
+cancel = _signal_handler.cancel

--- a/vimiv/commands/search.py
+++ b/vimiv/commands/search.py
@@ -53,6 +53,7 @@ class Search(QObject):
         super().__init__()
         self._text = ""
         self._reverse = False
+        api.signals.cancel.connect(self.clear)
 
     def __call__(
         self, text, mode, count=0, reverse=False, incremental=False

--- a/vimiv/gui/eventhandler.py
+++ b/vimiv/gui/eventhandler.py
@@ -9,7 +9,7 @@ from vimiv.qt.core import Qt, QTimer, QObject, Signal
 from vimiv.qt.gui import QKeySequence, QKeyEvent, QMouseEvent
 
 from vimiv import api, utils
-from vimiv.commands import runners, search
+from vimiv.commands import runners
 
 
 SequenceT = Tuple[str, ...]
@@ -93,6 +93,7 @@ class PartialHandler(QObject):
         self.count = TempKeyStorage()
         self.keys = TempKeyStorage()
         self.keys.timeout.connect(self.partial_cleared.emit)
+        api.signals.cancel.connect(self.clear_keys)
 
     def clear_keys(self):
         """Clear count and partially matched keys."""
@@ -128,9 +129,8 @@ class EventHandlerMixin:
         # matches instead of checking for them
         if keyname == "<escape>" and mode in api.modes.GLOBALS:
             _logger.debug("KeyPressEvent: handling <escape> key specially")
-            self.partial_handler.clear_keys()
-            search.search.clear()
-            api.status.update("escape pressed")
+            api.signals.cancel.emit()
+            api.status.update("<escape> pressed")
         # Count
         elif keyname and keyname in string.digits and mode != api.modes.COMMAND:
             _logger.debug("KeyPressEvent: adding digits to count")


### PR DESCRIPTION
This allows plugins to connect to a generic cancel signal. Currently used to reset partial keys and clear search.

Supersedes #691 as the command was finally not considered useful, but having the signal definitely is.