### PR TITLE
Implement flags for synchronizing the image list when changing the working directory

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,10 +25,12 @@ Added:
   center / bottom along with the  ``zt``, ``zz`` and ``zb`` bindings. Thanks
   `@Markuzcha`_ for the idea!
 * The ``--open-selected`` flag for ``:scroll left/right`` in the library. When using
-  this flag, any images in the new folder are automatically opened, in case the
-  focused path is an image. This comes with the new ``<ctrl-h/j/k/l>`` keybindings for
-  ``:scroll left/down/up/right`` for a consistent "move and select" flow. Thanks
+  this flag, any images in the new folder are automatically opened. If there are none,
+  any loaded images are cleared. This comes with the new ``<ctrl-h/j/k/l>`` keybindings
+  for ``:scroll left/down/up/right`` for a consistent "move and select" flow. Thanks
   `@mcp292`_ for the idea!
+* The ``--open-images`` flag for the ``:open`` command to emulate the
+  ``--open-selected`` behaviour in ``:scroll left/right`` in the library.
 
 Changed:
 ^^^^^^^^

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,11 @@ Added:
 * The ``:move-view`` command to move the view in image and thumbnail mode to the top /
   center / bottom along with the  ``zt``, ``zz`` and ``zb`` bindings. Thanks
   `@Markuzcha`_ for the idea!
+* The ``--open-selected`` flag for ``:scroll left/right`` in the library. When using
+  this flag, any images in the new folder are automatically opened, in case the
+  focused path is an image. This comes with the new ``<ctrl-h/j/k/l>`` keybindings for
+  ``:scroll left/down/up/right`` for a consistent "move and select" flow. Thanks
+  `@mcp292`_ for the idea!
 
 Changed:
 ^^^^^^^^
@@ -585,3 +590,4 @@ Initial release of the Qt version.
 .. _@xfzv: https://github.com/xfzv
 .. _@mozirilla213: https://github.com/mozirilla213
 .. _@Markuzcha: https://github.com/Markuzcha
+.. _@mcp292: https://github.com/mcp292

--- a/tests/end2end/features/library/libraryscroll.feature
+++ b/tests/end2end/features/library/libraryscroll.feature
@@ -159,3 +159,11 @@ Feature: Scrolling the library.
             | top      |
             | center   |
             | bottom   |
+
+    Scenario: Scroll right and open selected stored image
+        Given I open a directory with 3 images
+        When I run scroll down
+        When I run scroll left
+        And I run scroll right --open-selected
+        Then the library row should be 2
+        And the image should have the index 2

--- a/tests/end2end/features/library/libraryscroll.feature
+++ b/tests/end2end/features/library/libraryscroll.feature
@@ -167,3 +167,9 @@ Feature: Scrolling the library.
         And I run scroll right --open-selected
         Then the library row should be 2
         And the image should have the index 2
+
+    Scenario: Scroll left and clear the image list
+        Given I open a directory with 3 images
+        When I run scroll down --open-selected
+        And I run scroll left --open-selected
+        Then the image should have the index 0

--- a/vimiv/api/__init__.py
+++ b/vimiv/api/__init__.py
@@ -52,7 +52,7 @@ def pathlist(mode: modes.Mode = None) -> List[str]:
 
 @keybindings.register("o", "command --text='open '")
 @commands.register(name="open")
-def open_paths(paths: Iterable[str]) -> None:
+def open_paths(paths: Iterable[str], open_images: bool = False) -> None:
     """Open one or more paths.
 
     **syntax:** ``:open path [path ...]``
@@ -65,6 +65,9 @@ def open_paths(paths: Iterable[str]) -> None:
 
     positional arguments:
         * ``paths``: The path(s) to open.
+
+    optional arguments:
+        * ``--open-images``: If True, open any images in a new directory automatically.
     """
     images, directories = files.supported(paths)
     if images:
@@ -72,6 +75,8 @@ def open_paths(paths: Iterable[str]) -> None:
         signals.load_images.emit(images)
         modes.IMAGE.enter()
     elif directories:
+        # This is always the library, admittedly a bit hacky to access like this
+        modes.LIBRARY.widget.autoload = open_images  # type: ignore [attr-defined]
         working_directory.handler.chdir(directories[0])
         modes.LIBRARY.enter()
     else:

--- a/vimiv/api/working_directory.py
+++ b/vimiv/api/working_directory.py
@@ -120,9 +120,7 @@ class WorkingDirectoryHandler(QFileSystemWatcher):
         """List of images in the current working directory."""
         return self._images
 
-    def chdir(
-        self, directory: str, reload_current: bool = False, autoload: bool = False
-    ) -> None:
+    def chdir(self, directory: str, reload_current: bool = False) -> None:
         """Change the current working directory to directory."""
         directory = os.path.realpath(directory)
         if directory != self._dir or reload_current:
@@ -131,7 +129,7 @@ class WorkingDirectoryHandler(QFileSystemWatcher):
                 self.removePaths(self.directories())
             try:
                 os.chdir(directory)
-                self._load_directory(directory, autoload)
+                self._load_directory(directory)
                 self._monitor(directory)
             except PermissionError as e:
                 log.error("%s: Cannot access '%s'", str(e), directory)
@@ -156,13 +154,11 @@ class WorkingDirectoryHandler(QFileSystemWatcher):
             if self.directories() or self.files():
                 self.removePaths(self.directories() + self.files())
 
-    def _load_directory(self, directory: str, autoload: bool = False) -> None:
+    def _load_directory(self, directory: str) -> None:
         """Load supported files for new directory."""
         self._dir = directory
         self._images, self._directories = self._get_content(directory)
         self.loaded.emit(self._images, self._directories)
-        if autoload:
-            signals.load_images.emit(self._images)
 
     @throttled(delay_ms=WAIT_TIME_MS)
     def _reload_directory(self, _path: str) -> None:

--- a/vimiv/api/working_directory.py
+++ b/vimiv/api/working_directory.py
@@ -120,7 +120,9 @@ class WorkingDirectoryHandler(QFileSystemWatcher):
         """List of images in the current working directory."""
         return self._images
 
-    def chdir(self, directory: str, reload_current: bool = False) -> None:
+    def chdir(
+        self, directory: str, reload_current: bool = False, autoload: bool = False
+    ) -> None:
         """Change the current working directory to directory."""
         directory = os.path.realpath(directory)
         if directory != self._dir or reload_current:
@@ -129,7 +131,7 @@ class WorkingDirectoryHandler(QFileSystemWatcher):
                 self.removePaths(self.directories())
             try:
                 os.chdir(directory)
-                self._load_directory(directory)
+                self._load_directory(directory, autoload)
                 self._monitor(directory)
             except PermissionError as e:
                 log.error("%s: Cannot access '%s'", str(e), directory)
@@ -154,11 +156,13 @@ class WorkingDirectoryHandler(QFileSystemWatcher):
             if self.directories() or self.files():
                 self.removePaths(self.directories() + self.files())
 
-    def _load_directory(self, directory: str) -> None:
+    def _load_directory(self, directory: str, autoload: bool = False) -> None:
         """Load supported files for new directory."""
         self._dir = directory
         self._images, self._directories = self._get_content(directory)
         self.loaded.emit(self._images, self._directories)
+        if autoload:
+            signals.load_images.emit(self._images)
 
     @throttled(delay_ms=WAIT_TIME_MS)
     def _reload_directory(self, _path: str) -> None:

--- a/vimiv/gui/library.py
+++ b/vimiv/gui/library.py
@@ -163,18 +163,20 @@ class Library(
         """
         self._open_path(self.current(), close)
 
-    def _open_path(self, path: str, close: bool):
+    def _open_path(self, path: str, close: bool, autoload_directory: bool = False):
         """Open a given path possibly closing the library."""
         if not path:
             log.warning("Library: selecting empty path")
         elif os.path.isdir(path):
-            self._open_directory(path)
+            self._open_directory(
+                path, reload_current=False, autoload=autoload_directory
+            )
         else:
             self._open_image(path, close)
 
-    def _open_directory(self, path, reload_current=False):
+    def _open_directory(self, path, reload_current=False, autoload=False):
         """Open a directory."""
-        api.working_directory.handler.chdir(path, reload_current)
+        api.working_directory.handler.chdir(path, reload_current, autoload)
 
     def _open_image(self, path, close):
         """Open an image."""
@@ -233,12 +235,16 @@ class Library(
         if direction == direction.Right:
             current = self.current()
             # Close library on double selection
-            self._open_path(current, close=current == self._last_selected)
+            self._open_path(
+                current,
+                close=current == self._last_selected,
+                autoload_directory=open_selected,
+            )
         elif direction == direction.Left:
             self.store_position()
             parent = os.path.abspath(os.pardir)
             self._positions[parent] = Position(os.getcwd())
-            api.working_directory.handler.chdir(parent)
+            api.working_directory.handler.chdir(parent, autoload=open_selected)
         else:
             row = self.row()
             if row == -1:  # Directory is empty

--- a/vimiv/gui/library.py
+++ b/vimiv/gui/library.py
@@ -194,17 +194,27 @@ class Library(
         "<ctrl>d", "scroll half-page-down", mode=api.modes.LIBRARY
     )
     @api.keybindings.register(
-        ("p", "<button-back>"), "scroll up --open-selected", mode=api.modes.LIBRARY
+        ("p", "<button-back>", "<ctrl-k>"),
+        "scroll up --open-selected",
+        mode=api.modes.LIBRARY,
     )
     @api.keybindings.register("k", "scroll up", mode=api.modes.LIBRARY)
     @api.keybindings.register(
-        ("n", "<button-forward>"), "scroll down --open-selected", mode=api.modes.LIBRARY
+        ("n", "<button-forward>", "<ctrl-j>"),
+        "scroll down --open-selected",
+        mode=api.modes.LIBRARY,
     )
     @api.keybindings.register("j", "scroll down", mode=api.modes.LIBRARY)
     @api.keybindings.register(
         ("h", "<button-right>"), "scroll left", mode=api.modes.LIBRARY
     )
+    @api.keybindings.register(
+        "<ctrl-h>", "scroll left --open-selected", mode=api.modes.LIBRARY
+    )
     @api.keybindings.register("l", "scroll right", mode=api.modes.LIBRARY)
+    @api.keybindings.register(
+        "<ctrl-l>", "scroll right --open-selected", mode=api.modes.LIBRARY
+    )
     @api.commands.register(mode=api.modes.LIBRARY)
     def scroll(  # type: ignore[override]
         self,


### PR DESCRIPTION
Add flags to syncrhonize the image file list when changing the working directory:
* `:scroll left/right --open-selected` for the library as discussed in #694 along with the keybindings `<ctrl>h/j/k/l`.
* `:open PATH[s] --open-images` for the `:open` command to mimic the behaviour, getting closer to #132.

I believe this is as close as we will get to the ideas in #132 without going full-on async - which probably won't happen anytime soon (ever? :cry: ) given the time constraints for working on vimiv.

The odd outliers are when the image filelist is not in sync with a directory, e.g., when loading tags or opening images from multiple directories. However, this is not something the library (or opening a directory) would care about and sits on the other end of the spectrum.

Anyone still interested in testing this after such a long time? @mcp292 or @jcjgraf ? :blush: 

fixes #694 - along with the inconsistency noticed on initial testing ~7 months ago
fixes #132 - as we realistically won't go further into the async realm