### PR TITLE
Improvements for view positioning when scrolling

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,13 @@ Added:
   * ``PySide6``: Use PySide6 (Qt for Python). This is highly experimental and should be
     used with care.
 
+* The ``scroll_to_center`` setting. When set to true, always keep the cursor centered
+  when scrolling as previously hard-coded. Otherwise, cursor ends up at the top / bottom
+  when scrolling up / down. Thanks `@Markuzcha`_ for the idea!
+* The ``:move-view`` command to move the view in image and thumbnail mode to the top /
+  center / bottom along with the  ``zt``, ``zz`` and ``zb`` bindings. Thanks
+  `@Markuzcha`_ for the idea!
+
 Changed:
 ^^^^^^^^
 
@@ -577,3 +584,4 @@ Initial release of the Qt version.
 .. _@buzzingwires: https://github.com/buzzingwires
 .. _@xfzv: https://github.com/xfzv
 .. _@mozirilla213: https://github.com/mozirilla213
+.. _@Markuzcha: https://github.com/Markuzcha

--- a/tests/end2end/features/library/libraryscroll.feature
+++ b/tests/end2end/features/library/libraryscroll.feature
@@ -146,3 +146,16 @@ Feature: Scrolling the library.
         When I run scroll half-page-down
         And I run scroll half-page-up
         Then the library row should be 1
+
+    Scenario Outline: Move the view
+        Given I open a directory with 50 paths
+        When I run scroll half-page-down
+        And I run move-view <position>
+        # Simple test if we don't scroll and no crash happens
+        Then the library should be half a page down
+
+        Examples:
+            | position |
+            | top      |
+            | center   |
+            | bottom   |

--- a/vimiv/api/settings.py
+++ b/vimiv/api/settings.py
@@ -382,6 +382,11 @@ style = StrSetting("style", "default", hidden=True)
 read_only = BoolSetting(
     "read_only", False, desc="Disable any commands that are able to edit files on disk"
 )
+scroll_to_center = BoolSetting(
+    "scroll_to_center",
+    True,
+    desc="Ensure the cursor is always at the center of the screen when scrolling",
+)
 
 
 class command:  # pylint: disable=invalid-name

--- a/vimiv/commands/argtypes.py
+++ b/vimiv/commands/argtypes.py
@@ -111,3 +111,11 @@ class AspectRatio(QSize):
                 raise ValueError(
                     f"'Invalid aspectratio '{aspectratio}'. Use width:height, e.g. 4:3"
                 ) from None
+
+
+class ViewPosition(enum.Enum):
+    """Valid arguments for moving the view."""
+
+    Center = "center"
+    Top = "top"
+    Bottom = "bottom"

--- a/vimiv/gui/library.py
+++ b/vimiv/gui/library.py
@@ -290,6 +290,20 @@ class Library(
             raise api.commands.CommandError(str(e))
         self._select_row(row, open_selected_image=open_selected)
 
+    @api.keybindings.register("zt", "move-view top", mode=api.modes.LIBRARY)
+    @api.keybindings.register("zz", "move-view center", mode=api.modes.LIBRARY)
+    @api.keybindings.register("zb", "move-view bottom", mode=api.modes.LIBRARY)
+    @api.commands.register(mode=api.modes.LIBRARY)
+    def move_view(self, position: argtypes.ViewPosition):
+        """Move the view keeping the cursor on the same position.
+
+        **syntax:** ``:move-view position``
+
+        positional arguments:
+            * ``position``: Position to move the view to (top/center/bottom).
+        """
+        self.apply_move_view(position)
+
     def update_width(self):
         """Resize width and columns when main window width changes."""
         width = self.parent().width() * api.settings.library.width.value

--- a/vimiv/gui/thumbnail.py
+++ b/vimiv/gui/thumbnail.py
@@ -328,6 +328,20 @@ class ThumbnailView(
         """Select the first thumbnail in the current row."""
         self._select_index(self.current_row() * self.n_columns())
 
+    @api.keybindings.register("zt", "move-view top", mode=api.modes.THUMBNAIL)
+    @api.keybindings.register("zz", "move-view center", mode=api.modes.THUMBNAIL)
+    @api.keybindings.register("zb", "move-view bottom", mode=api.modes.THUMBNAIL)
+    @api.commands.register(mode=api.modes.THUMBNAIL)
+    def move_view(self, position: argtypes.ViewPosition):
+        """Move the view keeping the cursor on the same position.
+
+        **syntax:** ``:move-view position``
+
+        positional arguments:
+            * ``position``: Position to move the view to (top/center/bottom).
+        """
+        self.apply_move_view(position)
+
     @api.keybindings.register("-", "zoom out", mode=api.modes.THUMBNAIL)
     @api.keybindings.register("+", "zoom in", mode=api.modes.THUMBNAIL)
     @api.commands.register(mode=api.modes.THUMBNAIL)

--- a/vimiv/widgets.py
+++ b/vimiv/widgets.py
@@ -28,6 +28,7 @@ class ScrollToCenterMixin:
         self.scrollTo(self.currentIndex(), hint=hint)
 
     def scrollTo(self, index, hint=None):
+        """Override scrollTo to respect scroll_to_center setting."""
         if hint is None and api.settings.scroll_to_center.value:
             hint = self.ScrollHint.PositionAtCenter
         super().scrollTo(index, hint)

--- a/vimiv/widgets.py
+++ b/vimiv/widgets.py
@@ -20,17 +20,18 @@ class ScrollToCenterMixin:
     def apply_move_view(self, position: argtypes.ViewPosition):
         """Helper to move the view keeping the cursor on the same index."""
         hints = {
-            argtypes.ViewPosition.Top: self.ScrollHint.PositionAtTop,
-            argtypes.ViewPosition.Center: self.ScrollHint.PositionAtCenter,
-            argtypes.ViewPosition.Bottom: self.ScrollHint.PositionAtBottom,
+            argtypes.ViewPosition.Top: QAbstractItemView.ScrollHint.PositionAtTop,
+            argtypes.ViewPosition.Center: QAbstractItemView.ScrollHint.PositionAtCenter,
+            argtypes.ViewPosition.Bottom: QAbstractItemView.ScrollHint.PositionAtBottom,
         }
         hint = hints[position]
-        self.scrollTo(self.currentIndex(), hint=hint)
+        # currentIndex from library / thumbnail widget
+        self.scrollTo(self.currentIndex(), hint=hint)  # type: ignore[attr-defined]
 
     def scrollTo(self, index, hint=None):
         """Override scrollTo to respect scroll_to_center setting."""
         if hint is None and api.settings.scroll_to_center.value:
-            hint = self.ScrollHint.PositionAtCenter
+            hint = QAbstractItemView.ScrollHint.PositionAtCenter
         super().scrollTo(index, hint)
 
 

--- a/vimiv/widgets.py
+++ b/vimiv/widgets.py
@@ -9,12 +9,23 @@ from vimiv.qt.gui import QPainter, QFontMetrics
 from vimiv.qt.widgets import QTreeView, QAbstractItemView, QSlider, QDialog
 
 from vimiv import api
+from vimiv.commands import argtypes
 from vimiv.config import styles
 from vimiv.utils import cached_method
 
 
 class ScrollToCenterMixin:
     """Mixin class to ensure the selected index stays at the center when scrolling."""
+
+    def apply_move_view(self, position: argtypes.ViewPosition):
+        """Helper to move the view keeping the cursor on the same index."""
+        hints = {
+            argtypes.ViewPosition.Top: self.ScrollHint.PositionAtTop,
+            argtypes.ViewPosition.Center: self.ScrollHint.PositionAtCenter,
+            argtypes.ViewPosition.Bottom: self.ScrollHint.PositionAtBottom,
+        }
+        hint = hints[position]
+        self.scrollTo(self.currentIndex(), hint=hint)
 
     def scrollTo(self, index, hint=None):
         if hint is None and api.settings.scroll_to_center.value:

--- a/vimiv/widgets.py
+++ b/vimiv/widgets.py
@@ -8,6 +8,7 @@ from vimiv.qt.core import Qt, QTimer
 from vimiv.qt.gui import QPainter, QFontMetrics
 from vimiv.qt.widgets import QTreeView, QAbstractItemView, QSlider, QDialog
 
+from vimiv import api
 from vimiv.config import styles
 from vimiv.utils import cached_method
 
@@ -15,8 +16,10 @@ from vimiv.utils import cached_method
 class ScrollToCenterMixin:
     """Mixin class to ensure the selected index stays at the center when scrolling."""
 
-    def scrollTo(self, index, _hint=None):
-        super().scrollTo(index, self.ScrollHint.PositionAtCenter)
+    def scrollTo(self, index, hint=None):
+        if hint is None and api.settings.scroll_to_center.value:
+            hint = self.ScrollHint.PositionAtCenter
+        super().scrollTo(index, hint)
 
 
 class ScrollWheelCumulativeMixin:


### PR DESCRIPTION
Adds a new setting `scroll_to_center` that controls whether the view is always centred when scrolling along with the `:move-view` command that can position the view at top / center / bottom with the `zt` / `zz` / `zb` keybindings.