### PR TITLE
Fix py3exiv2 svg crash

### DIFF
--- a/tests/end2end/features/image/metadata.feature
+++ b/tests/end2end/features/image/metadata.feature
@@ -68,3 +68,9 @@ Feature: Metadata widget displaying image exif information
         And stdout should contain 'Make'
         And stdout should contain 'Model'
         And stdout should contain 'Copyright'
+
+    Scenario: Do not crash on svg files
+        Given I open a vector graphic
+        When I run metadata
+        Then no crash should happen
+        And the metadata text should contain 'No matching metadata found'

--- a/vimiv/plugins/metadata_pyexiv2.py
+++ b/vimiv/plugins/metadata_pyexiv2.py
@@ -32,7 +32,7 @@ class MetadataPyexiv2(metadata.MetadataPlugin):
         except FileNotFoundError:
             _logger.debug("File %s not found", path)
             self._metadata = None
-        except OSError as e:
+        except (OSError, TypeError) as e:
             _logger.warning(str(e))
             self._metadata = None
 

--- a/vimiv/plugins/metadata_pyexiv2.py
+++ b/vimiv/plugins/metadata_pyexiv2.py
@@ -32,6 +32,9 @@ class MetadataPyexiv2(metadata.MetadataPlugin):
         except FileNotFoundError:
             _logger.debug("File %s not found", path)
             self._metadata = None
+        except OSError as e:
+            _logger.warning(str(e))
+            self._metadata = None
 
     @staticmethod
     def name() -> str:


### PR DESCRIPTION
Catches additional exceptions when reading metadata with py3exiv2.

fixes #803 